### PR TITLE
docs: rewrite README and update CHANGELOG for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,41 @@
-## v0.3.2 (Unreleased)
+## v0.4.0 (Unreleased)
 
 ### Features
 
+- Add Sen's slope estimator (`sens_slope`) — robust median-of-pairwise-slopes trend magnitude.
+- Add CUSUM changepoint detection (`cusum`) — cumulative sum control chart for mean shift detection.
+- Add anomaly flagging to decomposition methods via `anomaly_threshold` parameter.
+- Add ERP (Edit Distance with Real Penalty) distance metric (`compute_pairwise_erp`).
+- Add LCSS (Longest Common Subsequence) distance metric (`compute_pairwise_lcss`).
+- Add TWE (Time Warp Edit Distance) distance metric (`compute_pairwise_twe`).
 - Add FastDTW approximate algorithm (`method="fast"`, `param=radius`).
 - Add Sakoe-Chiba band constraint (`method="sakoe_chiba"`, `param=window_size`).
 - Add Itakura parallelogram constraint (`method="itakura"`, `param=max_slope`).
 - `compute_pairwise_dtw` now accepts optional `method` and `param` arguments (backward compatible).
 
+### Improvements
+
+- Deduplicate Rust distance code into shared `utils.rs` (grouping, hashing, parallel pairwise).
+- Optimize all distance metrics to O(m) memory with two-row DP.
+- Add `#[pyo3(signature)]` annotations for Rust safety with pyo3 0.24+.
+- Add `pyarrow` as core dependency for reliable Arrow interchange.
+- Lightweight core: optional dependencies (`forecast`, `decomposition`) are lazy-loaded.
+- CI: add minimal-deps job, polars compatibility matrix, clippy, and code-quality checks.
+
 ### Fixes
 
-- Upgrade Rust dependencies for Python polars compatibility (pyo3 0.23 to 0.24, pyo3-polars 0.20 to 0.21, polars crate 0.46 to 0.48).
-- Add `#[pyo3(signature)]` annotations to fix implicit `Option` defaults in pyo3 0.24+ (wdtw, msm, msm_multi, dtw_multi).
-- Remove unused `polars-rows-iter` dependency.
-- Fix trailing space in `freqs` docstring parameter causing mkdocs strict build failure.
-- Pin Python polars to `>=1.20.0,<1.32.3` for ABI compatibility with Rust polars 0.48.
+- Upgrade Rust dependencies (pyo3 0.24, pyo3-polars 0.21, polars crate 0.48).
+- Pin Python polars to `>=1.30.0,<2.0.0` for ABI compatibility.
+- Fix trailing space in `freqs` docstring causing mkdocs strict build failure.
+
+### Tests
+
+- Add 286 tests covering all distance metrics, decomposition, trend, changepoint, and edge cases.
+- Add input validation, edge case, and parallelism stress tests for distance metrics.
 
 ## v0.3.0
 
-### ✨ Features
+### Features
 
 - Implement Seasonal Decomposition.
 - Implement Fourier Decomposition.
@@ -25,25 +43,25 @@
 
 ## v0.2.0
 
-### ✨ Features
+### Features
 
 - Implement Mann-Kendall's Trend Statistic.
 
-### 🛠️ Chore
+### Chore
 
 - Make library usable on PyPI with the Rust expressions.
 
 ## v0.1.0
 
-### ✨ Features
+### Features
 
 - Implement Kaboudan metric.
 
