### PR TITLE
refactor: restructure project for better organization (#15)

### DIFF
--- a/src/ddtw.rs
+++ b/src/ddtw.rs
@@ -5,6 +5,7 @@ use pyo3_polars::PyDataFrame;
 use pyo3::PyResult;
 use rayon::prelude::*;
 
+
 use crate::utils::{get_groups, df_to_hashmap};
 
 /// Compute the derivative of a time series using the method from Keogh & Pazzani (2001).
@@ -35,7 +36,7 @@ fn compute_derivative(q: &[f64]) -> Vec<f64> {
 }
 
 /// Optimized DTW distance implementation using two rows.
-/// This version uses O(m) memory instead of allocating the full (n+1)×(m+1) matrix.
+/// This version uses O(m) memory instead of allocating the full (n+1)x(m+1) matrix.
 fn dtw_distance(a: &[f64], b: &[f64]) -> f64 {
     let n = a.len();
     let m = b.len();

--- a/src/dtw_multi.rs
+++ b/src/dtw_multi.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use rayon::prelude::*;
-
 use crate::utils::{get_groups_multivariate, df_to_hashmap_multivariate};
 
 /// Distance metric for DTW cost calculations.

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -4,7 +4,6 @@ use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use pyo3::PyResult;
 use rayon::prelude::*;
-
 use crate::utils::{get_groups, df_to_hashmap};
 
 /// Helper function to calculate the MSM cost
@@ -16,7 +15,7 @@ fn msm_cost(x: f64, y: f64, z: f64, c: f64) -> f64 {
 }
 
 /// Optimized MSM distance implementation using two rows.
-/// This version uses O(m) memory instead of allocating the full n×m matrix.
+/// This version uses O(m) memory instead of allocating the full n*m matrix.
 fn msm_distance(a: &[f64], b: &[f64], c: f64) -> f64 {
     let n = a.len();
     let m = b.len();

--- a/src/msm_multi.rs
+++ b/src/msm_multi.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use rayon::prelude::*;
-
 use crate::utils::{get_groups_multivariate, df_to_hashmap_multivariate};
 
 /// Compute Manhattan distance between two vectors.

--- a/src/wdtw.rs
+++ b/src/wdtw.rs
@@ -5,6 +5,7 @@ use pyo3_polars::PyDataFrame;
 use pyo3::PyResult;
 use rayon::prelude::*;
 
+
 use crate::utils::{get_groups, df_to_hashmap};
 
 /// Precompute weight vector for WDTW calculation.


### PR DESCRIPTION
## Summary

- **Rust: Extract shared utilities into `src/utils.rs`** — Deduplicated `get_groups`, `df_to_hashmap`, `get_groups_multivariate`, and `df_to_hashmap_multivariate` from dtw.rs, ddtw.rs, wdtw.rs, msm.rs, dtw_multi.rs, and msm_multi.rs into a single `utils.rs` module
- **Rust: Remove dead code** — Deleted unused `src/dtw_extended.rs` and cleaned up commented-out code blocks in `lib.rs`
- **Python: Add `__init__.py` re-exports** — `polars_ts/decomposition/__init__.py` and `polars_ts/models/__init__.py` now export their public symbols; top-level `polars_ts/__init__.py` re-exports from subpackages and adds `mann_kendall` to `__all__`
- **Tests: Reorganize into subdirectories** — Moved decomposition tests into `tests/decomposition/`, metrics tests into `tests/metrics/`, and created `tests/distance/` with proper `__init__.py` files
- **CI: Upgrade deprecated GitHub Actions** — `actions/setup-python` v4 to v5, `actions/cache` v3 to v4, `actions/upload-artifact` v3 to v4, `actions/download-artifact` v3 to v4

Closes #15