### PR TITLE
feat: add ERP, LCSS, and TWE distance metrics

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -8,6 +8,9 @@ from polars_ts_rs.polars_ts_rs import (
     compute_pairwise_wdtw,
     compute_pairwise_dtw_multi,
     compute_pairwise_msm_multi,
+    compute_pairwise_erp,
+    compute_pairwise_lcss,
+    compute_pairwise_twe,
 )
 
 __all__ = [
@@ -17,7 +20,9 @@ __all__ = [
     "compute_pairwise_msm",
     "compute_pairwise_dtw_multi",
     "compute_pairwise_msm_multi",
-    # plus any pure-Python symbols you want to expose
+    "compute_pairwise_erp",
+    "compute_pairwise_lcss",
+    "compute_pairwise_twe",
 ]
 
 import polars as pl

--- a/src/dtw_multi.rs
+++ b/src/dtw_multi.rs
@@ -147,6 +147,7 @@ fn df_to_hashmap_multivariate(df: &DataFrame) -> HashMap<String, Vec<Vec<f64>>> 
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "dtw".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, metric=None))]
 pub fn compute_pairwise_dtw_multi(input1: PyDataFrame, input2: PyDataFrame, metric: Option<String>) -> PyResult<PyDataFrame> {
     // Determine the distance metric.
     let distance_metric = match metric.as_deref() {

--- a/src/erp.rs
+++ b/src/erp.rs
@@ -1,0 +1,180 @@
+use polars::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use pyo3::PyResult;
+use rayon::prelude::*;
+
+/// ERP (Edit Distance with Real Penalty) distance.
+/// Uses a gap value `g` as the reference point for insertions/deletions.
+/// O(m) memory.
+fn erp_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
+    let n = a.len();
+    let m = b.len();
+
+    let mut prev = vec![0.0_f64; m + 1];
+    let mut curr = vec![0.0_f64; m + 1];
+
+    // Initialize first column: cost of deleting all of a[0..i]
+    for i in 1..=n {
+        prev[0] = prev[0]; // will be set below
+    }
+    // Re-initialize properly
+    prev[0] = 0.0;
+    for j in 1..=m {
+        prev[j] = prev[j - 1] + (b[j - 1] - g).abs();
+    }
+
+    let mut first_col_cost = 0.0_f64;
+    for i in 1..=n {
+        first_col_cost += (a[i - 1] - g).abs();
+        curr[0] = first_col_cost;
+
+        for j in 1..=m {
+            let d_match = prev[j - 1] + (a[i - 1] - b[j - 1]).abs();
+            let d_delete = prev[j] + (a[i - 1] - g).abs();
+            let d_insert = curr[j - 1] + (b[j - 1] - g).abs();
+            curr[j] = d_match.min(d_delete).min(d_insert);
+        }
+
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[m]
+}
+
+/// Groups a DataFrame by "unique_id" and aggregates the "y" column.
+fn get_groups(df: &DataFrame) -> Result<LazyFrame, PolarsError> {
+    Ok(df.clone().lazy()
+        .select([
+            col("unique_id").cast(DataType::String),
+            col("y").cast(DataType::Float64)
+        ])
+        .group_by([col("unique_id")])
+        .agg([col("y")])
+    )
+}
+
+/// Optimized conversion of a grouped DataFrame into a HashMap mapping id -> Vec<f64>.
+fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
+    let unique_id_col = df.column("unique_id").expect("expected column unique_id");
+    let y_col = df.column("y").expect("expected column y");
+
+    let unique_ids: Vec<String> = unique_id_col
+        .str()
+        .expect("expected utf8 column for unique_id")
+        .into_no_null_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let y_lists: Vec<Vec<f64>> = y_col
+        .list()
+        .expect("expected a List type for y")
+        .into_iter()
+        .map(|opt_series| {
+            let series = opt_series.expect("null entry in 'y' list column");
+            series
+                .f64()
+                .expect("expected a f64 Series inside the list")
+                .into_no_null_iter()
+                .collect::<Vec<f64>>()
+        })
+        .collect();
+
+    assert_eq!(unique_ids.len(), y_lists.len(), "Mismatched lengths in unique_ids and y_lists");
+
+    let hashmap: HashMap<String, Vec<f64>> = (0..unique_ids.len())
+        .into_par_iter()
+        .map(|i| (unique_ids[i].clone(), y_lists[i].clone()))
+        .collect();
+    hashmap
+}
+
+/// Compute pairwise ERP distances between time series in two DataFrames.
+///
+/// # Arguments
+/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
+/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
+/// * `g` - Gap value (default 0.0). Points are compared against this reference when inserted/deleted.
+///
+/// # Returns
+/// A PyDataFrame with columns "id_1", "id_2", and "erp".
+#[pyfunction]
+pub fn compute_pairwise_erp(input1: PyDataFrame, input2: PyDataFrame, g: Option<f64>) -> PyResult<PyDataFrame> {
+    let g_value = g.unwrap_or(0.0);
+
+    let df_1: DataFrame = input1.into();
+    let df_2: DataFrame = input2.into();
+
+    let uid_a_dtype = df_1.column("unique_id")
+        .expect("df_a must have unique_id")
+        .dtype().clone();
+
+    let uid_b_dtype = df_2.column("unique_id")
+        .expect("df_b must have unique_id")
+        .dtype().clone();
+
+    let df_a = df_1
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let df_b = df_2
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let grouped_a = get_groups(&df_a).unwrap().collect().unwrap();
+    let grouped_b = get_groups(&df_b).unwrap().collect().unwrap();
+
+    let raw_map_a = df_to_hashmap(&grouped_a);
+    let raw_map_b = df_to_hashmap(&grouped_b);
+
+    let map_a = Arc::new(raw_map_a);
+    let map_b = Arc::new(raw_map_b);
+
+    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
+    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
+
+    let results: Vec<(String, String, f64)> = left_series_by_key
+        .par_iter()
+        .flat_map(|&(left_key, left_series)| {
+            let map_a = Arc::clone(&map_a);
+            let map_b = Arc::clone(&map_b);
+            let g = g_value;
+
+            right_series_by_key
+                .par_iter()
+                .filter_map(move |&(right_key, right_series)| {
+                    if left_key == right_key {
+                        return None;
+                    }
+                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
+                        if left_key >= right_key {
+                            return None;
+                        }
+                    }
+                    let distance = erp_distance(left_series, right_series, g);
+                    Some((left_key.clone(), right_key.clone(), distance))
+                })
+        })
+        .collect();
+
+    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
+    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
+    let erp_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
+
+    let columns = vec![
+        Column::new("id_1".into(), id1s),
+        Column::new("id_2".into(), id2s),
+        Column::new("erp".into(), erp_vals),
+    ];
+    let out_df = DataFrame::new(columns).unwrap();
+    let casted_out_df = out_df.clone().lazy()
+        .with_columns(vec![
+            col("id_1").cast(uid_a_dtype),
+            col("id_2").cast(uid_b_dtype),
+        ]).collect().unwrap();
+    Ok(PyDataFrame(casted_out_df))
+}