-### 📖 Documentation
+### Documentation
 
 - Add automatic references to docstrings.
 - Access docs under [https://drumtorben.github.io/polars-ts/](https://drumtorben.github.io/polars-ts/).
 
-### 🛠️ Chore
+### Chore
 
 - Initialize Repo.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Polars Time Series Extension
 
-Welcome to the documentation for the **Polars Time Series Extension**.
+A high-performance time series analysis toolkit for [Polars](https://pola.rs), with Rust-powered distance metrics and Python analytics.
 
 ---
 
@@ -8,43 +8,159 @@ Welcome to the documentation for the **Polars Time Series Extension**.
 
 **Source Code**: [https://github.com/drumtorben/polars-ts](https://github.com/drumtorben/polars-ts)
 
+**PyPI**: [https://pypi.org/project/polars-timeseries](https://pypi.org/project/polars-timeseries)
+
 ---
 
-## 📖 Overview
+## Features
 
-The **Polars Time Series Extention** offers a wide range of metrics, feature extractors, and various tools for time series forecasting.
+### Distance Metrics (Rust, parallelized via Rayon)
+
+| Metric | Function | Key Parameters |
+|--------|----------|----------------|
+| Dynamic Time Warping | `compute_pairwise_dtw` | `method`: standard, sakoe_chiba, itakura, fast |
+| Derivative DTW | `compute_pairwise_ddtw` | Shape-sensitive comparison |
+| Weighted DTW | `compute_pairwise_wdtw` | `g`: weight sharpness |
+| Move-Split-Merge | `compute_pairwise_msm` | `c`: move cost |
+| Edit Distance (Real Penalty) | `compute_pairwise_erp` | `g`: gap value |
+| Longest Common Subsequence | `compute_pairwise_lcss` | `epsilon`: matching threshold |
+| Time Warp Edit Distance | `compute_pairwise_twe` | `nu`: stiffness, `lambda_`: deletion cost |
+| Multivariate DTW | `compute_pairwise_dtw_multi` | `metric`: manhattan, euclidean |
+| Multivariate MSM | `compute_pairwise_msm_multi` | `c`: move cost |
+
+### Trend & Changepoint Detection (Rust)
+
+- **Mann-Kendall test** &mdash; non-parametric trend detection
+- **Sen's slope** &mdash; robust trend magnitude estimation
+- **CUSUM** &mdash; cumulative sum changepoint detection
+
+### Decomposition (Python)
+
+- **Seasonal decomposition** &mdash; additive or multiplicative (classical)
+- **Fourier decomposition** &mdash; harmonic decomposition with configurable frequencies
+- **Decomposition features** &mdash; trend/seasonal strength extraction (simple or MSTL)
+- **Anomaly flagging** &mdash; residual-based anomaly detection from any decomposition
+
+### Forecasting
+
+- **SCUM** &mdash; ensemble model combining AutoARIMA, AutoETS, AutoCES, and DynamicOptimizedTheta
+- **Kaboudan metric** &mdash; model robustness evaluation via block-shuffle backtesting
 
 ## Installation
 
-`pip install polars-timeseries`
+```bash
+pip install polars-timeseries
+```
 
-## How to use
+Optional dependencies for specific features:
 
-The `polars-ts` plugin is available under the namespace `pts`.
-See the following example where we compute the Kaboudan metric:
+```bash
+pip install "polars-timeseries[forecast]"      # Kaboudan metric, SCUM model
+pip install "polars-timeseries[decomposition]"  # Fourier decomposition
+pip install "polars-timeseries[all]"            # Everything
+```
+
+Requires Python 3.12+ and Polars 1.30+.
+
+## Quick Start
+
+### Pairwise DTW distance
+
+```python
+import polars as pl
+import polars_ts as pts
+
+df = pl.DataFrame({
+    "unique_id": ["A"] * 5 + ["B"] * 5,
+    "y": [1.0, 2.0, 3.0, 2.0, 1.0,
+          1.0, 3.0, 5.0, 3.0, 1.0],
+})
+
+# Standard DTW
+result = pts.compute_pairwise_dtw(df, df)
+
+# With Sakoe-Chiba band constraint
+result = pts.compute_pairwise_dtw(df, df, method="sakoe_chiba", param=2)
+```
+
+### Mann-Kendall trend test
+
+```python
+import polars as pl
+import polars_ts as pts
+
+df = pl.DataFrame({
+    "group": ["A"] * 10 + ["B"] * 10,
+    "y": list(range(10)) + [10 - x for x in range(10)],
+})
+
+result = df.group_by("group").agg(
+    pts.mann_kendall(pl.col("y")).alias("trend"),
+    pts.sens_slope(pl.col("y")).alias("slope"),
+)
+```
+
+### Seasonal decomposition
+
+```python
+import polars as pl
+import polars_ts as pts
+
+df = pl.DataFrame({
+    "unique_id": ["A"] * 48,
+    "ds": list(range(48)),
+    "y": [10 + 5 * (i % 12 > 5) + 0.5 * i for i in range(48)],
+})
+
+result = pts.seasonal_decomposition(df, freq=12, method="additive")
+```
+
+### CUSUM changepoint detection
+
+```python
+import polars as pl
+import polars_ts as pts
+
+df = pl.DataFrame({
+    "unique_id": ["A"] * 20,
+    "y": [1.0] * 10 + [5.0] * 10,
+})
+
+result = pts.cusum(df)
+```
+
+### Kaboudan metric
 
 ```python
 import polars as pl
 from statsforecast import StatsForecast
 from statsforecast.models import AutoETS, OptimizedTheta
-
 import polars_ts as pts  # noqa
 
-# Create sample dataframe with columns `unique_id`, `ds`, and `y`.
 df = (
     pl.scan_parquet("https://datasets-nixtla.s3.amazonaws.com/m4-hourly.parquet")
     .filter(pl.col("unique_id").is_in(["H1", "H2", "H3"]))
     .collect()
 )
 
-# Define models
-season_length = 24
-models = [
-    OptimizedTheta(season_length=season_length, decomposition_type="additive"),
-    AutoETS(season_length=season_length),
-]
-sf = StatsForecast(models=models, freq=1, n_jobs=-1)
+sf = StatsForecast(
+    models=[OptimizedTheta(season_length=24), AutoETS(season_length=24)],
+    freq=1, n_jobs=-1,
+)
 
-# Compute the Kaboudan metric in the `pts` namespace
 res = df.pts.kaboudan(sf, block_size=200, backtesting_start=0.5, n_folds=10)
 ```
+
+## Development
+
+```bash
+git clone https://github.com/drumtorben/polars-ts.git
+cd polars-ts
+uv sync
+uv pip install -e .
+uv run pytest
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **README rewrite** — replaced minimal overview with full feature inventory, installation options, and quick-start examples for all major APIs (DTW, Mann-Kendall, decomposition, CUSUM, Kaboudan)
- **CHANGELOG update** — consolidated entries into v0.4.0 covering all new features (Sen's slope, CUSUM, anomaly flags, ERP/LCSS/TWE, DTW variants), improvements (Rust dedup, O(m) memory, lazy loading, CI hardening), fixes, and test coverage (286 tests)

## Test plan

- [x] `uv run pytest tests/ -v` — 275 passed, 11 skipped (optional statsforecast)
- [ ] CI passes on all platforms
- [ ] Verify docs build with `mkdocs build --strict`