### PR TITLE
fix: aarch64-linux wheel build failure in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           manylinux: auto
+        env:
+          CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.target }}


### PR DESCRIPTION
## Summary

- Fixes the `aarch64-unknown-linux-gnu` wheel build failure in the Release workflow (run [#24441047979](https://github.com/drumtorben/polars-ts/actions/runs/24441047979))
- The `ring` crate (transitive dep via `polars` → `object_store` → `reqwest` → `rustls` → `ring`) requires `__ARM_ARCH` to be defined when cross-compiling ARM assembly, but the maturin Docker cross-compiler doesn't set it
- Sets `CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"` in the build step

## Test plan

- [ ] Re-run the release pipeline on a `v*` tag and verify all 5 wheel targets succeed