--- a/src/erp.rs
+++ b/src/erp.rs
@@ -16,12 +16,7 @@ fn erp_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
     let mut prev = vec![0.0_f64; m + 1];
     let mut curr = vec![0.0_f64; m + 1];
 
-    // Initialize first column: cost of deleting all of a[0..i]
-    for i in 1..=n {
-        prev[0] = prev[0]; // will be set below
-    }
-    // Re-initialize properly
-    prev[0] = 0.0;
+    // Initialize first row: cost of inserting all of b[0..j]
     for j in 1..=m {
         prev[j] = prev[j - 1] + (b[j - 1] - g).abs();
     }
@@ -101,6 +96,7 @@ fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "erp".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, g=None))]
 pub fn compute_pairwise_erp(input1: PyDataFrame, input2: PyDataFrame, g: Option<f64>) -> PyResult<PyDataFrame> {
     let g_value = g.unwrap_or(0.0);
 

--- a/src/lcss.rs
+++ b/src/lcss.rs
@@ -98,6 +98,7 @@ fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "lcss".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, epsilon=None))]
 pub fn compute_pairwise_lcss(input1: PyDataFrame, input2: PyDataFrame, epsilon: Option<f64>) -> PyResult<PyDataFrame> {
     let eps = epsilon.unwrap_or(1.0);
 

--- a/src/lcss.rs
+++ b/src/lcss.rs
@@ -1,0 +1,177 @@
+use polars::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use pyo3::PyResult;
+use rayon::prelude::*;
+
+/// LCSS (Longest Common Subsequence) distance.
+/// Two points match if their absolute difference is within `epsilon`.
+/// Returns 1 - (LCSS_length / min(n, m)), so 0 = identical, 1 = no matches.
+/// O(m) memory.
+fn lcss_distance(a: &[f64], b: &[f64], epsilon: f64) -> f64 {
+    let n = a.len();
+    let m = b.len();
+
+    if n == 0 || m == 0 {
+        return 1.0;
+    }
+
+    let mut prev = vec![0_usize; m + 1];
+    let mut curr = vec![0_usize; m + 1];
+
+    for i in 1..=n {
+        for j in 1..=m {
+            if (a[i - 1] - b[j - 1]).abs() <= epsilon {
+                curr[j] = prev[j - 1] + 1;
+            } else {
+                curr[j] = prev[j].max(curr[j - 1]);
+            }
+        }
+        std::mem::swap(&mut prev, &mut curr);
+        // Reset curr for next row
+        for j in 0..=m {
+            curr[j] = 0;
+        }
+    }
+
+    let lcss_len = prev[m] as f64;
+    let min_len = n.min(m) as f64;
+    1.0 - (lcss_len / min_len)
+}
+
+/// Groups a DataFrame by "unique_id" and aggregates the "y" column.
+fn get_groups(df: &DataFrame) -> Result<LazyFrame, PolarsError> {
+    Ok(df.clone().lazy()
+        .select([
+            col("unique_id").cast(DataType::String),
+            col("y").cast(DataType::Float64)
+        ])
+        .group_by([col("unique_id")])
+        .agg([col("y")])
+    )
+}
+
+/// Optimized conversion of a grouped DataFrame into a HashMap mapping id -> Vec<f64>.
+fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
+    let unique_id_col = df.column("unique_id").expect("expected column unique_id");
+    let y_col = df.column("y").expect("expected column y");
+
+    let unique_ids: Vec<String> = unique_id_col
+        .str()
+        .expect("expected utf8 column for unique_id")
+        .into_no_null_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let y_lists: Vec<Vec<f64>> = y_col
+        .list()
+        .expect("expected a List type for y")
+        .into_iter()
+        .map(|opt_series| {
+            let series = opt_series.expect("null entry in 'y' list column");
+            series
+                .f64()
+                .expect("expected a f64 Series inside the list")
+                .into_no_null_iter()
+                .collect::<Vec<f64>>()
+        })
+        .collect();
+
+    assert_eq!(unique_ids.len(), y_lists.len(), "Mismatched lengths in unique_ids and y_lists");
+
+    let hashmap: HashMap<String, Vec<f64>> = (0..unique_ids.len())
+        .into_par_iter()
+        .map(|i| (unique_ids[i].clone(), y_lists[i].clone()))
+        .collect();
+    hashmap
+}
+
+/// Compute pairwise LCSS distances between time series in two DataFrames.
+///
+/// # Arguments
+/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
+/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
+/// * `epsilon` - Matching threshold (default 1.0). Two points match if |a[i] - b[j]| <= epsilon.
+///
+/// # Returns
+/// A PyDataFrame with columns "id_1", "id_2", and "lcss".
+#[pyfunction]
+pub fn compute_pairwise_lcss(input1: PyDataFrame, input2: PyDataFrame, epsilon: Option<f64>) -> PyResult<PyDataFrame> {
+    let eps = epsilon.unwrap_or(1.0);
+
+    let df_1: DataFrame = input1.into();
+    let df_2: DataFrame = input2.into();
+
+    let uid_a_dtype = df_1.column("unique_id")
+        .expect("df_a must have unique_id")
+        .dtype().clone();
+
+    let uid_b_dtype = df_2.column("unique_id")
+        .expect("df_b must have unique_id")
+        .dtype().clone();
+
+    let df_a = df_1
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let df_b = df_2
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let grouped_a = get_groups(&df_a).unwrap().collect().unwrap();
+    let grouped_b = get_groups(&df_b).unwrap().collect().unwrap();
+
+    let raw_map_a = df_to_hashmap(&grouped_a);
+    let raw_map_b = df_to_hashmap(&grouped_b);
+
+    let map_a = Arc::new(raw_map_a);
+    let map_b = Arc::new(raw_map_b);
+
+    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
+    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
+
+    let results: Vec<(String, String, f64)> = left_series_by_key
+        .par_iter()
+        .flat_map(|&(left_key, left_series)| {
+            let map_a = Arc::clone(&map_a);
+            let map_b = Arc::clone(&map_b);
+            let epsilon = eps;
+
+            right_series_by_key
+                .par_iter()
+                .filter_map(move |&(right_key, right_series)| {
+                    if left_key == right_key {
+                        return None;
+                    }
+                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
+                        if left_key >= right_key {
+                            return None;
+                        }
+                    }
+                    let distance = lcss_distance(left_series, right_series, epsilon);
+                    Some((left_key.clone(), right_key.clone(), distance))
+                })
+        })
+        .collect();
+
+    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
+    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
+    let lcss_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
+
+    let columns = vec![
+        Column::new("id_1".into(), id1s),
+        Column::new("id_2".into(), id2s),
+        Column::new("lcss".into(), lcss_vals),
+    ];
+    let out_df = DataFrame::new(columns).unwrap();
+    let casted_out_df = out_df.clone().lazy()
+        .with_columns(vec![
+            col("id_1").cast(uid_a_dtype),
+            col("id_2").cast(uid_b_dtype),
+        ]).collect().unwrap();
+    Ok(PyDataFrame(casted_out_df))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ use wdtw::compute_pairwise_wdtw;
 use msm::compute_pairwise_msm;
 use dtw_multi::compute_pairwise_dtw_multi;
 use msm_multi::compute_pairwise_msm_multi;
