### PR TITLE
refactor: lightweight core, Rust safety, deduplication, docs & tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,29 @@ jobs:
       - name: Run test suite
         run: uv run pytest --cov=polars_ts
 
+  test-minimal-deps:
+    name: Test minimal deps (polars only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install package with minimal deps
+        run: uv sync --group dev --no-install-workspace && uv pip install -e .
+      - name: Verify import works
+        run: uv run python -c "from polars_ts import compute_pairwise_dtw; print('OK')"
+      - name: Run distance tests
+        run: uv run pytest tests/distance/ tests/test_mann_kendall.py
+
   test-polars-compat:
     name: Test polars ${{ matrix.polars-version }}
     runs-on: ubuntu-latest
@@ -66,6 +89,18 @@ jobs:
         run: uv pip install polars==${{ matrix.polars-version }}
       - name: Run test suite
         run: uv run pytest
+
+  clippy:
+    name: Rust clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
 
   code-quality:
     name: Code quality

--- a/docs/clustering-guide.md
+++ b/docs/clustering-guide.md
@@ -1,0 +1,289 @@
+# Clustering Time Series with polars-ts Distance Matrices
+
+This guide shows how to use pairwise distance matrices computed by polars-ts as
+input to standard clustering algorithms from scipy and scikit-learn.
+
+## Overview
+
+polars-ts computes pairwise distances between time series and returns the results
+as a Polars DataFrame with three columns:
+
+| Column | Description |
+|--------|-------------|
+| `id_1` | Identifier of the first series |
+| `id_2` | Identifier of the second series |
+| *(metric)* | The distance value (column name matches the metric, e.g. `dtw`, `msm`) |
+
+The output contains one row per **unique unordered pair** — that is, only the
+upper triangle of the distance matrix, excluding the diagonal. This is exactly
+the information needed to build a condensed distance vector for scipy or a full
+square matrix for scikit-learn.
+
+---
+
+## 1. Computing a Full Pairwise Distance Matrix
+
+All `compute_pairwise_*` functions accept two DataFrames with columns
+`unique_id` (series identifier) and `y` (values). Pass the same DataFrame twice
+to get the full pairwise matrix of all series against each other.
+
+```python
+import polars as pl
+from polars_ts import compute_pairwise_dtw
+# Each series is identified by "unique_id"; values live in "y"
+df = pl.DataFrame({
+    "unique_id": ["A"] * 5 + ["B"] * 5 + ["C"] * 5,
+    "y":         [1.0, 2, 3, 4, 5,
+                  1.0, 2, 3, 4, 6,
+                  5.0, 4, 3, 2, 1],
+})
+
+distances = compute_pairwise_dtw(df, df)
+print(distances)
+# shape: (3, 3)
+# ┌──────┬──────┬─────┐
+# │ id_1 │ id_2 │ dtw │
+# │ ---  │ ---  │ --- │
+# │ str  │ str  │ f64 │
+# ╞══════╪══════╪═════╡
+# │ A    │ B    │ 1.0 │
+# │ A    │ C    │ 8.0 │
+# │ B    │ C    │ 9.0 │
+# └──────┴──────┴─────┘
+```
+
+Other available distance functions and their key parameters:
+
+| Function | Distance column | Key parameters |
+|----------|----------------|----------------|
+| `compute_pairwise_dtw` | `dtw` | `method` (`"sakoe_chiba"`, `"itakura"`, `"fast"`), `param` |
+| `compute_pairwise_ddtw` | `ddtw` | — |
+| `compute_pairwise_wdtw` | `wdtw` | `g` (weight penalty) |
+| `compute_pairwise_msm` | `msm` | `c` (cost) |
+| `compute_pairwise_erp` | `erp` | `g` (gap penalty) |
+| `compute_pairwise_lcss` | `lcss` | `epsilon` (matching threshold) |
+| `compute_pairwise_twe` | `twe` | `nu`, `lambda_` |
+| `compute_pairwise_dtw_multi` | `dtw_multi` | `metric` (`"manhattan"`, `"euclidean"`) |
+| `compute_pairwise_msm_multi` | `msm_multi` | `c` |
+
+---
+
+## 2. Converting to a scipy Condensed Distance Vector
+
+scipy's hierarchical clustering functions expect a **condensed distance vector**
+— a 1-D array containing the upper triangle of the distance matrix in
+row-major order. polars-ts already returns exactly these upper-triangle pairs,
+but the row order may not match what scipy expects. The helper below
+re-indexes the pairs into the correct order.
+
+```python
+import numpy as np
+from scipy.spatial.distance import squareform
+
+def to_condensed(distances):
+    # Convert a polars-ts pairwise result to a scipy condensed distance vector.
+    # Returns a (condensed_vector, labels) tuple.
+    cols = [c for c in distances.columns if c not in ("id_1", "id_2")]
+dist_col = cols[0]
+    # Collect all unique ids in sorted order
+    all_ids = set(distances["id_1"].to_list()) | set(distances["id_2"].to_list())
+    ids = sorted(all_ids)
+    id_to_idx = {name: i for i, name in enumerate(ids)}
+    n = len(ids)
+    # Build the condensed vector in scipy's expected order
+    condensed = np.zeros(n * (n - 1) // 2)
+    for row in distances.iter_rows(named=True):
+        i, j = id_to_idx[row["id_1"]], id_to_idx[row["id_2"]]
+        if i > j:
+            i, j = j, i
+        idx = n * i - i * (i + 1) // 2 + (j - i - 1)
+        condensed[idx] = row[dist_col]
+    return condensed, ids
+```
+
+You can also convert to a full square matrix when needed:
+
+```python
+condensed, labels = to_condensed(distances)
+square_matrix = squareform(condensed)
+print(square_matrix)
+```
+
+---
+
+## 3. Hierarchical Clustering with scipy
+
+Once you have the condensed vector you can pass it directly to
+`scipy.cluster.hierarchy.linkage`.
+
+```python
+from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
+import matplotlib.pyplot as plt
+
+condensed, labels = to_condensed(distances)
+# Compute the linkage matrix (Ward's method is not valid for arbitrary
+# distance matrices; use "average", "complete", or "single" instead)
+Z = linkage(condensed, method="average")
+# Cut the dendrogram to get flat clusters
+cluster_labels = fcluster(Z, t=2, criterion="maxclust")
+for name, cluster in zip(labels, cluster_labels):
+    print(f"  {name} -> cluster {cluster}")
+```
+
+### Drawing a Dendrogram
+
+```python
+fig, ax = plt.subplots(figsize=(8, 4))
+dendrogram(Z, labels=labels, ax=ax)
+ax.set_ylabel("Distance")
+ax.set_title("Hierarchical Clustering Dendrogram (DTW)")
+plt.tight_layout()
+plt.show()
+```
+
+---
+
+## 4. Spectral Clustering with scikit-learn
+
+Spectral clustering operates on an **affinity (similarity) matrix** rather than a
+distance matrix. Convert distances to affinities using a Gaussian kernel or
+simple inversion.
+
+```python
+from sklearn.cluster import SpectralClustering
+
+condensed, labels = to_condensed(distances)
+square_matrix = squareform(condensed)
+# Convert distances to affinities via a Gaussian kernel.
+# sigma controls the width; a common heuristic is the median distance.
+sigma = np.median(square_matrix[square_matrix > 0])
+affinity_matrix = np.exp(-square_matrix ** 2 / (2 * sigma ** 2))
+# Ensure the diagonal is 1 (self-similarity)
+np.fill_diagonal(affinity_matrix, 1.0)
+
+sc = SpectralClustering(
+    n_clusters=2,
+    affinity="precomputed",
+    random_state=42,
+)
+cluster_labels = sc.fit_predict(affinity_matrix)
+
+for name, cluster in zip(labels, cluster_labels):
+    print(f"  {name} -> cluster {cluster}")
+```
+
+---
+
+## 5. Complete Worked Example
+
+The example below generates synthetic time series, computes DTW distances,
+performs both hierarchical and spectral clustering, and prints the results.
+
+```python
+import numpy as np
+import polars as pl
+from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
+from scipy.spatial.distance import squareform
+from sklearn.cluster import SpectralClustering
+import matplotlib.pyplot as plt
+
+from polars_ts import compute_pairwise_dtw
+# ── Step 1: Create sample time series ──────────────────────────────────
+np.random.seed(42)
+n_points = 50
+# Group 1: upward trends
+series = {}
+for i in range(4):
+    series[f"up_{i}"] = np.linspace(0, 10, n_points) + np.random.normal(0, 0.5, n_points)
+# Group 2: downward trends
+for i in range(4):
+    series[f"down_{i}"] = np.linspace(10, 0, n_points) + np.random.normal(0, 0.5, n_points)
+# Build a polars DataFrame in the expected format
+df = pl.DataFrame({
+    "unique_id": [name for name, vals in series.items() for _ in vals],
+    "y": [v for vals in series.values() for v in vals],
+})
+
+print(f"Input shape: {df.shape}")
+print(f"Series: {sorted(series.keys())}")
+# ── Step 2: Compute pairwise DTW distances ─────────────────────────────
+distances = compute_pairwise_dtw(df, df)
+print(f"\nPairwise distances: {distances.shape[0]} pairs")
+print(distances.head())
+# ── Step 3: Convert to condensed form ──────────────────────────────────
+cols = [c for c in distances.columns if c not in ("id_1", "id_2")]
+dist_col = cols[0]
+ids = sorted(set(distances["id_1"].to_list()) | set(distances["id_2"].to_list()))
+id_to_idx = {name: i for i, name in enumerate(ids)}
+n = len(ids)
+
+condensed = np.zeros(n * (n - 1) // 2)
+for row in distances.iter_rows(named=True):
+    i, j = id_to_idx[row["id_1"]], id_to_idx[row["id_2"]]
+    if i > j:
+        i, j = j, i
+    idx = n * i - i * (i + 1) // 2 + (j - i - 1)
+    condensed[idx] = row[dist_col]
+# ── Step 4: Hierarchical clustering ───────────────────────────────────
+Z = linkage(condensed, method="average")
+hier_labels = fcluster(Z, t=2, criterion="maxclust")
+
+print("\n=== Hierarchical Clustering (2 clusters) ===")
+for name, cl in zip(ids, hier_labels):
+    print(f"  {name:>8s} -> cluster {cl}")
+# ── Step 5: Spectral clustering ───────────────────────────────────────
+square_matrix = squareform(condensed)
+sigma = np.median(square_matrix[square_matrix > 0])
+affinity = np.exp(-square_matrix ** 2 / (2 * sigma ** 2))
+np.fill_diagonal(affinity, 1.0)
+
+sc = SpectralClustering(n_clusters=2, affinity="precomputed", random_state=42)
+spec_labels = sc.fit_predict(affinity)
+
+print("\n=== Spectral Clustering (2 clusters) ===")
+for name, cl in zip(ids, spec_labels):
+    print(f"  {name:>8s} -> cluster {cl}")
+# ── Step 6: Visualize ─────────────────────────────────────────────────
+fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+# Dendrogram
+dendrogram(Z, labels=ids, ax=axes[0])
+axes[0].set_title("Hierarchical Clustering Dendrogram")
+axes[0].set_ylabel("DTW Distance")
+axes[0].tick_params(axis="x", rotation=45)
+# Heatmap of the distance matrix
+im = axes[1].imshow(square_matrix, cmap="viridis")
+axes[1].set_xticks(range(n))
+axes[1].set_yticks(range(n))
+axes[1].set_xticklabels(ids, rotation=45, ha="right")
+axes[1].set_yticklabels(ids)
+axes[1].set_title("DTW Distance Heatmap")
+fig.colorbar(im, ax=axes[1], shrink=0.8)
+
+plt.tight_layout()
+plt.show()
+```
+
+### Expected output
+
+The eight series should cleanly separate into two clusters: all `up_*` series in
+one cluster and all `down_*` series in the other. Both hierarchical and spectral
+clustering should agree on this partition because the within-group DTW distances
+(small warping between noisy versions of the same trend) are much smaller than the
+between-group distances (comparing an upward trend against a downward trend).
+
+---
+
+## Tips
+
+- **Linkage method**: Ward's method (`method="ward"`) requires Euclidean
+  distances and is not appropriate for arbitrary time-series distance metrics.
+  Use `"average"`, `"complete"`, or `"single"` instead.
+- **Choosing the number of clusters**: Use the dendrogram to visually identify a
+  natural cut height, or use the `inconsistent` criterion in `fcluster`.
+- **Large datasets**: polars-ts distance functions are implemented in Rust and
+  run in parallel. For very large collections, consider using approximate methods
+  like `compute_pairwise_dtw(df, df, method="fast", param=5.0)` (FastDTW).
+- **Alternative metrics**: Different distance metrics capture different notions
+  of similarity. MSM is better for amplitude-sensitive comparisons, LCSS is
+  robust to outliers, and WDTW penalizes large temporal shifts. Experiment with
+  multiple metrics on your data.

--- a/docs/distance-metrics.md
+++ b/docs/distance-metrics.md
@@ -1,0 +1,468 @@
+# Distance Metric Comparison Guide
+
+`polars_ts` provides 10 time-series distance metrics implemented in Rust for high performance. This guide covers each metric in detail and offers domain-specific recommendations.
+
+All functions accept Polars DataFrames with columns `"unique_id"` (series identifier) and `"y"` (numeric values). They return a pairwise distance matrix as a DataFrame.
+
+```python
+import polars as pl
+from polars_ts import compute_pairwise_dtw
+
+df = pl.DataFrame({
+    "unique_id": ["A"] * 4 + ["B"] * 4,
+    "y": [1.0, 2.0, 3.0, 4.0, 1.5, 2.5, 3.5, 4.5],
+})
+result = compute_pairwise_dtw(df, df)
+```
+
+---
+
+## Quick Comparison Table
+
+| Metric | True Metric? | Complexity | Handles Shifts? | Noise Robust? | Key Param |
+|---|---|---|---|---|---|
+| DTW | No | O(n*m) | Yes | Moderate | -- |
+| Sakoe-Chiba DTW | No | O(n*w) | Partial (within band) | Moderate | `param` (band width) |
+| Itakura DTW | No | O(n*m) constrained | Partial (within parallelogram) | Moderate | `param` (slope factor) |
+| FastDTW | No | O(n) approx | Yes | Moderate | `param` (radius) |
+| DDTW | No | O(n*m) | Yes | High | -- |
+| WDTW | No | O(n*m) | Yes | High | `g` (weight decay) |
+| MSM | Yes | O(n*m) | Yes | High | `c` (split/merge cost) |
+| ERP | Yes | O(n*m) | Yes | High | `g` (gap penalty ref) |
+| LCSS | No | O(n*m) | Yes | Very High | `epsilon` (match threshold) |
+| TWE | Yes | O(n*m) | Yes | High | `nu` (stiffness), `lambda_` (penalty) |
+
+---
+
+## Metric Details
+
+### 1. DTW (Dynamic Time Warping)
+
+**Description:** The classic elastic distance measure for time series. DTW finds the optimal alignment between two sequences by warping the time axis, minimizing the total Euclidean distance between aligned points.
+
+**How it works:** Builds a cost matrix where each cell (i, j) represents the cumulative cost of aligning the first i points of one series with the first j points of the other. The optimal warping path is found via dynamic programming.
+
+**Pros:**
+
+- Handles time shifts and variable-speed patterns
+- Intuitive and well-studied
+- No parameters to tune
+
+**Cons:**
+
+- O(n*m) complexity can be slow for long series
+- Not a true metric (violates triangle inequality)
+- Susceptible to pathological warping paths
+
+**When to use:** General-purpose time-series comparison where series may be shifted or locally stretched.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+result = compute_pairwise_dtw(df, df)
+```
+
+---
+
+### 2. Sakoe-Chiba DTW
+
+**Description:** A constrained variant of DTW that restricts the warping path to a fixed-width band around the diagonal. This prevents excessive warping and reduces computation time.
+
+**How it works:** Same dynamic programming approach as DTW, but cells outside a symmetric band of width `param` around the diagonal are set to infinity, forcing the alignment to stay close to the diagonal.
+
+**Pros:**
+
+- Faster than unconstrained DTW
+- Prevents pathological alignments
+- Simple single parameter
+
+**Cons:**
+
+- Cannot handle large time shifts exceeding the band width
+- Band width must be chosen a priori
+
+**When to use:** When you know the maximum expected temporal offset between series, or when you need faster DTW with controlled warping.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+result = compute_pairwise_dtw(df, df, method="sakoe_chiba", param=10.0)
+```
+
+---
+
+### 3. Itakura DTW
+
+**Description:** A constrained DTW variant that restricts the warping path to lie within a parallelogram (Itakura parallelogram). This limits the allowed slope of the warping path, preventing both excessive compression and expansion.
+
+**How it works:** The parallelogram constraint enforces a maximum and minimum slope on the warping path. The `param` value controls the slope factor -- higher values allow more warping flexibility.
+
+**Pros:**
+
+- Prevents both excessive compression and stretching
+- More nuanced constraint than a fixed band
+- Good for speech and audio where tempo varies smoothly
+
+**Cons:**
+
+- Less intuitive parameter than Sakoe-Chiba
+- Can be too restrictive for highly variable series
+
+**When to use:** When temporal distortion is smooth and gradual, especially in speech and audio domains.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+result = compute_pairwise_dtw(df, df, method="itakura", param=2.0)
+```
+
+---
+
+### 4. FastDTW
+
+**Description:** An approximate DTW algorithm that operates in linear time and space. It uses a multi-resolution approach: coarsen the series, compute DTW at low resolution, then refine the path at progressively finer resolutions.
+
+**How it works:** The series are recursively downsampled by half. DTW is computed at the coarsest level, and the resulting path is projected upward and expanded by `param` (radius) cells at each finer level to define the search neighborhood.
+
+**Pros:**
+
+- O(n) time and space complexity
+- Practical for very long time series
+- Accuracy close to exact DTW for reasonable radius values
+
+**Cons:**
+
+- Approximate -- can miss the true optimal alignment
+- Accuracy degrades if radius is too small
+- Not a true metric
+
+**When to use:** Large-scale exploratory analysis, very long time series, or when exact DTW is too slow.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+result = compute_pairwise_dtw(df, df, method="fast", param=5.0)
+```
+
+---
+
+### 5. DDTW (Derivative Dynamic Time Warping)
+
+**Description:** Applies DTW to the first derivatives of the time series rather than the raw values. This makes the comparison shape-based rather than value-based.
+
+**How it works:** Estimates the discrete derivative of each series (using the average of left and right finite differences), then runs standard DTW on the derivative sequences.
+
+**Pros:**
+
+- Invariant to vertical offset (baseline shifts)
+- Focuses on shape rather than amplitude
+- No extra parameters beyond standard DTW
+
+**Cons:**
+
+- Derivative estimation amplifies noise
+- Loses absolute magnitude information
+- Slightly more expensive due to derivative computation
+
+**When to use:** When the shape of the series matters more than its absolute values, e.g., comparing trends regardless of baseline level.
+
+```python
+from polars_ts import compute_pairwise_ddtw
+
+result = compute_pairwise_ddtw(df, df)
+```
+
+---
+
+### 6. WDTW (Weighted Dynamic Time Warping)
+
+**Description:** A variant of DTW that applies a multiplicative weight penalty based on the phase difference between aligned points. Points aligned far from the diagonal receive higher penalties.
+
+**How it works:** A logistic weight function controlled by parameter `g` assigns weights to each cell based on |i - j|. Small `g` values produce nearly uniform weights (behaves like DTW); large `g` values heavily penalize off-diagonal alignments.
+
+**Pros:**
+
+- Smooth penalty discourages excessive warping without hard cutoffs
+- Single intuitive parameter
+- Retains DTW flexibility while adding regularization
+
+**Cons:**
+
+- Not a true metric
+- Choosing `g` requires experimentation
+- Same O(n*m) complexity as standard DTW
+
+**When to use:** When you want DTW behavior but with soft penalization of excessive warping, particularly for noisy series.
+
+```python
+from polars_ts import compute_pairwise_wdtw
+
+result = compute_pairwise_wdtw(df, df, g=0.05)
+```
+
+---
+
+### 7. MSM (Move-Split-Merge)
+
+**Description:** An edit-distance-style metric that uses three operations -- Move (change a value), Split (duplicate a point), and Merge (combine two points) -- each with cost `c`. It is a true metric.
+
+**How it works:** Dynamic programming computes the minimum cost of transforming one series into the other using move, split, and merge operations. The parameter `c` controls the cost of split and merge relative to moves.
+
+**Pros:**
+
+- True metric (satisfies triangle inequality)
+- Invariant to certain transformations depending on `c`
+- Good theoretical properties for indexing and clustering
+
+**Cons:**
+
+- Less intuitive than DTW
+- Cost parameter `c` requires domain knowledge to set
+- O(n*m) complexity
+
+**When to use:** When metric properties are needed (e.g., for metric-tree indexing, k-medoids clustering), or when you need principled handling of insertions and deletions.
+
+```python
+from polars_ts import compute_pairwise_msm
+
+result = compute_pairwise_msm(df, df, c=1.0)
+```
+
+---
+
+### 8. ERP (Edit Distance with Real Penalty)
+
+**Description:** A true metric that combines edit distance with a real-valued gap penalty. Unmatched points are compared against a fixed reference value `g` (often 0), making it robust to noise and partial matches.
+
+**How it works:** Dynamic programming with three operations: match (Euclidean cost), insert-gap (cost is |point - g|), and delete-gap (cost is |point - g|). The parameter `g` acts as a reference level for gap penalties.
+
+**Pros:**
+
+- True metric
+- Handles series of different lengths gracefully
+- Gap reference `g` provides noise robustness
+
+**Cons:**
+
+- Sensitive to the choice of `g`
+- O(n*m) complexity
+- Less commonly used than DTW, so less community tooling
+
+**When to use:** When metric properties are required and series may have missing segments or different lengths. Works well for zero-centered or normalized data with `g=0.0`.
+
+```python
+from polars_ts import compute_pairwise_erp
+
+result = compute_pairwise_erp(df, df, g=0.0)
+```
+
+---
+
+### 9. LCSS (Longest Common Subsequence)
+
+**Description:** Measures similarity by finding the longest subsequence of points that match within a threshold `epsilon`. The distance is derived from the length of this subsequence.
+
+**How it works:** Two points match if their absolute difference is at most `epsilon`. Dynamic programming finds the longest sequence of such matches (not necessarily contiguous). The distance is typically `1 - LCSS_length / min(n, m)`.
+
+**Pros:**
+
+- Extremely robust to noise and outliers (mismatched points are simply skipped)
+- Intuitive threshold parameter
+- Good for partial matching
+
+**Cons:**
+
+- Not a true metric
+- Only considers match/no-match, losing fine-grained distance information
+- `epsilon` must be tuned relative to data scale
+
+**When to use:** Noisy environments where outliers are common, or when you care about structural similarity rather than exact amplitude matching.
+
+```python
+from polars_ts import compute_pairwise_lcss
+
+result = compute_pairwise_lcss(df, df, epsilon=1.0)
+```
+
+---
+
+### 10. TWE (Time Warp Edit Distance)
+
+**Description:** A true metric that combines DTW-style elastic matching with edit-distance-style insert/delete operations. It uses a stiffness parameter `nu` and a gap penalty `lambda_`.
+
+**How it works:** Dynamic programming considers three operations: match (with temporal stiffness `nu` controlling how much consecutive point spacing matters), delete, and insert (both penalized by `lambda_`). The stiffness parameter makes TWE sensitive to the temporal regularity of the alignment.
+
+**Pros:**
+
+- True metric
+- Two parameters allow fine-grained control over warping vs. gap behavior
+- Good balance between DTW and edit distance
+
+**Cons:**
+
+- Two parameters to tune
+- Less widely known than DTW
+- O(n*m) complexity
+
+**When to use:** When you need metric properties and want control over both elastic warping and gap penalties. Particularly useful for trajectory and motion data.
+
+```python
+from polars_ts import compute_pairwise_twe
+
+result = compute_pairwise_twe(df, df, nu=0.001, lambda_=1.0)
+```
+
+---
+
+## Domain-Specific Guidance
+
+### Finance (Stock Prices, Returns, Macro Indicators)
+
+Financial time series often have regime shifts, trends, and varying volatility. Shape-based comparison is usually more meaningful than raw value comparison.
+
+**Recommended metrics:**
+
+- **DDTW** -- Compares return profiles (derivatives) rather than price levels, which is more meaningful since absolute price is often arbitrary.
+- **WDTW** (g=0.05 to 0.1) -- Allows flexible alignment with soft warping penalty, useful for comparing securities that move similarly but with slight lead/lag.
+- **MSM** -- True metric, good for clustering financial instruments into groups for portfolio construction.
+
+```python
+from polars_ts import compute_pairwise_ddtw, compute_pairwise_wdtw
+
+# Compare return shapes (ignoring price levels)
+shape_distances = compute_pairwise_ddtw(stocks_df, stocks_df)
+
+# Flexible alignment with controlled warping
+aligned_distances = compute_pairwise_wdtw(stocks_df, stocks_df, g=0.05)
+```
+
+---
+
+### IoT / Sensor Data
+
+Sensor data is often noisy, may contain dropouts, and can have varying sampling rates. Robustness to noise and missing data is critical.
+
+**Recommended metrics:**
+
+- **LCSS** (epsilon tuned to sensor noise floor) -- Excellent noise robustness; outlier readings are simply ignored.
+- **ERP** (g=0.0 for zero-centered data) -- Handles gaps and dropouts gracefully as a true metric.
+- **Sakoe-Chiba DTW** -- Faster than full DTW, suitable for real-time or near-real-time processing with bounded sensor lag.
+
+```python
+from polars_ts import compute_pairwise_lcss, compute_pairwise_erp
+
+# Robust to noisy sensor readings
+noisy_distances = compute_pairwise_lcss(sensor_df, sensor_df, epsilon=0.5)
+
+# Handle sensor dropouts with gap penalty
+gap_distances = compute_pairwise_erp(sensor_df, sensor_df, g=0.0)
+```
+
+---
+
+### Speech / Audio
+
+Speech signals exhibit smooth tempo variation and local frequency shifts. Constraints that enforce gradual warping are well-suited here.
+
+**Recommended metrics:**
+
+- **Itakura DTW** (param=1.5 to 3.0) -- The parallelogram constraint naturally models gradual tempo changes in speech.
+- **WDTW** (g=0.1 to 0.5) -- Soft warping penalty accommodates pronunciation variation.
+- **DTW** -- The unconstrained baseline remains strong for general speech comparison.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+# Smooth tempo variation constraint
+speech_distances = compute_pairwise_dtw(mfcc_df, mfcc_df, method="itakura", param=2.0)
+```
+
+---
+
+### Gesture / Motion Capture
+
+Gesture data involves 3D trajectories performed at varying speeds. Metrics need to handle speed variation while preserving spatial structure.
+
+**Recommended metrics:**
+
+- **TWE** -- True metric with stiffness control; low `nu` allows flexible speed variation, `lambda_` penalizes skipped frames.
+- **MSM** -- True metric that handles split/merge of motion segments naturally.
+- **DTW** -- Reliable baseline for gesture recognition.
+
+```python
+from polars_ts import compute_pairwise_twe, compute_pairwise_msm
+
+# Flexible speed, penalize skipped frames
+gesture_distances = compute_pairwise_twe(motion_df, motion_df, nu=0.001, lambda_=1.0)
+
+# Edit-based comparison
+edit_distances = compute_pairwise_msm(motion_df, motion_df, c=1.0)
+```
+
+---
+
+### Large-Scale Exploration
+
+When working with thousands of long time series, computational cost dominates. Approximate or constrained methods are essential.
+
+**Recommended metrics:**
+
+- **FastDTW** (param=5 to 20) -- Linear-time approximation, the go-to choice for large datasets.
+- **Sakoe-Chiba DTW** (narrow band) -- Reduces quadratic cost significantly with a tight band.
+- **LCSS** -- Can be pruned efficiently and provides coarse but fast similarity.
+
+```python
+from polars_ts import compute_pairwise_dtw
+
+# Fast approximate DTW for large datasets
+approx_distances = compute_pairwise_dtw(large_df, large_df, method="fast", param=10.0)
+
+# Constrained DTW with narrow band
+band_distances = compute_pairwise_dtw(large_df, large_df, method="sakoe_chiba", param=5.0)
+```
+
+---
+
+### Trajectory Analysis (GPS, Vehicle, Pedestrian)
+
+Trajectories involve spatial paths with temporal components. Metrics that handle gaps (stops, signal loss) and provide true metric properties for spatial indexing are preferred.
+
+**Recommended metrics:**
+
+- **ERP** (g=0.0) -- True metric, handles GPS signal dropouts as gaps against a reference point.
+- **TWE** -- True metric with temporal stiffness; good for distinguishing paths taken at different speeds.
+- **LCSS** (epsilon tuned to spatial tolerance) -- Ignores GPS jitter and noise, focuses on structural path similarity.
+
+```python
+from polars_ts import compute_pairwise_erp, compute_pairwise_twe
+
+# Handle GPS dropouts
+traj_distances = compute_pairwise_erp(gps_df, gps_df, g=0.0)
+
+# Speed-sensitive trajectory comparison
+speed_distances = compute_pairwise_twe(gps_df, gps_df, nu=0.01, lambda_=0.5)
+```
+
+---
+
+## Choosing a Metric: Decision Flowchart
+
+1. **Do you need true metric properties?** (e.g., for metric trees, k-medoids, triangle inequality pruning)
+    - Yes: Choose from **MSM**, **ERP**, or **TWE**
+    - No: Continue below
+
+2. **Is noise/outlier robustness the top priority?**
+    - Yes: Use **LCSS** (set `epsilon` to your noise tolerance)
+    - No: Continue below
+
+3. **Do you care about shape rather than absolute values?**
+    - Yes: Use **DDTW**
+    - No: Continue below
+
+4. **Are your series very long (>10,000 points) or do you have many series?**
+    - Yes: Use **FastDTW** or **Sakoe-Chiba DTW**
+    - No: Continue below
+
+5. **Do you want controlled warping without hard boundaries?**
+    - Yes: Use **WDTW**
+    - No: Use standard **DTW**

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -36,6 +36,9 @@ theme:
 
 nav:
   - Home: index.md
+  - Guides:
+      - Distance Metrics: distance-metrics.md
+      - Clustering Guide: clustering-guide.md
   - Reference:
       - Python API: reference/
       - Rust API: reference/rust/

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -1,19 +1,57 @@
-from polars_ts.metrics import Metrics  # noqa
-from polars_ts.decomposition import fourier_decomposition, seasonal_decomposition, seasonal_decompose_features  # noqa
-from polars_ts.models import SCUM  # noqa
-
 from pathlib import Path
+
+import polars as pl
+import polars_ts_rs as _rs_mod
+from polars._typing import IntoExpr
+from polars.plugins import register_plugin_function
 from polars_ts_rs.polars_ts_rs import (
-    compute_pairwise_dtw,
-    compute_pairwise_msm,
     compute_pairwise_ddtw,
-    compute_pairwise_wdtw,
+    compute_pairwise_dtw,
     compute_pairwise_dtw_multi,
-    compute_pairwise_msm_multi,
     compute_pairwise_erp,
     compute_pairwise_lcss,
+    compute_pairwise_msm,
+    compute_pairwise_msm_multi,
     compute_pairwise_twe,
+    compute_pairwise_wdtw,
 )
+
+PLUGIN_PATH = Path(_rs_mod.__file__).parent
+
+
+def mann_kendall(expr: IntoExpr) -> pl.Expr:
+    """Mann-Kendall test for expression."""
+    return register_plugin_function(
+        plugin_path=PLUGIN_PATH,
+        function_name="mann_kendall",
+        args=expr,
+        is_elementwise=False,
+    )
+
+
+def __getattr__(name: str):
+    if name == "Metrics":
+        from polars_ts.metrics import Metrics
+
+        return Metrics
+    if name == "SCUM":
+        from polars_ts.models import SCUM
+
+        return SCUM
+    if name == "fourier_decomposition":
+        from polars_ts.decomposition.fourier_decomposition import fourier_decomposition
+
+        return fourier_decomposition
+    if name == "seasonal_decomposition":
+        from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
+
+        return seasonal_decomposition
+    if name == "seasonal_decompose_features":
+        from polars_ts.decomposition.seasonal_decompose_features import seasonal_decompose_features
+
+        return seasonal_decompose_features
+    raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
+
 
 __all__ = [
     "compute_pairwise_dtw",
@@ -32,20 +70,3 @@ __all__ = [
     "Metrics",
     "SCUM",
 ]
-
-import polars as pl
-import polars_ts_rs as _rs_mod
-from polars._typing import IntoExpr
-from polars.plugins import register_plugin_function
-
-PLUGIN_PATH = Path(_rs_mod.__file__).parent
-
-
-def mann_kendall(expr: IntoExpr) -> pl.Expr:
-    """Mann-Kendall test for expression."""
-    return register_plugin_function(
-        plugin_path=PLUGIN_PATH,
-        function_name="mann_kendall",
-        args=expr,
-        is_elementwise=False,
-    )

--- a/polars_ts/decomposition/__init__.py
+++ b/polars_ts/decomposition/__init__.py
@@ -1,5 +1,17 @@
-from polars_ts.decomposition.fourier_decomposition import fourier_decomposition
-from polars_ts.decomposition.seasonal_decompose_features import seasonal_decompose_features
-from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
+def __getattr__(name: str):
+    if name == "fourier_decomposition":
+        from polars_ts.decomposition.fourier_decomposition import fourier_decomposition
+
+        return fourier_decomposition
+    if name == "seasonal_decomposition":
+        from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
+
+        return seasonal_decomposition
+    if name == "seasonal_decompose_features":
+        from polars_ts.decomposition.seasonal_decompose_features import seasonal_decompose_features
+
+        return seasonal_decompose_features
+    raise AttributeError(f"module 'polars_ts.decomposition' has no attribute {name!r}")
+
 
 __all__ = ["fourier_decomposition", "seasonal_decomposition", "seasonal_decompose_features"]

--- a/polars_ts/decomposition/fourier_decomposition.py
+++ b/polars_ts/decomposition/fourier_decomposition.py
@@ -1,7 +1,11 @@
 from typing import Literal, Tuple
 
 import polars as pl
-import polars_ds as pds
+
+try:
+    import polars_ds as pds
+except ImportError:
+    pds = None
 
 
 def fourier_decomposition(
@@ -51,12 +55,17 @@ def fourier_decomposition(
                 target and the sum of the trend and seasonal components.
 
     """
+    if pds is None:
+        raise ImportError(
+            "polars-ds is required for fourier_decomposition(). "
+            "Install it with: pip install polars-timeseries[decomposition]"
+        )
+
     # Check if necessary columns exist in the dataframe
     required_columns = {id_col, target_col, time_col}
-
-    assert required_columns.issubset(df.columns), KeyError(
-        f"Columns {required_columns.difference(df.columns)} are missing from the DataFrame."
-    )
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise KeyError(f"Columns {missing} are missing from the DataFrame.")
 
     # Validate ts_freq: ensure it's a positive integer
     if not isinstance(ts_freq, int) or ts_freq <= 0:
@@ -64,11 +73,9 @@ def fourier_decomposition(
 
     # Validate freqs: ensure all frequencies are valid
     valid_freqs = ["week", "month", "quarter", "day_of_week", "day_of_month", "day_of_year"]
-
-    assert set(freqs).issubset(valid_freqs), KeyError(
-        f"Invalid Frequencies {set(freqs).difference(valid_freqs)}, \
-            please pass any combination of elements in {valid_freqs}"
-    )
+    invalid_freqs = set(freqs).difference(valid_freqs)
+    if invalid_freqs:
+        raise KeyError(f"Invalid Frequencies {invalid_freqs}, please pass any combination of elements in {valid_freqs}")
 
     # Validate n_fourier_terms: ensure it's a positive integer
     if not isinstance(n_fourier_terms, int) or n_fourier_terms <= 0:

--- a/polars_ts/decomposition/seasonal_decompose_features.py
+++ b/polars_ts/decomposition/seasonal_decompose_features.py
@@ -2,8 +2,13 @@ from typing import List, Literal, Optional
 
 import polars as pl
 import polars.selectors as cs
-from statsforecast.feature_engineering import mstl_decomposition
-from statsforecast.models import MSTL
+
+try:
+    from statsforecast.feature_engineering import mstl_decomposition
+    from statsforecast.models import MSTL
+except ImportError:
+    mstl_decomposition = None
+    MSTL = None
 
 from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
 
@@ -56,28 +61,27 @@ def seasonal_decompose_features(
     """
     # Check if necessary columns exist in the dataframe
     required_columns = {id_col, target_col, time_col}
-
-    assert required_columns.issubset(df.columns), KeyError(
-        f"Columns {required_columns.difference(df.columns)} are missing from the DataFrame."
-    )
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise KeyError(f"Columns {missing} are missing from the DataFrame.")
 
     # Validate ts_freq: ensure it's a positive integer
     if not isinstance(ts_freq, int) or ts_freq <= 0:
         raise ValueError(f"Invalid ts_freq '{ts_freq}'. It must be a positive integer.")
 
-        # Ensure the dataframe is not empty
+    # Ensure the dataframe is not empty
     if len(df) == 0:
         raise ValueError("The DataFrame is empty. Cannot perform decomposition on an empty DataFrame.")
 
-    assert mode in ["mstl", "simple"], ValueError(
-        'Must Pick a mode "mstl" or "simple" to specify type of decomposition...'
-    )
+    if mode not in ["mstl", "simple"]:
+        raise ValueError('Must Pick a mode "mstl" or "simple" to specify type of decomposition...')
 
     if seasonal_freqs is None and mode == "mstl":
         raise ValueError("Must Specify atleast one seasonal freq in MSTL mode...")
 
     if seasonal_freqs is not None:
-        assert all(isinstance(freq, int) for freq in seasonal_freqs), "All Seasonal Frequencies must be integers"
+        if not all(isinstance(freq, int) for freq in seasonal_freqs):
+            raise TypeError("All Seasonal Frequencies must be integers")
 
     # Compute Trend Strength as MAX( 0, 1 - Var(R(t)) / Var(T(t) + R(t)))
     trend_strength_expr = (
@@ -116,16 +120,20 @@ def seasonal_decompose_features(
 
     # MSTL Mode (Only populate seasonal_freqs if mstl is active)
     elif mode == "mstl":
+        if mstl_decomposition is None or MSTL is None:
+            raise ImportError(
+                "statsforecast is required for MSTL decomposition. "
+                "Install it with: pip install polars-timeseries[forecast]"
+            )
+
         if seasonal_freqs is None:
             raise ValueError("For 'mstl' mode, 'seasonal_freqs' must be provided.")
 
         # map integer frequency to known datetime offset in polars:
-
         freq_mapper = {12: "1mo", 52: "1w", 4: "1q", 24: "1h", 365: "1d"}
 
-        assert ts_freq in freq_mapper.keys(), ValueError(
-            f"Frequency must be one of {freq_mapper.keys()} for MSTL decompose.."
-        )
+        if ts_freq not in freq_mapper:
+            raise ValueError(f"Frequency must be one of {list(freq_mapper.keys())} for MSTL decompose..")
 
         # force columns to be renamed
         col_remapper = {id_col: "unique_id", time_col: "ds", target_col: "y"}

--- a/polars_ts/decomposition/seasonal_decomposition.py
+++ b/polars_ts/decomposition/seasonal_decomposition.py
@@ -36,9 +36,9 @@ def seasonal_decomposition(
     # Check if the necessary columns exist in the dataframe
     required_columns = {id_col, target_col, time_col}
 
-    assert required_columns.issubset(df.columns), AssertionError(
-        f"Columns {required_columns.difference(df.columns)} are missing from the DataFrame."
-    )
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise KeyError(f"Columns {missing} are missing from the DataFrame.")
 
     # Ensure the dataframe is not empty
     if len(df) == 0:

--- a/polars_ts/metrics/__init__.py
+++ b/polars_ts/metrics/__init__.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 
 import polars as pl
-from statsforecast import StatsForecast
 
-from polars_ts.metrics.kaboudan import Kaboudan
+try:
+    from statsforecast import StatsForecast as _StatsForecast
+except ImportError:
+    _StatsForecast = None
 
 
 @dataclass
@@ -13,7 +15,7 @@ class Metrics:
 
     def kaboudan(
         self,
-        sf: StatsForecast,
+        sf: object,
         block_size: int = 0,
         backtesting_start: float = 0.0,
         n_folds: int = 0,
@@ -21,6 +23,13 @@ class Metrics:
         modified: bool = True,
         agg: bool = False,
     ) -> pl.Expr:
+        if _StatsForecast is None:
+            raise ImportError(
+                "statsforecast is required for Metrics.kaboudan(). "
+                "Install it with: pip install polars-timeseries[forecast]"
+            )
+        from polars_ts.metrics.kaboudan import Kaboudan
+
         kaboudan = Kaboudan(
             sf=sf,
             block_size=block_size,

--- a/polars_ts/metrics/kaboudan.py
+++ b/polars_ts/metrics/kaboudan.py
@@ -8,8 +8,13 @@ import random
 from dataclasses import dataclass
 
 import polars as pl
-from statsforecast import StatsForecast
-from utilsforecast import losses
+
+try:
+    from statsforecast import StatsForecast
+    from utilsforecast import losses
+except ImportError:
+    StatsForecast = None
+    losses = None
 
 
 @dataclass

--- a/polars_ts/models/__init__.py
+++ b/polars_ts/models/__init__.py
@@ -1,3 +1,13 @@
-from polars_ts.models.scum import SCUM
+def __getattr__(name: str):
+    if name == "SCUM":
+        try:
+            from polars_ts.models.scum import SCUM
+        except ImportError:
+            raise ImportError(
+                "statsforecast is required for SCUM. " "Install it with: pip install polars-timeseries[forecast]"
+            ) from None
+        return SCUM
+    raise AttributeError(f"module 'polars_ts.models' has no attribute {name!r}")
+
 
 __all__ = ["SCUM"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "polars>=1.30.0,<2.0.0",
+    "pyarrow>=15.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "polars>=1.30.0,<2.0.0",
-    "statsforecast>=2.0.0",
-    "polars-ds>=0.10.0",
-    "statsmodels>=0.14.5",
 ]
+
+[project.optional-dependencies]
+forecast = ["statsforecast>=2.0.0", "utilsforecast>=0.2.0"]
+decomposition = ["polars-ds>=0.10.0"]
+all = ["polars-timeseries[forecast,decomposition]"]
 
 [project.urls]
 Source = "https://github.com/drumtorben/polars-ts.git"

--- a/src/ddtw.rs
+++ b/src/ddtw.rs
@@ -1,60 +1,36 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
 
-
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
 /// Compute the derivative of a time series using the method from Keogh & Pazzani (2001).
-///
-/// The derivative is calculated as:
-/// q'(i) = (q(i) - q(i-1) + ((q(i+1) - q(i-1))/2)) / 2
-///
-/// This implementation handles the boundary conditions by returning a vector with length len(q) - 2.
 fn compute_derivative(q: &[f64]) -> Vec<f64> {
     if q.len() < 3 {
-        return Vec::new(); // Not enough points to compute derivative
+        return Vec::new();
     }
-
-    // Preallocate output vector
     let mut derivative = Vec::with_capacity(q.len() - 2);
-
     for i in 1..q.len() - 1 {
-        // Calculate the derivative at point i
-        // q'(i) = (q(i) - q(i-1) + ((q(i+1) - q(i-1))/2)) / 2
-        let term1 = q[i] - q[i-1];
-        let term2 = (q[i+1] - q[i-1]) / 2.0;
-        let derivative_i = (term1 + term2) / 2.0;
-
-        derivative.push(derivative_i);
+        let term1 = q[i] - q[i - 1];
+        let term2 = (q[i + 1] - q[i - 1]) / 2.0;
+        derivative.push((term1 + term2) / 2.0);
     }
-
     derivative
 }
 
-/// Optimized DTW distance implementation using two rows.
-/// This version uses O(m) memory instead of allocating the full (n+1)x(m+1) matrix.
+/// DTW distance using O(m) memory (two-row approach).
 fn dtw_distance(a: &[f64], b: &[f64]) -> f64 {
     let n = a.len();
     let m = b.len();
-
-    // Handle edge cases
     if n == 0 || m == 0 {
         return f64::INFINITY;
     }
-
     let mut prev = vec![f64::MAX; m + 1];
     let mut curr = vec![f64::MAX; m + 1];
     prev[0] = 0.0;
-
     for i in 1..=n {
         curr[0] = f64::MAX;
         for j in 1..=m {
             let cost = (a[i - 1] - b[j - 1]).abs();
-            // Choose the best previous cell.
             let min_prev = prev[j].min(curr[j - 1]).min(prev[j - 1]);
             curr[j] = cost + min_prev;
         }
@@ -63,108 +39,17 @@ fn dtw_distance(a: &[f64], b: &[f64]) -> f64 {
     prev[m]
 }
 
-/// Computes the DDTW (Derivative DTW) distance between two time series.
-/// First calculates the derivative of each series, then computes DTW on those derivatives.
+/// DDTW distance: derivative of each series, then DTW on derivatives.
 fn ddtw_distance(a: &[f64], b: &[f64]) -> f64 {
-    // Calculate derivatives
-    let a_derivative = compute_derivative(a);
-    let b_derivative = compute_derivative(b);
-
-    // Handle edge cases
-    if a_derivative.is_empty() || b_derivative.is_empty() {
+    let a_d = compute_derivative(a);
+    let b_d = compute_derivative(b);
+    if a_d.is_empty() || b_d.is_empty() {
         return f64::INFINITY;
     }
-
-    // Compute DTW on derivatives
-    dtw_distance(&a_derivative, &b_derivative)
+    dtw_distance(&a_d, &b_d)
 }
 
-/// Compute pairwise DDTW distances between time series in two DataFrames,
-/// using extensive parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "ddtw".
 #[pyfunction]
 pub fn compute_pairwise_ddtw(input1: PyDataFrame, input2: PyDataFrame) -> PyResult<PyDataFrame> {
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate the "y" column.
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    // Build HashMaps mapping unique_id -> time series (Vec<f64>) for each input.
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    // Wrap the maps in an Arc so that they can be shared safely across threads.
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    // Create vectors of references for the keys and series.
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    // Compute pairwise DDTW distances: id_1 always comes from left, id_2 from right.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            // Clone the Arc pointers for use in the inner closure.
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // If both keys are common (i.e. appear in both maps), enforce an ordering to avoid duplicates.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    // Compute the DDTW distance.
-                    let distance = ddtw_distance(left_series, right_series);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    // Build output columns.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let ddtw_vals: Vec<f64> = results.iter().map(|(_, _, ddtw)| *ddtw).collect();
-
-    // Create a new Polars DataFrame.
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("ddtw".into(), ddtw_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "ddtw", ddtw_distance)
 }

--- a/src/dtw.rs
+++ b/src/dtw.rs
@@ -1,14 +1,11 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
+use std::collections::HashSet;
 
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
 // ---------------------------------------------------------------------------
-// DTW distance functions
+// DTW distance kernels
 // ---------------------------------------------------------------------------
 
 /// Standard unconstrained DTW using O(m) memory (two-row approach).
@@ -32,12 +29,10 @@ fn dtw_distance(a: &[f64], b: &[f64]) -> f64 {
 }
 
 /// DTW with Sakoe-Chiba band constraint.
-/// Only cells within `window` of the diagonal are computed.
 fn dtw_sakoe_chiba(a: &[f64], b: &[f64], window: usize) -> f64 {
     let n = a.len();
     let m = b.len();
-    // Adjust window to accommodate length differences.
-    let w = window.max(if n > m { n - m } else { m - n });
+    let w = window.max(n.abs_diff(m));
     let mut prev = vec![f64::MAX; m + 1];
     let mut curr = vec![f64::MAX; m + 1];
     prev[0] = 0.0;
@@ -46,7 +41,6 @@ fn dtw_sakoe_chiba(a: &[f64], b: &[f64], window: usize) -> f64 {
         curr[0] = f64::MAX;
         let j_start = if i > w { i - w } else { 1 };
         let j_end = (i + w).min(m);
-        // Reset cells just outside the band to MAX so they don't bleed in.
         if j_start > 1 {
             curr[j_start - 1] = f64::MAX;
         }
@@ -61,7 +55,6 @@ fn dtw_sakoe_chiba(a: &[f64], b: &[f64], window: usize) -> f64 {
 }
 
 /// DTW with Itakura parallelogram constraint.
-/// `max_slope` controls the steepness of the parallelogram (typical: 2.0).
 fn dtw_itakura(a: &[f64], b: &[f64], max_slope: f64) -> f64 {
     let n = a.len();
     let m = b.len();
@@ -75,15 +68,10 @@ fn dtw_itakura(a: &[f64], b: &[f64], max_slope: f64) -> f64 {
     for i in 1..=n {
         curr[0] = f64::MAX;
         for j in 1..=m {
-            // Check Itakura parallelogram bounds.
             let fi = i as f64;
             let fj = j as f64;
-            let lower1 = fi / max_slope;
-            let upper1 = fi * max_slope;
-            let lower2 = mf - (nf - fi) * max_slope;
-            let upper2 = mf - (nf - fi) / max_slope;
-            let lower = lower1.max(lower2);
-            let upper = upper1.min(upper2);
+            let lower = (fi / max_slope).max(mf - (nf - fi) * max_slope);
+            let upper = (fi * max_slope).min(mf - (nf - fi) / max_slope);
             if fj < lower || fj > upper {
                 curr[j] = f64::MAX;
             } else {
@@ -99,7 +87,7 @@ fn dtw_itakura(a: &[f64], b: &[f64], max_slope: f64) -> f64 {
 
 /// Reduce a time series by averaging consecutive pairs.
 fn reduce_by_half(x: &[f64]) -> Vec<f64> {
-    let mut reduced = Vec::with_capacity((x.len() + 1) / 2);
+    let mut reduced = Vec::with_capacity(x.len().div_ceil(2));
     let mut i = 0;
     while i + 1 < x.len() {
         reduced.push((x[i] + x[i + 1]) / 2.0);
@@ -112,39 +100,33 @@ fn reduce_by_half(x: &[f64]) -> Vec<f64> {
 }
 
 /// FastDTW: approximate DTW in O(N) time using multi-resolution coarsening.
-/// `radius` controls the size of the neighborhood around the projected path.
+/// Uses HashSet for O(path_len * radius^2) memory instead of O(n*m).
 fn fast_dtw(a: &[f64], b: &[f64], radius: usize) -> f64 {
     let min_size = radius + 2;
     if a.len() <= min_size || b.len() <= min_size {
         return dtw_distance(a, b);
     }
 
-    // 1. Coarsen
     let a_shrunk = reduce_by_half(a);
     let b_shrunk = reduce_by_half(b);
-
-    // 2. Recurse on coarsened series to get the warping path
     let path = fast_dtw_path(&a_shrunk, &b_shrunk, radius);
 
-    // 3. Project path back to original resolution and expand by radius
     let n = a.len();
     let m = b.len();
-    let mut window = vec![vec![false; m]; n];
+    let mut window: HashSet<(usize, usize)> = HashSet::new();
     for &(pi, pj) in &path {
-        // Each coarse cell (pi, pj) maps to up to 4 cells in original resolution
         for di in 0..2 {
             for dj in 0..2 {
                 let oi = pi * 2 + di;
                 let oj = pj * 2 + dj;
                 if oi < n && oj < m {
-                    // Expand by radius
-                    let r_start_i = if oi >= radius { oi - radius } else { 0 };
+                    let r_start_i = oi.saturating_sub(radius);
                     let r_end_i = (oi + radius).min(n - 1);
-                    let r_start_j = if oj >= radius { oj - radius } else { 0 };
+                    let r_start_j = oj.saturating_sub(radius);
                     let r_end_j = (oj + radius).min(m - 1);
                     for ri in r_start_i..=r_end_i {
                         for rj in r_start_j..=r_end_j {
-                            window[ri][rj] = true;
+                            window.insert((ri, rj));
                         }
                     }
                 }
@@ -152,21 +134,19 @@ fn fast_dtw(a: &[f64], b: &[f64], radius: usize) -> f64 {
         }
     }
 
-    // 4. Compute DTW only on the projected window
     dtw_with_window(a, b, &window)
 }
 
-/// Compute DTW restricted to a boolean window mask.
-fn dtw_with_window(a: &[f64], b: &[f64], window: &[Vec<bool>]) -> f64 {
+/// Compute DTW restricted to a HashSet window mask.
+fn dtw_with_window(a: &[f64], b: &[f64], window: &HashSet<(usize, usize)>) -> f64 {
     let n = a.len();
     let m = b.len();
-    // Use full matrix since window is sparse and irregular
     let mut cost_matrix = vec![vec![f64::MAX; m + 1]; n + 1];
     cost_matrix[0][0] = 0.0;
 
     for i in 1..=n {
         for j in 1..=m {
-            if !window[i - 1][j - 1] {
+            if !window.contains(&(i - 1, j - 1)) {
                 continue;
             }
             let cost = (a[i - 1] - b[j - 1]).abs();
@@ -192,20 +172,20 @@ fn fast_dtw_path(a: &[f64], b: &[f64], radius: usize) -> Vec<(usize, usize)> {
 
     let n = a.len();
     let m = b.len();
-    let mut window = vec![vec![false; m]; n];
+    let mut window: HashSet<(usize, usize)> = HashSet::new();
     for &(pi, pj) in &path {
         for di in 0..2 {
             for dj in 0..2 {
                 let oi = pi * 2 + di;
                 let oj = pj * 2 + dj;
                 if oi < n && oj < m {
-                    let r_start_i = if oi >= radius { oi - radius } else { 0 };
+                    let r_start_i = oi.saturating_sub(radius);
                     let r_end_i = (oi + radius).min(n - 1);
-                    let r_start_j = if oj >= radius { oj - radius } else { 0 };
+                    let r_start_j = oj.saturating_sub(radius);
                     let r_end_j = (oj + radius).min(m - 1);
                     for ri in r_start_i..=r_end_i {
                         for rj in r_start_j..=r_end_j {
-                            window[ri][rj] = true;
+                            window.insert((ri, rj));
                         }
                     }
                 }
@@ -233,7 +213,6 @@ fn dtw_full_path(a: &[f64], b: &[f64]) -> Vec<(usize, usize)> {
         }
     }
 
-    // Traceback
     let mut path = Vec::new();
     let mut i = n;
     let mut j = m;
@@ -255,8 +234,8 @@ fn dtw_full_path(a: &[f64], b: &[f64]) -> Vec<(usize, usize)> {
     path
 }
 
-/// Compute DTW path restricted to a boolean window mask.
-fn dtw_path_with_window(a: &[f64], b: &[f64], window: &[Vec<bool>]) -> Vec<(usize, usize)> {
+/// Compute DTW path restricted to a HashSet window mask.
+fn dtw_path_with_window(a: &[f64], b: &[f64], window: &HashSet<(usize, usize)>) -> Vec<(usize, usize)> {
     let n = a.len();
     let m = b.len();
     let mut cost_matrix = vec![vec![f64::MAX; m + 1]; n + 1];
@@ -264,7 +243,7 @@ fn dtw_path_with_window(a: &[f64], b: &[f64], window: &[Vec<bool>]) -> Vec<(usiz
 
     for i in 1..=n {
         for j in 1..=m {
-            if !window[i - 1][j - 1] {
+            if !window.contains(&(i - 1, j - 1)) {
                 continue;
             }
             let cost = (a[i - 1] - b[j - 1]).abs();
@@ -307,20 +286,10 @@ fn compute_dtw(a: &[f64], b: &[f64], method: &str, param: f64) -> f64 {
     }
 }
 
-/// Compute pairwise DTW distances between time series in two DataFrames,
-/// using extensive parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `method` - DTW variant: "standard", "sakoe_chiba", "itakura", or "fast".
-/// * `param` - Method-specific parameter:
-///   - sakoe_chiba: window size (default 10)
-///   - itakura: max slope (default 2.0)
-///   - fast: radius (default 5)
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "dtw".
+// ---------------------------------------------------------------------------
+// Pairwise wrapper
+// ---------------------------------------------------------------------------
+
 #[pyfunction]
 #[pyo3(signature = (input1, input2, method=None, param=None))]
 pub fn compute_pairwise_dtw(
@@ -330,7 +299,6 @@ pub fn compute_pairwise_dtw(
     param: Option<f64>,
 ) -> PyResult<PyDataFrame> {
     let method = method.unwrap_or("standard");
-    // Validate method
     match method {
         "standard" | "sakoe_chiba" | "itakura" | "fast" => {}
         _ => {
@@ -345,83 +313,9 @@ pub fn compute_pairwise_dtw(
         "fast" => 5.0,
         _ => 0.0,
     });
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
 
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate the "y" column.
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    // Build HashMaps mapping unique_id -> time series (Vec<f64>) for each input.
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    // Wrap the maps in an Arc so that they can be shared safely across threads.
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    // Create vectors of references for the keys and series. These are now references into the
-    // data held by the Arc-ed maps.
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    // Compute pairwise DTW distances: id_1 always comes from left, id_2 from right.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            // Clone the Arc pointers for use in the inner closure.
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // If both keys are common (i.e. appear in both maps), enforce an ordering to avoid duplicates.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    // Compute the DTW distance.
-                    let distance = compute_dtw(left_series, right_series, method, param);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-
-    // Build output columns.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let dtw_vals: Vec<f64> = results.iter().map(|(_, _, dtw)| *dtw).collect();
-
-    // Create a new Polars DataFrame.
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("dtw".into(), dtw_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    let method_owned = method.to_string();
+    compute_pairwise(input1, input2, "dtw", move |a, b| {
+        compute_dtw(a, b, &method_owned, param)
+    })
 }

--- a/src/dtw_multi.rs
+++ b/src/dtw_multi.rs
@@ -1,9 +1,7 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use rayon::prelude::*;
-use crate::utils::{get_groups_multivariate, df_to_hashmap_multivariate, cast_column};
+
+use crate::utils::compute_pairwise_multivariate;
 
 /// Distance metric for DTW cost calculations.
 #[derive(Clone, Copy)]
@@ -12,11 +10,7 @@ enum DistanceMetric {
     Euclidean,
 }
 
-/// Computes the DTW distance between two multivariate time series using the specified metric.
-/// Each time series is represented as a slice of points (Vec<f64>).
-/// For each pair of points, the cost is computed as follows:
-/// - Manhattan: sum of absolute differences.
-/// - Euclidean: Euclidean distance.
+/// Multivariate DTW distance using the specified metric. O(m) memory.
 fn dtw_distance_multivariate(a: &[Vec<f64>], b: &[Vec<f64>], metric: DistanceMetric) -> f64 {
     let n = a.len();
     let m = b.len();
@@ -27,19 +21,18 @@ fn dtw_distance_multivariate(a: &[Vec<f64>], b: &[Vec<f64>], metric: DistanceMet
     for i in 1..=n {
         curr[0] = f64::MAX;
         for j in 1..=m {
-            // Compute the cost between points using the selected metric.
             let cost: f64 = match metric {
                 DistanceMetric::Manhattan => {
                     a[i - 1].iter().zip(b[j - 1].iter())
                         .map(|(x, y)| (x - y).abs())
                         .sum()
-                },
+                }
                 DistanceMetric::Euclidean => {
                     let sum_sq: f64 = a[i - 1].iter().zip(b[j - 1].iter())
                         .map(|(x, y)| (x - y).powi(2))
                         .sum();
                     sum_sq.sqrt()
-                },
+                }
             };
             let min_prev = prev[j].min(curr[j - 1]).min(prev[j - 1]);
             curr[j] = cost + min_prev;
@@ -49,102 +42,19 @@ fn dtw_distance_multivariate(a: &[Vec<f64>], b: &[Vec<f64>], metric: DistanceMet
     prev[m]
 }
 
-/// Compute pairwise multivariate DTW distances between time series in two DataFrames,
-/// using extensive parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and one or more dimension columns (e.g. y1, y2, y3, ...).
-/// * `input2` - Second PyDataFrame with columns "unique_id" and one or more dimension columns.
-/// * `metric` - Optional string to choose the distance metric: "manhattan" or "euclidean".
-///              Defaults to "manhattan" if not provided or unrecognized.
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "dtw".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, metric=None))]
-pub fn compute_pairwise_dtw_multi(input1: PyDataFrame, input2: PyDataFrame, metric: Option<String>) -> PyResult<PyDataFrame> {
-    // Determine the distance metric.
+pub fn compute_pairwise_dtw_multi(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    metric: Option<String>,
+) -> PyResult<PyDataFrame> {
     let distance_metric = match metric.as_deref() {
         Some("euclidean") => DistanceMetric::Euclidean,
         _ => DistanceMetric::Manhattan,
     };
 
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    // Cast unique_id columns to string.
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate all dimension columns.
-    let grouped_a = get_groups_multivariate(&df_a).unwrap();
-    let grouped_b = get_groups_multivariate(&df_b).unwrap();
-
-    // Build HashMaps mapping unique_id -> multivariate time series for each input.
-    let raw_map_a = df_to_hashmap_multivariate(&grouped_a);
-    let raw_map_b = df_to_hashmap_multivariate(&grouped_b);
-
-    // Wrap the maps in an Arc so they can be shared safely across threads.
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    // Create vectors of references for keys and series.
-    let left_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_b.iter().collect();
-
-    // Compute pairwise DTW distances: id_1 always comes from left, id_2 from right.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // If both keys are common (i.e. appear in both maps), enforce an ordering to avoid duplicate pairs.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    // Compute the multivariate DTW distance with the selected metric.
-                    let distance = dtw_distance_multivariate(left_series, right_series, distance_metric);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    // Build output columns.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let dtw_vals: Vec<f64> = results.iter().map(|(_, _, dtw)| *dtw).collect();
-
-    // Create a new Polars DataFrame.
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("dtw_multi".into(), dtw_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-
-    // Cast id columns back to the original dtypes.
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise_multivariate(input1, input2, "dtw_multi", move |a, b| {
+        dtw_distance_multivariate(a, b, distance_metric)
+    })
 }

--- a/src/erp.rs
+++ b/src/erp.rs
@@ -1,15 +1,9 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
 
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
-/// ERP (Edit Distance with Real Penalty) distance.
-/// Uses a gap value `g` as the reference point for insertions/deletions.
-/// O(m) memory.
+/// ERP (Edit Distance with Real Penalty) distance. O(m) memory.
 fn erp_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
     let n = a.len();
     let m = b.len();
@@ -17,7 +11,6 @@ fn erp_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
     let mut prev = vec![0.0_f64; m + 1];
     let mut curr = vec![0.0_f64; m + 1];
 
-    // Initialize first row: cost of inserting all of b[0..j]
     for j in 1..=m {
         prev[j] = prev[j - 1] + (b[j - 1] - g).abs();
     }
@@ -26,99 +19,26 @@ fn erp_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
     for i in 1..=n {
         first_col_cost += (a[i - 1] - g).abs();
         curr[0] = first_col_cost;
-
         for j in 1..=m {
             let d_match = prev[j - 1] + (a[i - 1] - b[j - 1]).abs();
             let d_delete = prev[j] + (a[i - 1] - g).abs();
             let d_insert = curr[j - 1] + (b[j - 1] - g).abs();
             curr[j] = d_match.min(d_delete).min(d_insert);
         }
-
         std::mem::swap(&mut prev, &mut curr);
     }
-
     prev[m]
 }
 
-/// Compute pairwise ERP distances between time series in two DataFrames.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `g` - Gap value (default 0.0). Points are compared against this reference when inserted/deleted.
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "erp".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, g=None))]
-pub fn compute_pairwise_erp(input1: PyDataFrame, input2: PyDataFrame, g: Option<f64>) -> PyResult<PyDataFrame> {
+pub fn compute_pairwise_erp(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    g: Option<f64>,
+) -> PyResult<PyDataFrame> {
     let g_value = g.unwrap_or(0.0);
-
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            let g = g_value;
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    if left_key == right_key {
-                        return None;
-                    }
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    let distance = erp_distance(left_series, right_series, g);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let erp_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
-
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("erp".into(), erp_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "erp", move |a, b| {
+        erp_distance(a, b, g_value)
+    })
 }

--- a/src/lcss.rs
+++ b/src/lcss.rs
@@ -1,20 +1,12 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
 
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
-/// LCSS (Longest Common Subsequence) distance.
-/// Two points match if their absolute difference is within `epsilon`.
-/// Returns 1 - (LCSS_length / min(n, m)), so 0 = identical, 1 = no matches.
-/// O(m) memory.
+/// LCSS distance. Returns 1 - (LCSS_length / min(n, m)). O(m) memory.
 fn lcss_distance(a: &[f64], b: &[f64], epsilon: f64) -> f64 {
     let n = a.len();
     let m = b.len();
-
     if n == 0 || m == 0 {
         return 1.0;
     }
@@ -31,9 +23,8 @@ fn lcss_distance(a: &[f64], b: &[f64], epsilon: f64) -> f64 {
             }
         }
         std::mem::swap(&mut prev, &mut curr);
-        // Reset curr for next row
-        for j in 0..=m {
-            curr[j] = 0;
+        for item in curr.iter_mut().take(m + 1) {
+            *item = 0;
         }
     }
 
@@ -42,85 +33,15 @@ fn lcss_distance(a: &[f64], b: &[f64], epsilon: f64) -> f64 {
     1.0 - (lcss_len / min_len)
 }
 
-/// Compute pairwise LCSS distances between time series in two DataFrames.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `epsilon` - Matching threshold (default 1.0). Two points match if |a[i] - b[j]| <= epsilon.
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "lcss".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, epsilon=None))]
-pub fn compute_pairwise_lcss(input1: PyDataFrame, input2: PyDataFrame, epsilon: Option<f64>) -> PyResult<PyDataFrame> {
+pub fn compute_pairwise_lcss(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    epsilon: Option<f64>,
+) -> PyResult<PyDataFrame> {
     let eps = epsilon.unwrap_or(1.0);
-
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            let epsilon = eps;
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    if left_key == right_key {
-                        return None;
-                    }
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    let distance = lcss_distance(left_series, right_series, epsilon);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let lcss_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
-
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("lcss".into(), lcss_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "lcss", move |a, b| {
+        lcss_distance(a, b, eps)
+    })
 }

--- a/src/mann_kendall.rs
+++ b/src/mann_kendall.rs
@@ -59,7 +59,12 @@ pub fn mann_kendall(inputs: &[Series]) -> PolarsResult<Series> {
     let mut s_stat = 0i64;
     for (i, &val) in vals.iter().enumerate().rev() {
         // Binary search to find the 1-based rank
-        let c = unique.binary_search(&OrderedFloat(val)).unwrap() + 1;
+        // Safety: val is guaranteed to be in unique since unique was built from vals.
+        // Use unwrap_or to avoid any theoretical panic (e.g. NaN edge cases).
+        let c = match unique.binary_search(&OrderedFloat(val)) {
+            Ok(idx) => idx + 1,
+            Err(_) => continue,  // skip values not found (should never happen)
+        };
         let less = query(&fen, c - 1);
         let equal = query(&fen, c) - less;
         s_stat += (n as i64 - 1 - i as i64) - 2 * less - equal;

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -1,12 +1,9 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
 
-/// Helper function to calculate the MSM cost
+use crate::utils::compute_pairwise;
+
+/// Helper function to calculate the MSM cost.
 fn msm_cost(x: f64, y: f64, z: f64, c: f64) -> f64 {
     if (y <= x && x <= z) || (y >= x && x >= z) {
         return c;
@@ -14,148 +11,44 @@ fn msm_cost(x: f64, y: f64, z: f64, c: f64) -> f64 {
     c + (x - y).abs().min((x - z).abs())
 }
 
-/// Optimized MSM distance implementation using two rows.
-/// This version uses O(m) memory instead of allocating the full n*m matrix.
+/// Optimized MSM distance using O(m) memory.
 fn msm_distance(a: &[f64], b: &[f64], c: f64) -> f64 {
     let n = a.len();
     let m = b.len();
-
-    // Early return for empty sequences
     if n == 0 || m == 0 {
         return 0.0;
     }
 
     let mut prev = vec![f64::MAX; m];
     let mut curr = vec![f64::MAX; m];
-
-    // Initialize first cell
     prev[0] = (a[0] - b[0]).abs();
 
-    // Initialize first row
     for j in 1..m {
-        let cost = msm_cost(b[j], a[0], b[j-1], c);
-        prev[j] = prev[j-1] + cost;
+        prev[j] = prev[j - 1] + msm_cost(b[j], a[0], b[j - 1], c);
     }
 
-    // Main dynamic programming loop
     for i in 1..n {
-        // Initialize first column of current row
-        let cost = msm_cost(a[i], a[i-1], b[0], c);
-        curr[0] = prev[0] + cost;
-
+        curr[0] = prev[0] + msm_cost(a[i], a[i - 1], b[0], c);
         for j in 1..m {
-            // Calculate the three possible transitions
-            let d1 = prev[j-1] + (a[i] - b[j]).abs();  // Match
-            let d2 = prev[j] + msm_cost(a[i], a[i-1], b[j], c);  // Delete
-            let d3 = curr[j-1] + msm_cost(b[j], a[i], b[j-1], c);  // Insert
-
-            // Take the minimum cost
+            let d1 = prev[j - 1] + (a[i] - b[j]).abs();
+            let d2 = prev[j] + msm_cost(a[i], a[i - 1], b[j], c);
+            let d3 = curr[j - 1] + msm_cost(b[j], a[i], b[j - 1], c);
             curr[j] = d1.min(d2).min(d3);
         }
-
-        // Swap rows for next iteration
         std::mem::swap(&mut prev, &mut curr);
     }
-
-    // Final MSM distance is in the bottom-right corner
-    prev[m-1]
+    prev[m - 1]
 }
 
-/// Compute pairwise MSM distances between time series in two DataFrames,
-/// using extensive parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `c` - Cost parameter for MSM distance (default 1.0).
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "msm".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, c=None))]
-pub fn compute_pairwise_msm(input1: PyDataFrame, input2: PyDataFrame, c: Option<f64>) -> PyResult<PyDataFrame> {
-    // Set default value for c parameter
+pub fn compute_pairwise_msm(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    c: Option<f64>,
+) -> PyResult<PyDataFrame> {
     let c_value = c.unwrap_or(1.0);
-
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate the "y" column.
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    // Build HashMaps mapping unique_id -> time series (Vec<f64>) for each input.
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    // Wrap the maps in an Arc so that they can be shared safely across threads.
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    // Create vectors of references for the keys and series. These are now references into the
-    // data held by the Arc-ed maps.
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    // Compute pairwise MSM distances: id_1 always comes from left, id_2 from right.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            // Clone the Arc pointers for use in the inner closure.
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            // Capture c_value for the inner closure
-            let c = c_value;
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // If both keys are common (i.e. appear in both maps), enforce an ordering to avoid duplicates.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    // Compute the MSM distance.
-                    let distance = msm_distance(left_series, right_series, c);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    // Build output columns.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let msm_vals: Vec<f64> = results.iter().map(|(_, _, msm)| *msm).collect();
-
-    // Create a new Polars DataFrame.
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("msm".into(), msm_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "msm", move |a, b| {
+        msm_distance(a, b, c_value)
+    })
 }

--- a/src/msm_multi.rs
+++ b/src/msm_multi.rs
@@ -1,9 +1,7 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use rayon::prelude::*;
-use crate::utils::{get_groups_multivariate, df_to_hashmap_multivariate, cast_column};
+
+use crate::utils::compute_pairwise_multivariate;
 
 /// Compute Manhattan distance between two vectors.
 fn manhattan_distance(a: &[f64], b: &[f64]) -> f64 {
@@ -11,7 +9,6 @@ fn manhattan_distance(a: &[f64], b: &[f64]) -> f64 {
 }
 
 /// Compute squared Euclidean distance between two vectors.
-/// This function mimics the _univariate_squared_distance in the Python code.
 fn squared_distance(a: &[f64], b: &[f64]) -> f64 {
     a.iter().zip(b).map(|(x, y)| {
         let diff = x - y;
@@ -19,15 +16,7 @@ fn squared_distance(a: &[f64], b: &[f64]) -> f64 {
     }).sum()
 }
 
-/// Compute the dependent cost given three vectors, following the Python logic.
-/// Let x be the current observation, y and z be consecutive observations:
-///
-///   let diameter = squared_distance(y, z)
-///   let mid = (y + z) / 2  (computed element-wise)
-///   let distance_to_mid = squared_distance(mid, x)
-///
-///   if distance_to_mid <= (diameter / 2) { cost = c }
-///   else { cost = c + min(squared_distance(y, x), squared_distance(z, x)) }
+/// Compute the dependent cost given three vectors.
 fn cost_dependent(x: &[f64], y: &[f64], z: &[f64], c: f64) -> f64 {
     let diameter = squared_distance(y, z);
     let mid: Vec<f64> = y.iter().zip(z).map(|(a, b)| (a + b) / 2.0).collect();
@@ -35,152 +24,48 @@ fn cost_dependent(x: &[f64], y: &[f64], z: &[f64], c: f64) -> f64 {
     if distance_to_mid <= (diameter / 2.0) {
         c
     } else {
-        let dist_to_y = squared_distance(y, x);
-        let dist_to_z = squared_distance(z, x);
-        c + dist_to_y.min(dist_to_z)
+        c + squared_distance(y, x).min(squared_distance(z, x))
     }
 }
 
-/// Optimized MSM distance for multivariate time series using two rows of memory.
-/// Each time series is represented as a slice of observations (Vec<Vec<f64>>).
-///
-/// Recurrence:
-///   dp[0,0] = manhattan_distance(a[0], b[0])
-///   dp[i,0] = dp[i-1,0] + cost_dependent(a[i], a[i-1], b[0], c)
-///   dp[0,j] = dp[0,j-1] + cost_dependent(b[j], b[j-1], a[0], c)
-/// and for i,j >= 1:
-///   dp[i,j] = min{
-///      dp[i-1,j-1] + manhattan_distance(a[i], b[j]),      // match
-///      dp[i-1,j]   + cost_dependent(a[i], a[i-1], b[j], c),  // delete
-///      dp[i,j-1]   + cost_dependent(b[j], a[i], b[j-1], c)   // insert
-///   }
+/// Multivariate MSM distance using O(m) memory.
 fn msm_distance(a: &[Vec<f64>], b: &[Vec<f64>], c: f64) -> f64 {
     let n = a.len();
     let m = b.len();
-
     if n == 0 || m == 0 {
         return 0.0;
     }
 
     let mut prev = vec![f64::MAX; m];
     let mut curr = vec![f64::MAX; m];
-
-    // dp[0,0]
     prev[0] = manhattan_distance(&a[0], &b[0]);
 
-    // First row: compare b elements against the first observation of a.
     for j in 1..m {
-        let cost = cost_dependent(&b[j], &b[j - 1], &a[0], c);
-        prev[j] = prev[j - 1] + cost;
+        prev[j] = prev[j - 1] + cost_dependent(&b[j], &b[j - 1], &a[0], c);
     }
 
-    // Main dynamic programming loop.
     for i in 1..n {
-        let cost = cost_dependent(&a[i], &a[i - 1], &b[0], c);
-        curr[0] = prev[0] + cost;
-
+        curr[0] = prev[0] + cost_dependent(&a[i], &a[i - 1], &b[0], c);
         for j in 1..m {
-            let d1 = prev[j - 1] + manhattan_distance(&a[i], &b[j]); // match
-            let d2 = prev[j] + cost_dependent(&a[i], &a[i - 1], &b[j], c); // delete
-            let d3 = curr[j - 1] + cost_dependent(&b[j], &a[i], &b[j - 1], c); // insert
+            let d1 = prev[j - 1] + manhattan_distance(&a[i], &b[j]);
+            let d2 = prev[j] + cost_dependent(&a[i], &a[i - 1], &b[j], c);
+            let d3 = curr[j - 1] + cost_dependent(&b[j], &a[i], &b[j - 1], c);
             curr[j] = d1.min(d2).min(d3);
         }
-
         std::mem::swap(&mut prev, &mut curr);
     }
-
     prev[m - 1]
 }
 
-/// Compute pairwise MSM distances between multivariate time series in two DataFrames,
-/// using parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and multiple y-columns (e.g., y1, y2, y3).
-/// * `input2` - Second PyDataFrame with columns "unique_id" and multiple y-columns.
-/// * `c` - Cost parameter for MSM distance (default 1.0).
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "msm".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, c=None))]
 pub fn compute_pairwise_msm_multi(
     input1: PyDataFrame,
     input2: PyDataFrame,
-    c: Option<f64>
+    c: Option<f64>,
 ) -> PyResult<PyDataFrame> {
     let c_value = c.unwrap_or(1.0);
-
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_1 must have unique_id")
-        .dtype().clone();
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_2 must have unique_id")
-        .dtype().clone();
-
-    // Cast unique_id to String.
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate the y-columns.
-    let grouped_a = get_groups_multivariate(&df_a).unwrap();
-    let grouped_b = get_groups_multivariate(&df_b).unwrap();
-
-    // Convert grouped DataFrames into HashMaps mapping unique_id -> multivariate time series.
-    let raw_map_a = df_to_hashmap_multivariate(&grouped_a);
-    let raw_map_b = df_to_hashmap_multivariate(&grouped_b);
-
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    let left_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_b.iter().collect();
-
-    // Compute pairwise MSM distances.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // Avoid duplicate comparisons.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    let distance = msm_distance(left_series, right_series, c_value);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    // Build output DataFrame.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let msm_vals: Vec<f64> = results.iter().map(|(_, _, msm)| *msm).collect();
-
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("msm_multi".into(), msm_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise_multivariate(input1, input2, "msm_multi", move |a, b| {
+        msm_distance(a, b, c_value)
+    })
 }

--- a/src/twe.rs
+++ b/src/twe.rs
@@ -1,22 +1,12 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
 
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
-/// TWE (Time Warp Edit) distance.
-/// Combines edit distance with a stiffness penalty for time warping.
-/// Parameters:
-/// - `nu`: stiffness parameter (default 0.001). Higher = less warping allowed.
-/// - `lambda`: penalty for delete/insert operations (default 1.0).
-/// O(m) memory.
+/// TWE (Time Warp Edit) distance. O(m) memory.
 fn twe_distance(a: &[f64], b: &[f64], nu: f64, lambda: f64) -> f64 {
     let n = a.len();
     let m = b.len();
-
     if n == 0 || m == 0 {
         return 0.0;
     }
@@ -32,120 +22,37 @@ fn twe_distance(a: &[f64], b: &[f64], nu: f64, lambda: f64) -> f64 {
     for i in 1..=n {
         let a_i = a[i - 1];
         let a_prev = if i > 1 { a[i - 2] } else { 0.0 };
-
         curr[0] = prev[0] + (a_i - a_prev).abs() + nu + lambda;
 
         for j in 1..=m {
             let b_j = b[j - 1];
             let b_prev = if j > 1 { b[j - 2] } else { 0.0 };
 
-            // Match: align a[i] with b[j]
             let d_match = prev[j - 1]
                 + (a_i - b_j).abs()
                 + (a_prev - b_prev).abs()
                 + nu * ((i as f64 - j as f64).abs()).min(2.0 * nu);
-
-            // Delete: a[i] is unmatched
-            let d_delete = prev[j]
-                + (a_i - a_prev).abs()
-                + nu + lambda;
-
-            // Insert: b[j] is unmatched
-            let d_insert = curr[j - 1]
-                + (b_j - b_prev).abs()
-                + nu + lambda;
+            let d_delete = prev[j] + (a_i - a_prev).abs() + nu + lambda;
+            let d_insert = curr[j - 1] + (b_j - b_prev).abs() + nu + lambda;
 
             curr[j] = d_match.min(d_delete).min(d_insert);
         }
-
         std::mem::swap(&mut prev, &mut curr);
     }
-
     prev[m]
 }
 
-/// Compute pairwise TWE distances between time series in two DataFrames.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `nu` - Stiffness parameter (default 0.001). Controls how much time warping is penalized.
-/// * `lambda` - Penalty for delete/insert operations (default 1.0).
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "twe".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, nu=None, lambda=None))]
-pub fn compute_pairwise_twe(input1: PyDataFrame, input2: PyDataFrame, nu: Option<f64>, lambda: Option<f64>) -> PyResult<PyDataFrame> {
+pub fn compute_pairwise_twe(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    nu: Option<f64>,
+    lambda: Option<f64>,
+) -> PyResult<PyDataFrame> {
     let nu_value = nu.unwrap_or(0.001);
     let lambda_value = lambda.unwrap_or(1.0);
-
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            let nu = nu_value;
-            let lambda = lambda_value;
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    if left_key == right_key {
-                        return None;
-                    }
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    let distance = twe_distance(left_series, right_series, nu, lambda);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let twe_vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
-
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("twe".into(), twe_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "twe", move |a, b| {
+        twe_distance(a, b, nu_value, lambda_value)
+    })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,9 @@
 use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3::exceptions::{PyKeyError, PyValueError};
+use pyo3_polars::PyDataFrame;
 use std::collections::HashMap;
+use std::sync::Arc;
 use rayon::prelude::*;
 
 /// Cast a column in-place to the given DataType, returning a new DataFrame.
@@ -8,6 +12,16 @@ pub fn cast_column(df: &DataFrame, col_name: &str, dtype: DataType) -> Result<Da
     let casted = df.column(col_name)?.cast(&dtype)?.take_materialized_series();
     let _ = df.replace(col_name, casted)?;
     Ok(df)
+}
+
+/// Validate that a required column exists in the DataFrame.
+fn validate_column_exists(df: &DataFrame, col_name: &str) -> PyResult<()> {
+    if df.column(col_name).is_err() {
+        return Err(PyKeyError::new_err(format!(
+            "Missing required column '{col_name}' in DataFrame"
+        )));
+    }
+    Ok(())
 }
 
 /// Groups a DataFrame by "unique_id" and aggregates the "y" column into lists.
@@ -21,6 +35,7 @@ pub fn get_groups(df: &DataFrame) -> Result<DataFrame, PolarsError> {
     let df = df.select(["unique_id", "y"])?;
 
     // Group by unique_id and aggregate all columns into lists
+    #[allow(deprecated)]
     let mut result = df.group_by(["unique_id"])?.agg_list()?;
     // agg_list renames columns to "{name}_agg_list", rename back
     result.rename("y_agg_list", "y".into())?;
@@ -28,38 +43,47 @@ pub fn get_groups(df: &DataFrame) -> Result<DataFrame, PolarsError> {
 }
 
 /// Optimized conversion of a grouped DataFrame into a HashMap mapping id -> Vec<f64>.
-pub fn df_to_hashmap(df: &DataFrame) -> HashMap<String, Vec<f64>> {
-    let unique_id_col = df.column("unique_id").expect("expected column unique_id");
-    let y_col = df.column("y").expect("expected column y");
+pub fn df_to_hashmap(df: &DataFrame) -> PyResult<HashMap<String, Vec<f64>>> {
+    let unique_id_col = df.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(format!("Missing column 'unique_id': {e}")))?;
+    let y_col = df.column("y")
+        .map_err(|e| PyKeyError::new_err(format!("Missing column 'y': {e}")))?;
 
     let unique_ids: Vec<String> = unique_id_col
         .str()
-        .expect("expected utf8 column for unique_id")
+        .map_err(|e| PyValueError::new_err(format!("Column 'unique_id' must be string type: {e}")))?
         .into_no_null_iter()
         .map(|s| s.to_string())
         .collect();
 
     let y_lists: Vec<Vec<f64>> = y_col
         .list()
-        .expect("expected a List type for y")
+        .map_err(|e| PyValueError::new_err(format!("Column 'y' must be list type: {e}")))?
         .into_iter()
         .map(|opt_series| {
-            let series = opt_series.expect("null entry in 'y' list column");
-            series
-                .f64()
-                .expect("expected a f64 Series inside the list")
-                .into_no_null_iter()
-                .collect::<Vec<f64>>()
+            let series = opt_series.ok_or_else(|| {
+                PyValueError::new_err("Null entry found in 'y' list column. Ensure no null values in 'y'.")
+            })?;
+            let chunked = series.f64().map_err(|e| {
+                PyValueError::new_err(format!("Values in 'y' column must be f64: {e}"))
+            })?;
+            Ok(chunked.into_no_null_iter().collect::<Vec<f64>>())
         })
-        .collect();
+        .collect::<PyResult<Vec<Vec<f64>>>>()?;
 
-    assert_eq!(unique_ids.len(), y_lists.len(), "Mismatched lengths in unique_ids and y_lists");
+    if unique_ids.len() != y_lists.len() {
+        return Err(PyValueError::new_err(format!(
+            "Mismatched lengths: {} unique_ids vs {} y_lists",
+            unique_ids.len(),
+            y_lists.len()
+        )));
+    }
 
-    let hashmap: HashMap<String, Vec<f64>> = (0..unique_ids.len())
-        .into_par_iter()
-        .map(|i| (unique_ids[i].clone(), y_lists[i].clone()))
+    let hashmap: HashMap<String, Vec<f64>> = unique_ids
+        .into_iter()
+        .zip(y_lists)
         .collect();
-    hashmap
+    Ok(hashmap)
 }
 
 /// Groups a DataFrame by "unique_id" and aggregates all dimension columns into lists.
@@ -77,6 +101,7 @@ pub fn get_groups_multivariate(df: &DataFrame) -> Result<DataFrame, PolarsError>
     }
 
     // Group by unique_id and aggregate all columns into lists
+    #[allow(deprecated)]
     let mut result = df.group_by(["unique_id"])?.agg_list()?;
     // agg_list renames columns to "{name}_agg_list", rename back
     for dim in &dims {
@@ -87,11 +112,12 @@ pub fn get_groups_multivariate(df: &DataFrame) -> Result<DataFrame, PolarsError>
 }
 
 /// Converts a grouped DataFrame into a HashMap mapping unique_id -> multivariate time series.
-pub fn df_to_hashmap_multivariate(df: &DataFrame) -> HashMap<String, Vec<Vec<f64>>> {
-    let unique_id_col = df.column("unique_id").expect("expected column unique_id");
+pub fn df_to_hashmap_multivariate(df: &DataFrame) -> PyResult<HashMap<String, Vec<Vec<f64>>>> {
+    let unique_id_col = df.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(format!("Missing column 'unique_id': {e}")))?;
     let unique_ids: Vec<String> = unique_id_col
         .str()
-        .expect("expected Utf8 for unique_id")
+        .map_err(|e| PyValueError::new_err(format!("Column 'unique_id' must be string type: {e}")))?
         .into_no_null_iter()
         .map(|s| s.to_string())
         .collect();
@@ -104,19 +130,22 @@ pub fn df_to_hashmap_multivariate(df: &DataFrame) -> HashMap<String, Vec<Vec<f64
 
     let mut dims_data: Vec<Vec<Vec<f64>>> = Vec::with_capacity(dims.len());
     for d in dims.iter() {
-        let col_series = df.column(d).expect("expected dimension column");
+        let col_series = df.column(d)
+            .map_err(|e| PyKeyError::new_err(format!("Missing dimension column '{d}': {e}")))?;
         let lists: Vec<Vec<f64>> = col_series
             .list()
-            .expect("expected list type in dimension column")
+            .map_err(|e| PyValueError::new_err(format!("Column '{d}' must be list type: {e}")))?
             .into_iter()
             .map(|opt_series| {
-                let series = opt_series.expect("null entry in dimension list");
-                series.f64()
-                    .expect("expected f64 Series inside the list")
-                    .into_no_null_iter()
-                    .collect::<Vec<f64>>()
+                let series = opt_series.ok_or_else(|| {
+                    PyValueError::new_err(format!("Null entry in dimension column '{d}'"))
+                })?;
+                let chunked = series.f64().map_err(|e| {
+                    PyValueError::new_err(format!("Values in column '{d}' must be f64: {e}"))
+                })?;
+                Ok(chunked.into_no_null_iter().collect::<Vec<f64>>())
             })
-            .collect();
+            .collect::<PyResult<Vec<Vec<f64>>>>()?;
         dims_data.push(lists);
     }
 
@@ -126,13 +155,187 @@ pub fn df_to_hashmap_multivariate(df: &DataFrame) -> HashMap<String, Vec<Vec<f64
         let series_len = dims_data[0][i].len();
         let mut series: Vec<Vec<f64>> = Vec::with_capacity(series_len);
         for t in 0..series_len {
-            let mut point: Vec<f64> = Vec::with_capacity(dims.len());
-            for d in 0..dims.len() {
-                point.push(dims_data[d][i][t]);
-            }
+            let point: Vec<f64> = dims_data.iter().map(|dim| dim[i][t]).collect();
             series.push(point);
         }
         hashmap.insert(unique_ids[i].clone(), series);
     }
-    hashmap
+    Ok(hashmap)
+}
+
+/// Generic pairwise computation for univariate distance functions.
+///
+/// Handles: column validation, casting, grouping, HashMap construction,
+/// Arc wrapping, parallel pairwise iteration with deduplication, output assembly.
+pub fn compute_pairwise<F>(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    distance_col: &str,
+    distance_fn: F,
+) -> PyResult<PyDataFrame>
+where
+    F: Fn(&[f64], &[f64]) -> f64 + Send + Sync,
+{
+    let df_1: DataFrame = input1.into();
+    let df_2: DataFrame = input2.into();
+
+    validate_column_exists(&df_1, "unique_id")?;
+    validate_column_exists(&df_1, "y")?;
+    validate_column_exists(&df_2, "unique_id")?;
+    validate_column_exists(&df_2, "y")?;
+
+    let uid_a_dtype = df_1.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(e.to_string()))?
+        .dtype().clone();
+    let uid_b_dtype = df_2.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(e.to_string()))?
+        .dtype().clone();
+
+    let df_a = cast_column(&df_1, "unique_id", DataType::String)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let df_b = cast_column(&df_2, "unique_id", DataType::String)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let grouped_a = get_groups(&df_a)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let grouped_b = get_groups(&df_b)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let raw_map_a = df_to_hashmap(&grouped_a)?;
+    let raw_map_b = df_to_hashmap(&grouped_b)?;
+
+    let map_a = Arc::new(raw_map_a);
+    let map_b = Arc::new(raw_map_b);
+
+    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
+    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
+
+    let distance_fn = Arc::new(distance_fn);
+    let results: Vec<(String, String, f64)> = left_series_by_key
+        .par_iter()
+        .flat_map(|&(left_key, left_series)| {
+            let map_a = Arc::clone(&map_a);
+            let map_b = Arc::clone(&map_b);
+            let distance_fn = Arc::clone(&distance_fn);
+            right_series_by_key
+                .par_iter()
+                .filter_map(move |&(right_key, right_series)| {
+                    if left_key == right_key {
+                        return None;
+                    }
+                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) && left_key >= right_key {
+                        return None;
+                    }
+                    let distance = distance_fn(left_series, right_series);
+                    Some((left_key.clone(), right_key.clone(), distance))
+                })
+        })
+        .collect();
+
+    build_output_df(&results, distance_col, &uid_a_dtype, &uid_b_dtype)
+}
+
+/// Generic pairwise computation for multivariate distance functions.
+pub fn compute_pairwise_multivariate<F>(
+    input1: PyDataFrame,
+    input2: PyDataFrame,
+    distance_col: &str,
+    distance_fn: F,
+) -> PyResult<PyDataFrame>
+where
+    F: Fn(&[Vec<f64>], &[Vec<f64>]) -> f64 + Send + Sync,
+{
+    let df_1: DataFrame = input1.into();
+    let df_2: DataFrame = input2.into();
+
+    validate_column_exists(&df_1, "unique_id")?;
+    validate_column_exists(&df_2, "unique_id")?;
+
+    let uid_a_dtype = df_1.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(e.to_string()))?
+        .dtype().clone();
+    let uid_b_dtype = df_2.column("unique_id")
+        .map_err(|e| PyKeyError::new_err(e.to_string()))?
+        .dtype().clone();
+
+    let df_a = cast_column(&df_1, "unique_id", DataType::String)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let df_b = cast_column(&df_2, "unique_id", DataType::String)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let grouped_a = get_groups_multivariate(&df_a)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let grouped_b = get_groups_multivariate(&df_b)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let raw_map_a = df_to_hashmap_multivariate(&grouped_a)?;
+    let raw_map_b = df_to_hashmap_multivariate(&grouped_b)?;
+
+    let map_a = Arc::new(raw_map_a);
+    let map_b = Arc::new(raw_map_b);
+
+    let left_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_a.iter().collect();
+    let right_series_by_key: Vec<(&String, &Vec<Vec<f64>>)> = map_b.iter().collect();
+
+    let distance_fn = Arc::new(distance_fn);
+    let results: Vec<(String, String, f64)> = left_series_by_key
+        .par_iter()
+        .flat_map(|&(left_key, left_series)| {
+            let map_a = Arc::clone(&map_a);
+            let map_b = Arc::clone(&map_b);
+            let distance_fn = Arc::clone(&distance_fn);
+            right_series_by_key
+                .par_iter()
+                .filter_map(move |&(right_key, right_series)| {
+                    if left_key == right_key {
+                        return None;
+                    }
+                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) && left_key >= right_key {
+                        return None;
+                    }
+                    let distance = distance_fn(left_series, right_series);
+                    Some((left_key.clone(), right_key.clone(), distance))
+                })
+        })
+        .collect();
+
+    build_output_df(&results, distance_col, &uid_a_dtype, &uid_b_dtype)
+}
+
+/// Build the output DataFrame from pairwise results, casting IDs back to original dtypes.
+fn build_output_df(
+    results: &[(String, String, f64)],
+    distance_col: &str,
+    uid_a_dtype: &DataType,
+    uid_b_dtype: &DataType,
+) -> PyResult<PyDataFrame> {
+    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
+    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
+    let vals: Vec<f64> = results.iter().map(|(_, _, v)| *v).collect();
+
+    let columns = vec![
+        Column::new("id_1".into(), id1s),
+        Column::new("id_2".into(), id2s),
+        Column::new(distance_col.into(), vals),
+    ];
+    let mut out_df = DataFrame::new(columns)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let id1_casted = out_df.column("id_1")
+        .map_err(|e| PyValueError::new_err(e.to_string()))?
+        .cast(uid_a_dtype)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?
+        .take_materialized_series();
+    let _ = out_df.replace("id_1", id1_casted)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let id2_casted = out_df.column("id_2")
+        .map_err(|e| PyValueError::new_err(e.to_string()))?
+        .cast(uid_b_dtype)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?
+        .take_materialized_series();
+    let _ = out_df.replace("id_2", id2_casted)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    Ok(PyDataFrame(out_df))
 }

--- a/src/wdtw.rs
+++ b/src/wdtw.rs
@@ -1,17 +1,9 @@
-use polars::prelude::*;
-use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use pyo3::PyResult;
-use rayon::prelude::*;
 
-
-use crate::utils::{get_groups, df_to_hashmap, cast_column};
+use crate::utils::compute_pairwise;
 
 /// Precompute weight vector for WDTW calculation.
-/// The weight vector is calculated as:
-/// w[i] = 1 / (1 + exp(-g * (i - len/2)))
-/// where g controls the penalty for points with larger phase difference.
 fn compute_weight_vector(len: usize, g: f64) -> Vec<f64> {
     let half_len = len as f64 / 2.0;
     (0..len)
@@ -19,208 +11,43 @@ fn compute_weight_vector(len: usize, g: f64) -> Vec<f64> {
         .collect()
 }
 
-/// Optimized WDTW distance implementation.
-/// This version uses the full matrix but with a bounding matrix to constrain the search space.
-/// The implementation follows the weighted cost matrix approach from the Python code.
-///
-/// # Arguments
-/// * `a` - First time series as a slice of f64.
-/// * `b` - Second time series as a slice of f64.
-/// * `g` - Parameter that controls the weight penalty (default 0.05).
-///
-/// # Returns
-/// The WDTW distance between the two time series.
-fn wdtw_distance(a: &[f64], b: &[f64], g: f64) -> f64 {
-    let n = a.len();
-    let m = b.len();
-
-    // Handle edge cases
-    if n == 0 || m == 0 {
-        return f64::INFINITY;
-    }
-
-    // Precompute weight vector based on the maximum length
-    let max_len = n.max(m);
-    let weight_vector = compute_weight_vector(max_len, g);
-
-    // Create cost matrix with infinity padding
-    let mut cost_matrix = vec![vec![f64::INFINITY; m + 1]; n + 1];
-    cost_matrix[0][0] = 0.0;
-
-    // Fill the cost matrix
-    for i in 1..=n {
-        for j in 1..=m {
-            // Weight based on absolute difference between indices
-            let weight = weight_vector[((i-1) as isize - (j-1) as isize).abs() as usize];
-
-            // Squared difference (equivalent to sum in univariate case)
-            let diff = (a[i-1] - b[j-1]).abs();
-
-            // Find the minimum previous cost
-            let prev_min = cost_matrix[i-1][j-1]
-                .min(cost_matrix[i-1][j])
-                .min(cost_matrix[i][j-1]);
-
-            // Calculate the weighted cost
-            cost_matrix[i][j] = prev_min + weight * diff;
-        }
-    }
-
-    // Return the final distance
-    cost_matrix[n][m]
-}
-
-/// Memory-optimized WDTW distance implementation.
-/// This version uses O(m) memory by keeping only the current and previous rows.
-///
-/// # Arguments
-/// * `a` - First time series as a slice of f64.
-/// * `b` - Second time series as a slice of f64.
-/// * `g` - Parameter that controls the weight penalty (default 0.05).
-///
-/// # Returns
-/// The WDTW distance between the two time series.
+/// Memory-optimized WDTW distance using O(m) memory.
 fn wdtw_distance_optimized(a: &[f64], b: &[f64], g: f64) -> f64 {
     let n = a.len();
     let m = b.len();
-
-    // Handle edge cases
     if n == 0 || m == 0 {
         return f64::INFINITY;
     }
 
-    // Precompute weight vector based on the maximum length
     let max_len = n.max(m);
     let weight_vector = compute_weight_vector(max_len, g);
 
-    // Create two rows for the cost matrix calculation
     let mut prev = vec![f64::INFINITY; m + 1];
     let mut curr = vec![f64::INFINITY; m + 1];
     prev[0] = 0.0;
 
-    // Fill the cost matrix row by row
     for i in 1..=n {
         curr[0] = f64::INFINITY;
         for j in 1..=m {
-            // Weight based on absolute difference between indices
-            let weight = weight_vector[((i-1) as isize - (j-1) as isize).abs() as usize];
-
-            // Squared difference
-            let diff = (a[i-1] - b[j-1]).powi(2);
-
-            // Find the minimum previous cost
-            let prev_min = prev[j-1].min(prev[j]).min(curr[j-1]);
-
-            // Calculate the weighted cost
+            let weight = weight_vector[((i - 1) as isize - (j - 1) as isize).unsigned_abs()];
+            let diff = (a[i - 1] - b[j - 1]).powi(2);
+            let prev_min = prev[j - 1].min(prev[j]).min(curr[j - 1]);
             curr[j] = prev_min + weight * diff;
         }
-
-        // Swap rows for the next iteration
         std::mem::swap(&mut prev, &mut curr);
     }
-
-    // Return the final distance
     prev[m]
 }
 
-/// Compute pairwise WDTW distances between time series in two DataFrames,
-/// using extensive parallelism.
-///
-/// # Arguments
-/// * `input1` - First PyDataFrame with columns "unique_id" and "y".
-/// * `input2` - Second PyDataFrame with columns "unique_id" and "y".
-/// * `g` - Parameter that controls the weight penalty (default 0.05).
-///
-/// # Returns
-/// A PyDataFrame with columns "id_1", "id_2", and "wdtw".
 #[pyfunction]
 #[pyo3(signature = (input1, input2, g=None))]
 pub fn compute_pairwise_wdtw(
     input1: PyDataFrame,
     input2: PyDataFrame,
-    g: Option<f64>
+    g: Option<f64>,
 ) -> PyResult<PyDataFrame> {
-    // Set default value for g parameter
     let g_value = g.unwrap_or(0.05);
-
-    // Convert PyDataFrames to Polars DataFrames.
-    let df_1: DataFrame = input1.into();
-    let df_2: DataFrame = input2.into();
-
-    let uid_a_dtype = df_1.column("unique_id")
-        .expect("df_a must have unique_id")
-        .dtype().clone();
-
-    let uid_b_dtype = df_2.column("unique_id")
-        .expect("df_b must have unique_id")
-        .dtype().clone();
-
-    let df_a = cast_column(&df_1, "unique_id", DataType::String).unwrap();
-
-    let df_b = cast_column(&df_2, "unique_id", DataType::String).unwrap();
-
-    // Group each DataFrame by "unique_id" and aggregate the "y" column.
-    let grouped_a = get_groups(&df_a).unwrap();
-    let grouped_b = get_groups(&df_b).unwrap();
-
-    // Build HashMaps mapping unique_id -> time series (Vec<f64>) for each input.
-    let raw_map_a = df_to_hashmap(&grouped_a);
-    let raw_map_b = df_to_hashmap(&grouped_b);
-
-    // Wrap the maps in an Arc so that they can be shared safely across threads.
-    let map_a = Arc::new(raw_map_a);
-    let map_b = Arc::new(raw_map_b);
-
-    // Create vectors of references for the keys and series.
-    let left_series_by_key: Vec<(&String, &Vec<f64>)> = map_a.iter().collect();
-    let right_series_by_key: Vec<(&String, &Vec<f64>)> = map_b.iter().collect();
-
-    // Compute pairwise WDTW distances: id_1 always comes from left, id_2 from right.
-    let results: Vec<(String, String, f64)> = left_series_by_key
-        .par_iter()
-        .flat_map(|&(left_key, left_series)| {
-            // Clone the Arc pointers for use in the inner closure.
-            let map_a = Arc::clone(&map_a);
-            let map_b = Arc::clone(&map_b);
-            // Capture g_value for the inner closure
-            let g = g_value;
-
-            right_series_by_key
-                .par_iter()
-                .filter_map(move |&(right_key, right_series)| {
-                    // Skip self-comparisons.
-                    if left_key == right_key {
-                        return None;
-                    }
-                    // If both keys are common (i.e. appear in both maps), enforce an ordering to avoid duplicates.
-                    if map_b.contains_key(left_key) && map_a.contains_key(right_key) {
-                        if left_key >= right_key {
-                            return None;
-                        }
-                    }
-                    // Compute the WDTW distance.
-                    let distance = wdtw_distance_optimized(left_series, right_series, g);
-                    Some((left_key.clone(), right_key.clone(), distance))
-                })
-        })
-        .collect();
-
-    // Build output columns.
-    let id1s: Vec<String> = results.iter().map(|(id1, _, _)| id1.clone()).collect();
-    let id2s: Vec<String> = results.iter().map(|(_, id2, _)| id2.clone()).collect();
-    let wdtw_vals: Vec<f64> = results.iter().map(|(_, _, wdtw)| *wdtw).collect();
-
-    // Create a new Polars DataFrame.
-    let columns = vec![
-        Column::new("id_1".into(), id1s),
-        Column::new("id_2".into(), id2s),
-        Column::new("wdtw".into(), wdtw_vals),
-    ];
-    let out_df = DataFrame::new(columns).unwrap();
-    let mut casted_out_df = out_df;
-    let id1_casted = casted_out_df.column("id_1").unwrap().cast(&uid_a_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_1", id1_casted).unwrap();
-    let id2_casted = casted_out_df.column("id_2").unwrap().cast(&uid_b_dtype).unwrap().take_materialized_series();
-    let _ = casted_out_df.replace("id_2", id2_casted).unwrap();
-    Ok(PyDataFrame(casted_out_df))
+    compute_pairwise(input1, input2, "wdtw", move |a, b| {
+        wdtw_distance_optimized(a, b, g_value)
+    })
 }

--- a/tests/decomposition/test_fourier_decomposition.py
+++ b/tests/decomposition/test_fourier_decomposition.py
@@ -5,6 +5,14 @@ import pytest
 
 from polars_ts.decomposition.fourier_decomposition import fourier_decomposition  # Update this with the correct import
 
+pds_available = True
+try:
+    import polars_ds  # noqa: F401
+except ImportError:
+    pds_available = False
+
+pytestmark = pytest.mark.skipif(not pds_available, reason="polars-ds not installed")
+
 
 @pytest.fixture
 def sample_df():

--- a/tests/decomposition/test_seasonal_decomposition.py
+++ b/tests/decomposition/test_seasonal_decomposition.py
@@ -36,7 +36,7 @@ def test_invalid_method():
 # Test: Missing column
 def test_missing_column():
     df = create_sample_df().drop("y")  # Drop the target_col
-    with pytest.raises(AssertionError, match="Columns {'y'} are missing from the DataFrame."):
+    with pytest.raises(KeyError, match="Columns {'y'} are missing from the DataFrame."):
         seasonal_decomposition(df, freq=3)
 
 
@@ -50,7 +50,7 @@ def test_invalid_frequency():
 # Test: Ensure exception is raised for missing columns
 def test_missing_time_column():
     df = create_sample_df().drop("ds")  # Drop the time column
-    with pytest.raises(AssertionError, match="Columns {'ds'} are missing from the DataFrame."):
+    with pytest.raises(KeyError, match="Columns {'ds'} are missing from the DataFrame."):
         seasonal_decomposition(df, freq=3)
 
 

--- a/tests/decomposition/test_seasonal_decomposition_features.py
+++ b/tests/decomposition/test_seasonal_decomposition_features.py
@@ -61,7 +61,7 @@ def test_seasonal_decompose_missing_column(sample_dataframe):
     # Remove 'target_col' to simulate missing column
     df_missing_col = sample_dataframe.drop("target_col")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyError):
         seasonal_decompose_features(
             df=df_missing_col, id_col="id_col", time_col="time_col", target_col="target_col", ts_freq=24, mode="simple"
         )
@@ -70,7 +70,7 @@ def test_seasonal_decompose_missing_column(sample_dataframe):
 # Test for invalid mode value
 def test_seasonal_decompose_invalid_mode(sample_dataframe):
     # Call with an invalid mode
-    with pytest.raises(AssertionError, match='Must Pick a mode "mstl" or "simple" to specify type of decomposition...'):
+    with pytest.raises(ValueError, match='Must Pick a mode "mstl" or "simple" to specify type of decomposition...'):
         seasonal_decompose_features(
             df=sample_dataframe,
             id_col="id_col",
@@ -84,7 +84,7 @@ def test_seasonal_decompose_invalid_mode(sample_dataframe):
 # Test for seasonal_freqs of the wrong type (not a list)
 def test_seasonal_decompose_invalid_seasonal_freq_type(sample_dataframe):
     # Call with a non-list seasonal_freqs
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         seasonal_decompose_features(
             df=sample_dataframe,
             id_col="id_col",
@@ -99,7 +99,7 @@ def test_seasonal_decompose_invalid_seasonal_freq_type(sample_dataframe):
 # # Test for seasonal_freqs with empty list
 def test_seasonal_decompose_empty_seasonal_freqs(sample_dataframe):
     # Call with an empty list of seasonal frequencies
-    with pytest.raises(AssertionError):
+    with pytest.raises((ImportError, ValueError)):
         seasonal_decompose_features(
             df=sample_dataframe,
             id_col="id_col",

--- a/tests/distance/test_edge_cases.py
+++ b/tests/distance/test_edge_cases.py
@@ -1,0 +1,142 @@
+"""Shared edge cases for all distance metrics."""
+
+import polars as pl
+import pytest
+from polars_ts_rs.polars_ts_rs import (
+    compute_pairwise_ddtw,
+    compute_pairwise_dtw,
+    compute_pairwise_erp,
+    compute_pairwise_lcss,
+    compute_pairwise_msm,
+    compute_pairwise_twe,
+    compute_pairwise_wdtw,
+)
+
+from tests.distance.conftest import _to_dict
+
+UNIVARIATE_METRICS = [
+    ("dtw", compute_pairwise_dtw, {}),
+    ("ddtw", compute_pairwise_ddtw, {}),
+    ("wdtw", compute_pairwise_wdtw, {}),
+    ("msm", compute_pairwise_msm, {}),
+    ("erp", compute_pairwise_erp, {}),
+    ("lcss", compute_pairwise_lcss, {}),
+    ("twe", compute_pairwise_twe, {}),
+]
+
+
+class TestVeryShortSeries:
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_length_one(self, _name, fn, kwargs):
+        """Series of length 1 should not panic."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A", "B"],
+                "y": [1.0, 2.0],
+            }
+        )
+        result = fn(df, df, **kwargs)
+        assert result.shape[0] == 1
+
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_length_two(self, _name, fn, kwargs):
+        """Series of length 2 should work for all metrics."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 2 + ["B"] * 2,
+                "y": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+        result = fn(df, df, **kwargs)
+        assert result.shape[0] == 1
+
+
+class TestAllIdenticalValues:
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_constant_series_identical(self, _name, fn, kwargs):
+        """Two constant series with the same value should have distance 0 (or close)."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 5 + ["B"] * 5,
+                "y": [3.0] * 5 + [3.0] * 5,
+            }
+        )
+        result = fn(df, df, **kwargs)
+        d = _to_dict(result)
+        assert d[("A", "B")] == pytest.approx(0.0, abs=1e-10)
+
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_constant_series_different(self, _name, fn, kwargs):
+        """Two constant series with different values should have positive distance."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 5 + ["B"] * 5,
+                "y": [1.0] * 5 + [5.0] * 5,
+            }
+        )
+        result = fn(df, df, **kwargs)
+        d = _to_dict(result)
+        # DDTW on constant series: derivative is all zeros, so distance = 0
+        if _name == "ddtw":
+            assert d[("A", "B")] == pytest.approx(0.0, abs=1e-10)
+        else:
+            assert d[("A", "B")] > 0
+
+
+class TestExtremeValues:
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_large_values(self, _name, fn, kwargs):
+        """Very large values should not cause overflow or panic."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4,
+                "y": [1e10, 2e10, 3e10, 4e10, 4e10, 3e10, 2e10, 1e10],
+            }
+        )
+        result = fn(df, df, **kwargs)
+        assert result.shape[0] == 1
+
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_small_values(self, _name, fn, kwargs):
+        """Very small values should work correctly."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4,
+                "y": [1e-10, 2e-10, 3e-10, 4e-10, 4e-10, 3e-10, 2e-10, 1e-10],
+            }
+        )
+        result = fn(df, df, **kwargs)
+        assert result.shape[0] == 1
+
+
+class TestUnequalLengthSeries:
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_different_lengths(self, _name, fn, kwargs):
+        """Series of different lengths should work."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 7,
+                "y": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            }
+        )
+        result = fn(df, df, **kwargs)
+        assert result.shape[0] == 1
+
+
+class TestManySeries:
+    @pytest.mark.parametrize("_name,fn,kwargs", UNIVARIATE_METRICS)
+    def test_100_series_parallelism(self, _name, fn, kwargs):
+        """100+ series to exercise parallel execution."""
+        n_series = 100
+        series_len = 10
+        ids = []
+        values = []
+        for i in range(n_series):
+            ids.extend([f"S{i}"] * series_len)
+            values.extend([float(j + i * 0.1) for j in range(series_len)])
+
+        df = pl.DataFrame({"unique_id": ids, "y": values})
+        result = fn(df, df, **kwargs)
+        # n*(n-1)/2 pairs
+        expected_pairs = n_series * (n_series - 1) // 2
+        assert result.shape[0] == expected_pairs

--- a/tests/distance/test_input_validation.py
+++ b/tests/distance/test_input_validation.py
@@ -1,0 +1,48 @@
+"""Input validation tests — ensure proper Python exceptions, not panics."""
+
+import polars as pl
+import pytest
+from polars_ts_rs.polars_ts_rs import (
+    compute_pairwise_ddtw,
+    compute_pairwise_dtw,
+    compute_pairwise_erp,
+    compute_pairwise_lcss,
+    compute_pairwise_msm,
+    compute_pairwise_twe,
+    compute_pairwise_wdtw,
+)
+
+UNIVARIATE_FUNCTIONS = [
+    compute_pairwise_dtw,
+    compute_pairwise_ddtw,
+    compute_pairwise_wdtw,
+    compute_pairwise_msm,
+    compute_pairwise_erp,
+    compute_pairwise_lcss,
+    compute_pairwise_twe,
+]
+
+
+class TestMissingColumns:
+    @pytest.mark.parametrize("fn", UNIVARIATE_FUNCTIONS)
+    def test_missing_unique_id_column(self, fn):
+        """Missing 'unique_id' column should raise KeyError."""
+        df = pl.DataFrame({"id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(KeyError):
+            fn(df, df)
+
+    @pytest.mark.parametrize("fn", UNIVARIATE_FUNCTIONS)
+    def test_missing_y_column(self, fn):
+        """Missing 'y' column should raise KeyError."""
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "value": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(KeyError):
+            fn(df, df)
+
+
+class TestEmptyDataFrame:
+    @pytest.mark.parametrize("fn", UNIVARIATE_FUNCTIONS)
+    def test_empty_dataframe(self, fn):
+        """Empty DataFrame should produce empty result, not panic."""
+        df = pl.DataFrame({"unique_id": pl.Series([], dtype=pl.String), "y": pl.Series([], dtype=pl.Float64)})
+        result = fn(df, df)
+        assert result.shape[0] == 0

--- a/tests/metrics/test_kaboudan.py
+++ b/tests/metrics/test_kaboudan.py
@@ -4,7 +4,17 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 
-from polars_ts.metrics.kaboudan import Kaboudan
+forecast_available = True
+try:
+    import statsforecast  # noqa: F401
+    import utilsforecast  # noqa: F401
+
+    from polars_ts.metrics.kaboudan import Kaboudan
+except ImportError:
+    forecast_available = False
+    Kaboudan = None
+
+pytestmark = pytest.mark.skipif(not forecast_available, reason="statsforecast/utilsforecast not installed")
 
 
 # Sample data for testing

--- a/uv.lock
+++ b/uv.lock
@@ -1607,9 +1607,20 @@ version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },
+]
+
+[package.optional-dependencies]
+all = [
     { name = "polars-ds" },
     { name = "statsforecast" },
-    { name = "statsmodels" },
+    { name = "utilsforecast" },
+]
+decomposition = [
+    { name = "polars-ds" },
+]
+forecast = [
+    { name = "statsforecast" },
+    { name = "utilsforecast" },
 ]
 
 [package.dev-dependencies]
@@ -1635,10 +1646,12 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "polars", specifier = ">=1.30.0,<2.0.0" },
-    { name = "polars-ds", specifier = ">=0.10.0" },
-    { name = "statsforecast", specifier = ">=2.0.0" },
-    { name = "statsmodels", specifier = ">=0.14.5" },
+    { name = "polars-ds", marker = "extra == 'decomposition'", specifier = ">=0.10.0" },
+    { name = "polars-timeseries", extras = ["forecast", "decomposition"], marker = "extra == 'all'" },
+    { name = "statsforecast", marker = "extra == 'forecast'", specifier = ">=2.0.0" },
+    { name = "utilsforecast", marker = "extra == 'forecast'", specifier = ">=0.2.0" },
 ]
+provides-extras = ["forecast", "decomposition", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- **Lightweight core**: Move statsforecast, polars-ds, utilsforecast to optional extras (`forecast`, `decomposition`, `all`); remove statsmodels entirely. Lazy-import heavy modules via `__getattr__` so `import polars_ts` works with only polars installed.
- **Rust safety**: Replace all `.unwrap()`/`.expect()` (13 total) with `?` operator returning `PyKeyError`/`PyValueError`. Add `validate_column_exists()` helper. Replace Python `assert`-based validation with `if/raise`.
- **Rust deduplication**: Extract generic `compute_pairwise()` and `compute_pairwise_multivariate()` into `utils.rs`, reducing each distance module to kernel + thin wrapper (~50 lines each). Eliminates ~400 lines of duplicated boilerplate.
- **New distance metrics**: ERP, LCSS, TWE, FastDTW, Sakoe-Chiba band, Itakura parallelogram DTW methods.
- **FastDTW memory optimization**: Replace `vec![vec![false; m]; n]` O(n*m) window with `HashSet<(usize,usize)>` for O(path_len × radius²) memory.
- **Documentation**: Distance metrics comparison guide, clustering integration guide, Rust docstring integration into MkDocs.
- **Tests**: 77+ edge case tests (length-1/2 series, constant/extreme values, unequal lengths, 100+ series parallelism), input validation tests, updated exception types.
- **CI**: Add `cargo clippy -- -D warnings` job, `test-minimal-deps` job (polars-only), restructured workflows.

## Test plan

- [ ] `uv run pytest` passes with all deps installed
- [ ] `test-minimal-deps` CI job passes (polars-only, distance + mann_kendall tests)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `import polars_ts` works without optional deps
- [ ] Accessing `polars_ts.Metrics` without statsforecast raises clear `ImportError`