### PR TITLE
ci: add automated MkDocs deployment to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for mkdocs-git-authors-plugin
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: uv sync --group docs
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Deploy to GitHub Pages
+        run: uv run mkdocs gh-deploy --force --strict --clean


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` that automatically builds and deploys MkDocs documentation to GitHub Pages on every push to `main`
- Uses `mkdocs gh-deploy --force --strict --clean` for reliable deployment
- Includes `fetch-depth: 0` for `mkdocs-git-authors-plugin` support
- Existing CI docs job continues to validate builds on PRs

Closes #13

## Test plan

- [x] Local `mkdocs build -s -c` succeeds without errors
- [x] Workflow uses same setup pattern as existing CI docs job (uv, Python 3.12, Rust toolchain)
- [ ] After merge, verify docs deploy to https://drumtorben.github.io/polars-ts/

## Notes

The repo must have GitHub Pages configured to deploy from the `gh-pages` branch (which already exists from prior manual deployments). No additional secrets are needed — the workflow uses the default `GITHUB_TOKEN` with `contents: write` permission.