+use erp::compute_pairwise_erp;
+use lcss::compute_pairwise_lcss;
+use twe::compute_pairwise_twe;
 
 mod dtw;
 mod dtw_multi;
@@ -16,6 +19,9 @@ mod msm;
 mod msm_multi;
 mod ddtw;
 mod wdtw;
+mod erp;
+mod lcss;
+mod twe;
 mod mann_kendall;
 
 #[global_allocator]
@@ -50,5 +56,8 @@ fn polars_ts_rs(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compute_pairwise_wdtw, m)?)?;
     m.add_function(wrap_pyfunction!(compute_pairwise_dtw_multi, m)?)?;
     m.add_function(wrap_pyfunction!(compute_pairwise_msm_multi, m)?)?;
+    m.add_function(wrap_pyfunction!(compute_pairwise_erp, m)?)?;
+    m.add_function(wrap_pyfunction!(compute_pairwise_lcss, m)?)?;
+    m.add_function(wrap_pyfunction!(compute_pairwise_twe, m)?)?;
     Ok(())
 }

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -125,6 +125,7 @@ fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "msm".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, c=None))]
 pub fn compute_pairwise_msm(input1: PyDataFrame, input2: PyDataFrame, c: Option<f64>) -> PyResult<PyDataFrame> {
     // Set default value for c parameter
     let c_value = c.unwrap_or(1.0);

--- a/src/msm_multi.rs
+++ b/src/msm_multi.rs
@@ -189,6 +189,7 @@ fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<Vec<f64>>> {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "msm".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, c=None))]
 pub fn compute_pairwise_msm_multi(
     input1: PyDataFrame,
     input2: PyDataFrame,

--- a/src/twe.rs
+++ b/src/twe.rs
@@ -1,0 +1,202 @@
+use polars::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use pyo3::PyResult;
+use rayon::prelude::*;
+
+/// TWE (Time Warp Edit) distance.
+/// Combines edit distance with a stiffness penalty for time warping.
+/// Parameters:
+/// - `nu`: stiffness parameter (default 0.001). Higher = less warping allowed.
+/// - `lambda`: penalty for delete/insert operations (default 1.0).
+/// O(m) memory.
+fn twe_distance(a: &[f64], b: &[f64], nu: f64, lambda: f64) -> f64 {
+    let n = a.len();
+    let m = b.len();
+
+    if n == 0 || m == 0 {
+        return 0.0;
+    }
+
+    let mut prev = vec![f64::MAX; m + 1];
+    let mut curr = vec![f64::MAX; m + 1];
+
+    prev[0] = 0.0;
+    for j in 1..=m {
+        prev[j] = prev[j - 1] + (b[j - 1] - if j > 1 { b[j - 2] } else { 0.0 }).abs() + nu + lambda;
+    }
+
+    for i in 1..=n {
+        let a_i = a[i - 1];
+        let a_prev = if i > 1 { a[i - 2] } else { 0.0 };
+
+        curr[0] = prev[0] + (a_i - a_prev).abs() + nu + lambda;
+
+        for j in 1..=m {
+            let b_j = b[j - 1];
+            let b_prev = if j > 1 { b[j - 2] } else { 0.0 };
+
+            // Match: align a[i] with b[j]
+            let d_match = prev[j - 1]
+                + (a_i - b_j).abs()
+                + (a_prev - b_prev).abs()
+                + nu * ((i as f64 - j as f64).abs()).min(2.0 * nu);
+
+            // Delete: a[i] is unmatched
+            let d_delete = prev[j]
+                + (a_i - a_prev).abs()
+                + nu + lambda;
+
+            // Insert: b[j] is unmatched
+            let d_insert = curr[j - 1]
+                + (b_j - b_prev).abs()
+                + nu + lambda;
+
+            curr[j] = d_match.min(d_delete).min(d_insert);
+        }
+
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[m]
+}
+
+/// Groups a DataFrame by "unique_id" and aggregates the "y" column.
+fn get_groups(df: &DataFrame) -> Result<LazyFrame, PolarsError> {
+    Ok(df.clone().lazy()
+        .select([
+            col("unique_id").cast(DataType::String),
+            col("y").cast(DataType::Float64)
+        ])
+        .group_by([col("unique_id")])
+        .agg([col("y")])
+    )
+}
+
+/// Optimized conversion of a grouped DataFrame into a HashMap mapping id -> Vec<f64>.
+fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
+    let unique_id_col = df.column("unique_id").expect("expected column unique_id");
+    let y_col = df.column("y").expect("expected column y");
+
+    let unique_ids: Vec<String> = unique_id_col
+        .str()
+        .expect("expected utf8 column for unique_id")
+        .into_no_null_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let y_lists: Vec<Vec<f64>> = y_col
+        .list()
+        .expect("expected a List type for y")
+        .into_iter()
+        .map(|opt_series| {
+            let series = opt_series.expect("null entry in 'y' list column");
+            series
+                .f64()
+                .expect("expected a f64 Series inside the list")
+                .into_no_null_iter()
+                .collect::<Vec<f64>>()
+        })
+        .collect();
+
+    assert_eq!(unique_ids.len(), y_lists.len(), "Mismatched lengths in unique_ids and y_lists");
+
+    let hashmap: HashMap<String, Vec<f64>> = (0..unique_ids.len())
+        .into_par_iter()
+        .map(|i| (unique_ids[i].clone(), y_lists[i].clone()))
+        .collect();
+    hashmap
+}
+
+/// Compute pairwise TWE distances between time series in two DataFrames.
+///
+/// # Arguments
+/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
+/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
+/// * `nu` - Stiffness parameter (default 0.001). Controls how much time warping is penalized.
+/// * `lambda` - Penalty for delete/insert operations (default 1.0).
+///
+/// # Returns
+/// A PyDataFrame with columns "id_1", "id_2", and "twe".
+#[pyfunction]
+pub fn compute_pairwise_twe(input1: PyDataFrame, input2: PyDataFrame, nu: Option<f64>, lambda: Option<f64>) -> PyResult<PyDataFrame> {
+    let nu_value = nu.unwrap_or(0.001);
+    let lambda_value = lambda.unwrap_or(1.0);
+
+    let df_1: DataFrame = input1.into();
+    let df_2: DataFrame = input2.into();
+
+    let uid_a_dtype = df_1.column("unique_id")
+        .expect("df_a must have unique_id")
+        .dtype().clone();
+
+    let uid_b_dtype = df_2.column("unique_id")
+        .expect("df_b must have unique_id")
+        .dtype().clone();
+
+    let df_a = df_1
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let df_b = df_2
+        .lazy()
+        .with_column(col("unique_id").cast(DataType::String))
+        .collect().unwrap();
+
+    let grouped_a = get_groups(&df_a).unwrap().collect().unwrap();
+    let grouped_b = get_groups(&df_b).unwrap().collect().unwrap();
+
+    let raw_map_a = df_to_hashmap(&grouped_a);
+    let raw_map_b = df_to_hashmap(&grouped_b);
+
+    let map_a = Arc::new(raw_map_a);
+    let map_b = Arc::new(raw_map_b);
+
+    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
+    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
+
+    let results: Vec<(String, String, f64)> = left_series_by_key
+        .par_iter()
+        .flat_map(|&(left_key, left_series)| {
+            let map_a = Arc::clone(&map_a);
+            let map_b = Arc::clone(&map_b);
+            let nu = nu_value;
+            let lambda = lambda_value;
+
+            right_series_by_key
+                .par_iter()
+                .filter_map(move |&(right_key, right_series)| {
+                    if left_key == right_key {
+                        return None;
+                    }
+                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
+                        if left_key >= right_key {
+                            return None;
+                        }
+                    }
+                    let distance = twe_distance(left_series, right_series, nu, lambda);
+                    Some((left_key.clone(), right_key.clone(), distance))
+                })
+        })
+        .collect();
+
+    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
+    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
+    let twe_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
+
+    let columns = vec![
+        Column::new("id_1".into(), id1s),
+        Column::new("id_2".into(), id2s),
+        Column::new("twe".into(), twe_vals),
+    ];
+    let out_df = DataFrame::new(columns).unwrap();
+    let casted_out_df = out_df.clone().lazy()
+        .with_columns(vec![
+            col("id_1").cast(uid_a_dtype),
+            col("id_2").cast(uid_b_dtype),
+        ]).collect().unwrap();
+    Ok(PyDataFrame(casted_out_df))
+}

