### PR TITLE
chore: Add GitHub actions for tests, pre-commit, docs/wheels build

### DIFF
--- a/notebooks/.github/workflows/tests-build.yaml
+++ b/notebooks/.github/workflows/tests-build.yaml
@@ -89,3 +89,22 @@ jobs:
           name: wheels
           path: dist/*
 
+  upload-pypi:
+    name: Upload to PyPi
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/polars-timeseries/
+    permissions:
+      id-token: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/notebooks/.github/workflows/tests-build.yaml
+++ b/notebooks/.github/workflows/tests-build.yaml
@@ -1,0 +1,91 @@
+name: Tests, Code Quality, Build
+
+on:
+  push:
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.12" ]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Run test suite
+        run: uv run pytest --cov=polars-timeseries
+
+  code-quality:
+    name: Code quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> ${GITHUB_ENV}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install dependencies
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run -v --show-diff-on-failure
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync --group docs
+      - name: Build documentation
+        run: uv run mkdocs build -s -c
+
+  build:
+    name: Build wheels
+    needs: [ test, code-quality, docs ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels and source distribution
+        run: |
+          python -m pip install build
+          python -m build --wheel --sdist --outdir dist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist/*
+


### PR DESCRIPTION
Partially addresses https://github.com/drumtorben/polars-ts/issues/14

Add Github actions:
- unit tests
- code quality (pre-commit)
- mkdocs build
- wheels build (depends on previous)
- upload to pypi only on tags

I can add commitizen autobump version too, but this would require some secrets on your side.

Copy/paste from https://github.com/khrapovs/OrderBookMatchingEngine