--- a/src/twe.rs
+++ b/src/twe.rs
@@ -121,6 +121,7 @@ fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "twe".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, nu=None, lambda=None))]
 pub fn compute_pairwise_twe(input1: PyDataFrame, input2: PyDataFrame, nu: Option<f64>, lambda: Option<f64>) -> PyResult<PyDataFrame> {
     let nu_value = nu.unwrap_or(0.001);
     let lambda_value = lambda.unwrap_or(1.0);

--- a/src/wdtw.rs
+++ b/src/wdtw.rs
@@ -185,6 +185,7 @@ fn wdtw_distance_optimized(a: &[f64], b: &[f64], g: f64) -> f64 {
 /// # Returns
 /// A PyDataFrame with columns "id_1", "id_2", and "wdtw".
 #[pyfunction]
+#[pyo3(signature = (input1, input2, g=None))]
 pub fn compute_pairwise_wdtw(
     input1: PyDataFrame,
     input2: PyDataFrame,

--- a/tests/test_distance_metrics.py
+++ b/tests/test_distance_metrics.py
@@ -1,0 +1,343 @@
+import polars as pl
+import pytest
+from polars_ts_rs.polars_ts_rs import (
+    compute_pairwise_dtw,
+    compute_pairwise_erp,
+    compute_pairwise_lcss,
+    compute_pairwise_twe,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def two_series():
+    """Two simple time series A and B that differ by one point."""
+    return pl.DataFrame({
+        "unique_id": ["A"] * 4 + ["B"] * 4,
+        "y": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 5.0],
+    })
+
+
+@pytest.fixture
+def three_series():
+    """Three time series: A ascending, B similar to A, C reversed."""
+    return pl.DataFrame({
+        "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+        "y": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 5.0, 4.0, 3.0, 2.0, 1.0],
+    })
+
+
+@pytest.fixture
+def identical_series():
+    """Two identical time series."""
+    return pl.DataFrame({
+        "unique_id": ["A"] * 4 + ["B"] * 4,
+        "y": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
+    })
+
+
+@pytest.fixture
+def single_series():
+    """A single time series — no pairs to compare."""
+    return pl.DataFrame({
+        "unique_id": ["A"] * 4,
+        "y": [1.0, 2.0, 3.0, 4.0],
+    })
+
+
+@pytest.fixture
+def int_id_series():
+    """Time series with integer unique_id."""
+    return pl.DataFrame({
+        "unique_id": [1] * 4 + [2] * 4,
+        "y": [1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _to_dict(df: pl.DataFrame) -> dict:
+    """Convert pairwise result to {(id1, id2): distance} dict, sorted keys."""
+    rows = df.to_dicts()
+    dist_col = [c for c in df.columns if c not in ("id_1", "id_2")][0]
+    result = {}
+    for r in rows:
+        key = tuple(sorted([str(r["id_1"]), str(r["id_2"])]))
+        result[key] = r[dist_col]
+    return result
+
+
+# ===========================================================================
+# ERP tests
+# ===========================================================================
+
+class TestERP:
+    def test_identical_series_zero_distance(self, identical_series):
+        result = compute_pairwise_erp(identical_series, identical_series)
+        d = _to_dict(result)
+        assert d[("A", "B")] == 0.0
+
+    def test_basic_distance(self, two_series):
+        result = compute_pairwise_erp(two_series, two_series)
+        d = _to_dict(result)
+        assert d[("A", "B")] == 1.0  # only last point differs by 1
+
+    def test_symmetric(self, three_series):
+        result = compute_pairwise_erp(three_series, three_series)
+        d = _to_dict(result)
+        assert d[("A", "C")] == d[("A", "C")]  # trivially true
+        # Also check A-C computed from both directions gives same result
+        df_a = three_series.filter(pl.col("unique_id") == "A")
+        df_c = three_series.filter(pl.col("unique_id") == "C")
+        ac = compute_pairwise_erp(df_a, df_c)
+        ca = compute_pairwise_erp(df_c, df_a)
+        assert ac["erp"][0] == ca["erp"][0]
+
+    def test_gap_value_affects_distance(self):
+        # Use series of different lengths to force insertions/deletions
+        # where the gap value matters
+        df = pl.DataFrame({
+            "unique_id": ["A"] * 3 + ["B"] * 5,
+            "y": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        })
+        d0 = _to_dict(compute_pairwise_erp(df, df, g=0.0))
+        d5 = _to_dict(compute_pairwise_erp(df, df, g=5.0))
+        # Different gap values should produce different distances
+        # when insertions/deletions are needed
+        assert d0[("A", "B")] != d5[("A", "B")]
+
+    def test_triangle_inequality(self, three_series):
+        result = compute_pairwise_erp(three_series, three_series)
+        d = _to_dict(result)
+        # ERP is a metric: d(A,C) <= d(A,B) + d(B,C)
+        assert d[("A", "C")] <= d[("A", "B")] + d[("B", "C")] + 1e-10
+
+    def test_output_columns(self, two_series):
+        result = compute_pairwise_erp(two_series, two_series)
+        assert set(result.columns) == {"id_1", "id_2", "erp"}
+
+    def test_no_self_comparisons(self, three_series):
+        result = compute_pairwise_erp(three_series, three_series)
+        for row in result.to_dicts():
+            assert row["id_1"] != row["id_2"]
+
+    def test_no_duplicate_pairs(self, three_series):
+        result = compute_pairwise_erp(three_series, three_series)
+        # 3 series → 3 unique pairs
+        assert result.height == 3
+
+    def test_single_series_empty_result(self, single_series):
+        result = compute_pairwise_erp(single_series, single_series)
+        assert result.height == 0
+
+    def test_preserves_int_dtype(self, int_id_series):
+        result = compute_pairwise_erp(int_id_series, int_id_series)
+        assert result["id_1"].dtype == result["id_2"].dtype
+        assert result["id_1"].dtype != pl.String
+
+    def test_non_negative(self, three_series):
+        result = compute_pairwise_erp(three_series, three_series)
+        assert (result["erp"] >= 0).all()
+
+
+# ===========================================================================
+# LCSS tests
+# ===========================================================================
+
+class TestLCSS:
+    def test_identical_series_zero_distance(self, identical_series):
+        result = compute_pairwise_lcss(identical_series, identical_series, epsilon=0.01)
+        d = _to_dict(result)
+        assert d[("A", "B")] == 0.0
+
+    def test_basic_distance(self, two_series):
+        result = compute_pairwise_lcss(two_series, two_series, epsilon=0.5)
+        d = _to_dict(result)
+        # A=[1,2,3,4] B=[1,2,3,5]: 3 of 4 match within 0.5 → distance = 1-3/4 = 0.25
+        assert d[("A", "B")] == 0.25
+
+    def test_large_epsilon_all_match(self, three_series):
+        result = compute_pairwise_lcss(three_series, three_series, epsilon=100.0)
+        d = _to_dict(result)
+        # With huge epsilon everything matches → distance = 0
+        for v in d.values():
+            assert v == 0.0
+
+    def test_tiny_epsilon_no_match(self):
+        df = pl.DataFrame({
+            "unique_id": ["A"] * 3 + ["B"] * 3,
+            "y": [1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+        })
+        result = compute_pairwise_lcss(df, df, epsilon=0.001)
+        d = _to_dict(result)
+        assert d[("A", "B")] == 1.0  # no matches → max distance
+
+    def test_range_zero_to_one(self, three_series):
+        result = compute_pairwise_lcss(three_series, three_series)
+        for v in result["lcss"].to_list():
+            assert 0.0 <= v <= 1.0
+
+    def test_default_epsilon(self, two_series):
+        # Default epsilon=1.0: A=[1,2,3,4] B=[1,2,3,5], all within 1.0
+        result = compute_pairwise_lcss(two_series, two_series)
+        d = _to_dict(result)
+        assert d[("A", "B")] == 0.0
+
+    def test_output_columns(self, two_series):
+        result = compute_pairwise_lcss(two_series, two_series)
+        assert set(result.columns) == {"id_1", "id_2", "lcss"}
+
+    def test_no_self_comparisons(self, three_series):
+        result = compute_pairwise_lcss(three_series, three_series)
+        for row in result.to_dicts():
+            assert row["id_1"] != row["id_2"]
+
+    def test_no_duplicate_pairs(self, three_series):
+        result = compute_pairwise_lcss(three_series, three_series)
+        assert result.height == 3
+
+    def test_single_series_empty_result(self, single_series):
+        result = compute_pairwise_lcss(single_series, single_series)
+        assert result.height == 0
+
+    def test_preserves_int_dtype(self, int_id_series):
+        result = compute_pairwise_lcss(int_id_series, int_id_series)
+        assert result["id_1"].dtype == result["id_2"].dtype
+        assert result["id_1"].dtype != pl.String
+
+    def test_symmetric(self, three_series):
+        df_a = three_series.filter(pl.col("unique_id") == "A")
+        df_c = three_series.filter(pl.col("unique_id") == "C")
+        ac = compute_pairwise_lcss(df_a, df_c, epsilon=1.0)
+        ca = compute_pairwise_lcss(df_c, df_a, epsilon=1.0)
+        assert ac["lcss"][0] == ca["lcss"][0]
+
+
+# ===========================================================================
+# TWE tests
+# ===========================================================================
+
+class TestTWE:
+    def test_identical_series_zero_distance(self, identical_series):
+        result = compute_pairwise_twe(identical_series, identical_series)
+        d = _to_dict(result)
+        assert abs(d[("A", "B")]) < 1e-10
+
+    def test_basic_distance(self, two_series):
+        result = compute_pairwise_twe(two_series, two_series)
+        d = _to_dict(result)
+        assert d[("A", "B")] > 0  # not identical → positive distance
+
+    def test_reversed_series_larger(self, three_series):
+        result = compute_pairwise_twe(three_series, three_series)
+        d = _to_dict(result)
+        # C is A reversed — should be further than B which differs by 1 point
+        assert d[("A", "C")] > d[("A", "B")]
+
+    def test_stiffness_increases_distance(self, two_series):
+        d_low = _to_dict(compute_pairwise_twe(two_series, two_series, 0.001, 1.0))
+        d_high = _to_dict(compute_pairwise_twe(two_series, two_series, 10.0, 1.0))
+        # Higher stiffness penalizes warping more
+        assert d_high[("A", "B")] >= d_low[("A", "B")]
+
+    def test_lambda_increases_distance(self, two_series):
+        d_low = _to_dict(compute_pairwise_twe(two_series, two_series, 0.001, 0.1))
+        d_high = _to_dict(compute_pairwise_twe(two_series, two_series, 0.001, 10.0))
+        # Higher lambda penalizes insertions/deletions more
+        assert d_high[("A", "B")] >= d_low[("A", "B")]
+
+    def test_output_columns(self, two_series):
+        result = compute_pairwise_twe(two_series, two_series)
+        assert set(result.columns) == {"id_1", "id_2", "twe"}
+
+    def test_no_self_comparisons(self, three_series):
+        result = compute_pairwise_twe(three_series, three_series)
+        for row in result.to_dicts():
+            assert row["id_1"] != row["id_2"]
+
+    def test_no_duplicate_pairs(self, three_series):
+        result = compute_pairwise_twe(three_series, three_series)
+        assert result.height == 3
+
+    def test_single_series_empty_result(self, single_series):
+        result = compute_pairwise_twe(single_series, single_series)
+        assert result.height == 0
+
+    def test_preserves_int_dtype(self, int_id_series):
+        result = compute_pairwise_twe(int_id_series, int_id_series)
+        assert result["id_1"].dtype == result["id_2"].dtype
+        assert result["id_1"].dtype != pl.String
+
+    def test_non_negative(self, three_series):
+        result = compute_pairwise_twe(three_series, three_series)
+        assert (result["twe"] >= 0).all()
+
+    def test_symmetric(self, three_series):
+        df_a = three_series.filter(pl.col("unique_id") == "A")
+        df_c = three_series.filter(pl.col("unique_id") == "C")
+        ac = compute_pairwise_twe(df_a, df_c)
+        ca = compute_pairwise_twe(df_c, df_a)
+        assert abs(ac["twe"][0] - ca["twe"][0]) < 1e-10
+
+
+# ===========================================================================
+# Cross-metric consistency tests
+# ===========================================================================
+
+class TestCrossMetric:
+    def test_identical_all_zero(self, identical_series):
+        """All metrics should return 0 for identical series."""
+        dtw = _to_dict(compute_pairwise_dtw(identical_series, identical_series))
+        erp = _to_dict(compute_pairwise_erp(identical_series, identical_series))
+        lcss = _to_dict(compute_pairwise_lcss(identical_series, identical_series, epsilon=0.01))
+        twe = _to_dict(compute_pairwise_twe(identical_series, identical_series))
+
+        assert dtw[("A", "B")] == 0.0
+        assert erp[("A", "B")] == 0.0
+        assert lcss[("A", "B")] == 0.0
+        assert abs(twe[("A", "B")]) < 1e-10
+
+    def test_ordering_consistent(self, three_series):
+        """All metrics should agree that A-B is closer than A-C."""
+        dtw = _to_dict(compute_pairwise_dtw(three_series, three_series))
+        erp = _to_dict(compute_pairwise_erp(three_series, three_series))
+        lcss = _to_dict(compute_pairwise_lcss(three_series, three_series, epsilon=0.5))
+        twe = _to_dict(compute_pairwise_twe(three_series, three_series))
+
+        assert dtw[("A", "B")] < dtw[("A", "C")]
+        assert erp[("A", "B")] < erp[("A", "C")]
+        assert lcss[("A", "B")] < lcss[("A", "C")]
+        assert twe[("A", "B")] < twe[("A", "C")]
+
+    def test_all_same_pair_count(self, three_series):
+        """All metrics should produce the same number of pairs."""
+        n_dtw = compute_pairwise_dtw(three_series, three_series).height
+        n_erp = compute_pairwise_erp(three_series, three_series).height
+        n_lcss = compute_pairwise_lcss(three_series, three_series).height
+        n_twe = compute_pairwise_twe(three_series, three_series).height
+        assert n_dtw == n_erp == n_lcss == n_twe == 3
+
+    def test_cross_dataframe(self):
+        """Test comparing series across two different DataFrames."""
+        df1 = pl.DataFrame({
+            "unique_id": ["X"] * 3,
+            "y": [1.0, 2.0, 3.0],
+        })
+        df2 = pl.DataFrame({
+            "unique_id": ["Y"] * 3,
+            "y": [3.0, 2.0, 1.0],
+        })
+        erp = compute_pairwise_erp(df1, df2)
+        lcss = compute_pairwise_lcss(df1, df2)
+        twe = compute_pairwise_twe(df1, df2)
+
+        assert erp.height == 1
+        assert lcss.height == 1
+        assert twe.height == 1
+        assert erp["erp"][0] > 0
+        assert twe["twe"][0] > 0


### PR DESCRIPTION
## Summary

- **ERP** (Edit Distance with Real Penalty): true metric satisfying triangle inequality, configurable gap reference value (`g` param, default 0.0)
- **LCSS** (Longest Common Subsequence): threshold-based similarity returning normalized distance [0,1], robust to outliers (`epsilon` param, default 1.0)
- **TWE** (Time Warp Edit): combines DTW alignment with edit distance penalties (`nu` stiffness + `lambda` edit penalty params)

All three follow the same implementation patterns as existing metrics:
- O(m) memory-optimized dynamic programming
- Rayon parallelism for pairwise computation
- Deduplication of symmetric pairs and self-comparisons
- Mixed `unique_id` dtype support (String/Int)

### Usage

```python
import polars_ts as pts

result_erp  = pts.compute_pairwise_erp(df, df, g=0.0)
result_lcss = pts.compute_pairwise_lcss(df, df, epsilon=0.5)
result_twe  = pts.compute_pairwise_twe(df, df, 0.001, 1.0)
```

### Files changed

| File | Description |
|------|-------------|
| `src/erp.rs` | ERP distance implementation |
| `src/lcss.rs` | LCSS distance implementation |
| `src/twe.rs` | TWE distance implementation |
| `src/lib.rs` | Module registration |
| `polars_ts/__init__.py` | Python exports |
| `tests/test_distance_metrics.py` | 39 tests |

## Test plan

- [x] 11 ERP tests (zero distance, symmetry, triangle inequality, gap value effect, dtype preservation, edge cases)
- [x] 12 LCSS tests (zero distance, epsilon thresholds, [0,1] range, symmetry, dtype preservation, edge cases)
- [x] 12 TWE tests (zero distance, stiffness/lambda effects, symmetry, non-negativity, dtype preservation, edge cases)
- [x] 4 cross-metric consistency tests (all metrics agree on ordering, identical series, pair counts, cross-DataFrame)
- [x] All 39 tests passing