### PR TITLE
feat: add forecast ensembling (weighted ensemble, stacking)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -144,6 +144,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
+    if name in {"WeightedEnsemble", "StackingForecaster"}:
+        from polars_ts import ensemble as _ens
+
+        return getattr(_ens, name)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 
@@ -204,4 +208,6 @@ __all__ = [
     "fft_forecast",
     "RecursiveForecaster",
     "DirectForecaster",
+    "WeightedEnsemble",
+    "StackingForecaster",
 ]

--- a/polars_ts/ensemble/__init__.py
+++ b/polars_ts/ensemble/__init__.py
@@ -1,0 +1,24 @@
+"""Forecast ensembling: weighted combination and stacking.
+
+Implements ensemble strategies from Ch 9 of
+"Modern Time Series Forecasting with Python" (2nd Ed.).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "WeightedEnsemble":
+        from polars_ts.ensemble.weighted import WeightedEnsemble
+
+        return WeightedEnsemble
+    if name == "StackingForecaster":
+        from polars_ts.ensemble.stacking import StackingForecaster
+
+        return StackingForecaster
+    raise AttributeError(f"module 'polars_ts.ensemble' has no attribute {name!r}")
+
+
+__all__ = ["WeightedEnsemble", "StackingForecaster"]

--- a/polars_ts/ensemble/stacking.py
+++ b/polars_ts/ensemble/stacking.py
@@ -1,0 +1,128 @@
+"""Stacking forecaster using a meta-learner.
+
+Trains a meta-learner on out-of-fold predictions from multiple base
+models, then combines new forecasts through the fitted meta-learner.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from polars_ts.ensemble.weighted import _join_forecasts
+from polars_ts.models.multistep import Estimator
+
+
+class StackingForecaster:
+    """Stacking ensemble that trains a meta-learner on base model predictions.
+
+    Parameters
+    ----------
+    meta_learner
+        A scikit-learn-compatible estimator with ``fit`` and ``predict``.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps.
+    target_col
+        Column with actual target values.
+
+    """
+
+    def __init__(
+        self,
+        meta_learner: Estimator,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> None:
+        self.meta_learner = meta_learner
+        self.id_col = id_col
+        self.time_col = time_col
+        self.target_col = target_col
+        self.is_fitted_: bool = False
+        self.n_models_: int = 0
+
+    def fit(
+        self,
+        cv_predictions: list[pl.DataFrame],
+        actuals: pl.DataFrame,
+    ) -> StackingForecaster:
+        """Train the meta-learner on out-of-fold base model predictions.
+
+        Parameters
+        ----------
+        cv_predictions
+            List of DataFrames, one per base model, each containing
+            out-of-fold predictions with columns ``[id_col, time_col, "y_hat"]``.
+        actuals
+            DataFrame with actual values in ``target_col``, keyed by
+            ``id_col`` and ``time_col``.
+
+        Returns
+        -------
+        StackingForecaster
+            Fitted forecaster (``self``).
+
+        """
+        if not cv_predictions:
+            raise ValueError("cv_predictions must be a non-empty list")
+        if len(cv_predictions) < 2:
+            raise ValueError("Need at least 2 base models for stacking")
+
+        self.n_models_ = len(cv_predictions)
+
+        # Join all CV predictions into feature matrix
+        joined = _join_forecasts(cv_predictions, self.id_col, self.time_col)
+
+        # Join with actuals to get target
+        join_cols = [c for c in [self.id_col, self.time_col] if c in joined.columns]
+        with_target = joined.join(
+            actuals.select(*join_cols, self.target_col),
+            on=join_cols,
+            how="inner",
+        )
+
+        if len(with_target) == 0:
+            raise ValueError("No matching rows between cv_predictions and actuals")
+
+        # Build numpy arrays
+        hat_cols = [f"y_hat_{i}" for i in range(self.n_models_)]
+        X = with_target.select(hat_cols).to_numpy().astype(np.float64)
+        y = with_target[self.target_col].to_numpy().astype(np.float64)
+
+        self.meta_learner.fit(X, y)
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, forecasts: list[pl.DataFrame]) -> pl.DataFrame:
+        """Combine base model forecasts through the fitted meta-learner.
+
+        Parameters
+        ----------
+        forecasts
+            List of forecast DataFrames, one per base model, each with
+            ``[id_col, time_col, "y_hat"]``.
+
+        Returns
+        -------
+        pl.DataFrame
+            Combined forecast with columns ``[id_col, time_col, "y_hat"]``.
+
+        """
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before predict()")
+        if len(forecasts) != self.n_models_:
+            raise ValueError(f"Expected {self.n_models_} forecasts, got {len(forecasts)}")
+
+        joined = _join_forecasts(forecasts, self.id_col, self.time_col)
+        hat_cols = [f"y_hat_{i}" for i in range(self.n_models_)]
+        X = joined.select(hat_cols).to_numpy().astype(np.float64)
+
+        preds = self.meta_learner.predict(X)
+
+        join_cols = [c for c in [self.id_col, self.time_col] if c in joined.columns]
+        result = joined.select(join_cols).with_columns(
+            pl.Series("y_hat", preds.astype(np.float64)),
+        )
+        return result

--- a/polars_ts/ensemble/weighted.py
+++ b/polars_ts/ensemble/weighted.py
@@ -1,0 +1,165 @@
+"""Weighted forecast ensemble.
+
+Combines multiple forecast DataFrames using equal, manual, or
+inverse-error-optimized weights.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def _join_forecasts(
+    forecasts: list[pl.DataFrame],
+    id_col: str,
+    time_col: str,
+) -> pl.DataFrame:
+    """Join multiple forecast DataFrames on (id_col, time_col).
+
+    Renames each ``y_hat`` column to ``y_hat_0``, ``y_hat_1``, etc.
+    Validates that all forecasts share the same (id_col, time_col) rows.
+
+    Returns
+    -------
+    pl.DataFrame
+        Joined DataFrame with columns ``[id_col, time_col, y_hat_0, y_hat_1, ...]``.
+
+    """
+    if not forecasts:
+        raise ValueError("forecasts must be a non-empty list")
+
+    join_cols = [id_col, time_col] if id_col in forecasts[0].columns else [time_col]
+
+    base = forecasts[0].select(*join_cols, pl.col("y_hat").alias("y_hat_0"))
+    n_rows = len(base)
+
+    for i, fc in enumerate(forecasts[1:], start=1):
+        renamed = fc.select(*join_cols, pl.col("y_hat").alias(f"y_hat_{i}"))
+        base = base.join(renamed, on=join_cols, how="inner")
+        if len(base) != n_rows:
+            raise ValueError(
+                f"Forecast {i} has different (id, time) rows than forecast 0 "
+                f"({len(renamed)} vs {n_rows} rows; {len(base)} matched)"
+            )
+
+    return base
+
+
+class WeightedEnsemble:
+    """Combine multiple forecasts using weighted averaging.
+
+    Accepts pre-computed forecast DataFrames and combines them.
+    No model training is performed.
+
+    Parameters
+    ----------
+    weights
+        Weighting strategy:
+
+        - ``"equal"`` (default): all models get equal weight ``1/n``.
+        - ``"inverse_error"``: weights are ``1/MAE`` normalized to sum
+          to 1. Requires ``validation_pairs`` in :meth:`combine`.
+        - A ``list[float]``: explicit weights (will be normalized).
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps.
+
+    """
+
+    def __init__(
+        self,
+        weights: str | list[float] = "equal",
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+    ) -> None:
+        self.weights = weights
+        self.id_col = id_col
+        self.time_col = time_col
+
+    def combine(
+        self,
+        forecasts: list[pl.DataFrame],
+        validation_dfs: list[pl.DataFrame] | None = None,
+    ) -> pl.DataFrame:
+        """Combine forecast DataFrames into a single ensemble forecast.
+
+        Parameters
+        ----------
+        forecasts
+            List of forecast DataFrames, each with ``[id_col, time_col, "y_hat"]``.
+        validation_dfs
+            Required when ``weights="inverse_error"``. List of
+            DataFrames (one per model), each with ``y`` and ``y_hat``
+            columns for computing per-model MAE.
+
+        Returns
+        -------
+        pl.DataFrame
+            Combined forecast with columns ``[id_col, time_col, "y_hat"]``.
+
+        """
+        if not forecasts:
+            raise ValueError("forecasts must be a non-empty list")
+        if len(forecasts) < 2:
+            raise ValueError("Need at least 2 forecasts to ensemble")
+
+        n = len(forecasts)
+        w = self._resolve_weights(n, validation_dfs)
+
+        joined = _join_forecasts(forecasts, self.id_col, self.time_col)
+        hat_cols = [f"y_hat_{i}" for i in range(n)]
+
+        # Weighted sum
+        expr = pl.lit(0.0)
+        for i, col_name in enumerate(hat_cols):
+            expr = expr + pl.col(col_name) * w[i]
+
+        join_cols = [c for c in [self.id_col, self.time_col] if c in joined.columns]
+        return joined.select(*join_cols, expr.alias("y_hat"))
+
+    def _resolve_weights(
+        self,
+        n: int,
+        validation_dfs: list[pl.DataFrame] | None,
+    ) -> list[float]:
+        if isinstance(self.weights, list):
+            if len(self.weights) != n:
+                raise ValueError(f"Expected {n} weights, got {len(self.weights)}")
+            total = sum(self.weights)
+            if total <= 0:
+                raise ValueError("Weights must sum to a positive value")
+            return [w / total for w in self.weights]
+
+        if self.weights == "equal":
+            return [1.0 / n] * n
+
+        if self.weights == "inverse_error":
+            if validation_dfs is None:
+                raise ValueError("validation_dfs required when weights='inverse_error'")
+            if len(validation_dfs) != n:
+                raise ValueError(f"Expected {n} validation DataFrames, got {len(validation_dfs)}")
+            return self._compute_inverse_error_weights(validation_dfs)
+
+        raise ValueError(f"Unknown weights strategy: {self.weights!r}")
+
+    @staticmethod
+    def _compute_inverse_error_weights(
+        validation_dfs: list[pl.DataFrame],
+    ) -> list[float]:
+        from polars_ts.metrics.forecast import mae
+
+        errors: list[float] = []
+        for df in validation_dfs:
+            if "y" not in df.columns or "y_hat" not in df.columns:
+                raise ValueError("Validation DataFrames must have 'y' and 'y_hat' columns")
+            score = mae(df, actual_col="y", predicted_col="y_hat")
+            if not isinstance(score, float):
+                score = score.item()  # type: ignore[union-attr]
+            if score <= 0:
+                score = 1e-10  # Avoid division by zero for perfect models
+            errors.append(score)
+
+        inv = [1.0 / e for e in errors]
+        total = sum(inv)
+        return [w / total for w in inv]

--- a/polars_ts/models/__init__.py
+++ b/polars_ts/models/__init__.py
@@ -4,7 +4,6 @@ _BASELINE_NAMES = {"naive_forecast", "seasonal_naive_forecast", "moving_average_
 _MULTISTEP_NAMES = {"RecursiveForecaster", "DirectForecaster"}
 
 
-
 def __getattr__(name: str) -> Any:
     if name == "SCUM":
         try:

--- a/polars_ts/models/multistep.py
+++ b/polars_ts/models/multistep.py
@@ -172,7 +172,7 @@ class RecursiveForecaster:
                 buffer.append(pred)
                 rows.append({self.id_col: group_id[0], self.time_col: future_times[step], "y_hat": pred})
 
-        schema = {self.id_col: df.schema[self.id_col], self.time_col: df.schema[self.time_col], "y_hat": pl.Float64}
+        schema = {self.id_col: df.schema[self.id_col], self.time_col: df.schema[self.time_col], "y_hat": pl.Float64()}
         return pl.DataFrame(rows, schema=schema).sort(self.id_col, self.time_col)
 
 
@@ -309,5 +309,5 @@ class DirectForecaster:
                 pred = float(estimator.predict(x_row)[0])
                 rows.append({self.id_col: group_id[0], self.time_col: future_times[step], "y_hat": pred})
 
-        schema = {self.id_col: df.schema[self.id_col], self.time_col: df.schema[self.time_col], "y_hat": pl.Float64}
+        schema = {self.id_col: df.schema[self.id_col], self.time_col: df.schema[self.time_col], "y_hat": pl.Float64()}
         return pl.DataFrame(rows, schema=schema).sort(self.id_col, self.time_col)

--- a/tests/ensemble/test_stacking.py
+++ b/tests/ensemble/test_stacking.py
@@ -1,0 +1,177 @@
+"""Tests for stacking forecaster."""
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+sklearn = pytest.importorskip("sklearn")
+from sklearn.linear_model import LinearRegression, Ridge  # noqa: E402
+
+from polars_ts.ensemble.stacking import StackingForecaster  # noqa: E402
+
+
+def _make_forecast(values: list[float], series_id: str = "A") -> pl.DataFrame:
+    n = len(values)
+    return pl.DataFrame(
+        {
+            "unique_id": [series_id] * n,
+            "ds": [date(2024, 1, i + 1) for i in range(n)],
+            "y_hat": values,
+        }
+    )
+
+
+def _make_actuals(values: list[float], series_id: str = "A") -> pl.DataFrame:
+    n = len(values)
+    return pl.DataFrame(
+        {
+            "unique_id": [series_id] * n,
+            "ds": [date(2024, 1, i + 1) for i in range(n)],
+            "y": values,
+        }
+    )
+
+
+class TestStackingForecaster:
+    def test_fit_predict_basic(self):
+        # Two base models with CV predictions
+        cv1 = _make_forecast([10.0, 20.0, 30.0, 40.0, 50.0])
+        cv2 = _make_forecast([12.0, 22.0, 28.0, 42.0, 48.0])
+        actuals = _make_actuals([11.0, 21.0, 29.0, 41.0, 49.0])
+
+        sf = StackingForecaster(LinearRegression())
+        sf.fit([cv1, cv2], actuals)
+
+        test1 = _make_forecast([60.0])
+        test2 = _make_forecast([58.0])
+        result = sf.predict([test1, test2])
+
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+        assert len(result) == 1
+
+    def test_output_schema(self):
+        cv1 = _make_forecast([1.0, 2.0, 3.0])
+        cv2 = _make_forecast([2.0, 3.0, 4.0])
+        actuals = _make_actuals([1.5, 2.5, 3.5])
+
+        sf = StackingForecaster(LinearRegression())
+        sf.fit([cv1, cv2], actuals)
+
+        result = sf.predict([_make_forecast([5.0]), _make_forecast([6.0])])
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+
+    def test_predict_before_fit(self):
+        sf = StackingForecaster(LinearRegression())
+        with pytest.raises(RuntimeError, match="fit"):
+            sf.predict([_make_forecast([1.0]), _make_forecast([2.0])])
+
+    def test_wrong_number_of_forecasts(self):
+        cv1 = _make_forecast([1.0, 2.0, 3.0])
+        cv2 = _make_forecast([2.0, 3.0, 4.0])
+        actuals = _make_actuals([1.5, 2.5, 3.5])
+
+        sf = StackingForecaster(LinearRegression())
+        sf.fit([cv1, cv2], actuals)
+
+        with pytest.raises(ValueError, match="2 forecasts"):
+            sf.predict([_make_forecast([5.0])])
+
+    def test_multiple_series(self):
+        cv1 = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 3,
+                "ds": [date(2024, 1, i + 1) for i in range(3)] * 2,
+                "y_hat": [10.0, 20.0, 30.0, 100.0, 200.0, 300.0],
+            }
+        )
+        cv2 = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 3,
+                "ds": [date(2024, 1, i + 1) for i in range(3)] * 2,
+                "y_hat": [12.0, 22.0, 28.0, 110.0, 210.0, 290.0],
+            }
+        )
+        actuals = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 3,
+                "ds": [date(2024, 1, i + 1) for i in range(3)] * 2,
+                "y": [11.0, 21.0, 29.0, 105.0, 205.0, 295.0],
+            }
+        )
+
+        sf = StackingForecaster(LinearRegression())
+        sf.fit([cv1, cv2], actuals)
+
+        test1 = pl.DataFrame(
+            {"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [40.0, 400.0]}
+        )
+        test2 = pl.DataFrame(
+            {"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [38.0, 390.0]}
+        )
+        result = sf.predict([test1, test2])
+        assert len(result) == 2
+
+    def test_stacking_with_ridge(self):
+        """Works with different meta-learners."""
+        cv1 = _make_forecast([1.0, 2.0, 3.0, 4.0, 5.0])
+        cv2 = _make_forecast([1.5, 2.5, 3.5, 4.5, 5.5])
+        actuals = _make_actuals([1.2, 2.2, 3.2, 4.2, 5.2])
+
+        sf = StackingForecaster(Ridge(alpha=0.1))
+        sf.fit([cv1, cv2], actuals)
+        result = sf.predict([_make_forecast([6.0]), _make_forecast([6.5])])
+        assert len(result) == 1
+
+    def test_stacking_beats_individual(self):
+        """Stacking should outperform individual biased models."""
+        from polars_ts.metrics.forecast import mae
+
+        n = 20
+        true_vals = [float(i) for i in range(n)]
+        # Model A: consistently over-predicts by 2
+        model_a_vals = [v + 2.0 for v in true_vals]
+        # Model B: consistently under-predicts by 2
+        model_b_vals = [v - 2.0 for v in true_vals]
+
+        cv1 = _make_forecast(model_a_vals)
+        cv2 = _make_forecast(model_b_vals)
+        actuals = _make_actuals(true_vals)
+
+        sf = StackingForecaster(LinearRegression())
+        sf.fit([cv1, cv2], actuals)
+
+        # Test set
+        test_true = [float(i) for i in range(n, n + 5)]
+        test1 = _make_forecast([v + 2.0 for v in test_true])
+        test2 = _make_forecast([v - 2.0 for v in test_true])
+        result = sf.predict([test1, test2])
+
+        test_actuals = _make_actuals(test_true)
+        combined = test_actuals.join(result, on=["unique_id", "ds"])
+        stacking_mae = mae(combined, actual_col="y", predicted_col="y_hat")
+
+        # Individual MAEs are both 2.0
+        assert stacking_mae < 1.0  # Stacking should be much better
+
+    def test_empty_cv_predictions(self):
+        sf = StackingForecaster(LinearRegression())
+        with pytest.raises(ValueError, match="non-empty"):
+            sf.fit([], _make_actuals([1.0]))
+
+    def test_single_model_rejected(self):
+        sf = StackingForecaster(LinearRegression())
+        with pytest.raises(ValueError, match="at least 2"):
+            sf.fit([_make_forecast([1.0])], _make_actuals([1.0]))
+
+
+def test_top_level_import():
+    import polars_ts
+
+    assert polars_ts.StackingForecaster is StackingForecaster
+
+
+def test_submodule_import():
+    from polars_ts.ensemble import StackingForecaster as SF
+
+    assert callable(SF)

--- a/tests/ensemble/test_stacking.py
+++ b/tests/ensemble/test_stacking.py
@@ -103,12 +103,8 @@ class TestStackingForecaster:
         sf = StackingForecaster(LinearRegression())
         sf.fit([cv1, cv2], actuals)
 
-        test1 = pl.DataFrame(
-            {"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [40.0, 400.0]}
-        )
-        test2 = pl.DataFrame(
-            {"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [38.0, 390.0]}
-        )
+        test1 = pl.DataFrame({"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [40.0, 400.0]})
+        test2 = pl.DataFrame({"unique_id": ["A", "B"], "ds": [date(2024, 1, 4)] * 2, "y_hat": [38.0, 390.0]})
         result = sf.predict([test1, test2])
         assert len(result) == 2
 

--- a/tests/ensemble/test_weighted.py
+++ b/tests/ensemble/test_weighted.py
@@ -1,0 +1,146 @@
+"""Tests for weighted forecast ensemble."""
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from polars_ts.ensemble.weighted import WeightedEnsemble
+
+
+def _make_forecast(values: list[float], series_id: str = "A") -> pl.DataFrame:
+    n = len(values)
+    return pl.DataFrame(
+        {
+            "unique_id": [series_id] * n,
+            "ds": [date(2024, 1, i + 1) for i in range(n)],
+            "y_hat": values,
+        }
+    )
+
+
+class TestWeightedEnsemble:
+    def test_equal_weights(self):
+        f1 = _make_forecast([10.0, 20.0])
+        f2 = _make_forecast([20.0, 40.0])
+        ens = WeightedEnsemble(weights="equal")
+        result = ens.combine([f1, f2])
+
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+        assert result["y_hat"].to_list() == pytest.approx([15.0, 30.0])
+
+    def test_manual_weights(self):
+        f1 = _make_forecast([10.0, 20.0])
+        f2 = _make_forecast([20.0, 40.0])
+        ens = WeightedEnsemble(weights=[0.75, 0.25])
+        result = ens.combine([f1, f2])
+
+        # 0.75*10 + 0.25*20 = 12.5, 0.75*20 + 0.25*40 = 25.0
+        assert result["y_hat"].to_list() == pytest.approx([12.5, 25.0])
+
+    def test_manual_weights_normalized(self):
+        """Weights don't need to sum to 1 — they get normalized."""
+        f1 = _make_forecast([10.0])
+        f2 = _make_forecast([20.0])
+        ens = WeightedEnsemble(weights=[3.0, 1.0])
+        result = ens.combine([f1, f2])
+
+        # 0.75*10 + 0.25*20 = 12.5
+        assert result["y_hat"][0] == pytest.approx(12.5)
+
+    def test_inverse_error_weights(self):
+        f1 = _make_forecast([10.0, 20.0])
+        f2 = _make_forecast([20.0, 40.0])
+
+        # Model 1 has MAE=1, Model 2 has MAE=2
+        val1 = pl.DataFrame({"y": [11.0, 21.0], "y_hat": [10.0, 20.0]})  # MAE = 1
+        val2 = pl.DataFrame({"y": [11.0, 21.0], "y_hat": [9.0, 19.0]})  # MAE = 2
+
+        ens = WeightedEnsemble(weights="inverse_error")
+        result = ens.combine([f1, f2], validation_dfs=[val1, val2])
+
+        # w1 = (1/1) / (1/1 + 1/2) = 2/3, w2 = (1/2) / (1/1 + 1/2) = 1/3
+        expected_0 = (2 / 3) * 10.0 + (1 / 3) * 20.0
+        assert result["y_hat"][0] == pytest.approx(expected_0, abs=0.1)
+
+    def test_multiple_series(self):
+        f1 = pl.DataFrame(
+            {
+                "unique_id": ["A", "A", "B", "B"],
+                "ds": [date(2024, 1, 1), date(2024, 1, 2)] * 2,
+                "y_hat": [10.0, 20.0, 100.0, 200.0],
+            }
+        )
+        f2 = pl.DataFrame(
+            {
+                "unique_id": ["A", "A", "B", "B"],
+                "ds": [date(2024, 1, 1), date(2024, 1, 2)] * 2,
+                "y_hat": [20.0, 40.0, 200.0, 400.0],
+            }
+        )
+        ens = WeightedEnsemble(weights="equal")
+        result = ens.combine([f1, f2])
+
+        assert len(result) == 4
+        a = result.filter(pl.col("unique_id") == "A")["y_hat"].to_list()
+        assert a == pytest.approx([15.0, 30.0])
+
+    def test_three_models(self):
+        f1 = _make_forecast([10.0])
+        f2 = _make_forecast([20.0])
+        f3 = _make_forecast([30.0])
+        ens = WeightedEnsemble(weights="equal")
+        result = ens.combine([f1, f2, f3])
+
+        assert result["y_hat"][0] == pytest.approx(20.0)
+
+    def test_output_schema(self):
+        f1 = _make_forecast([1.0])
+        f2 = _make_forecast([2.0])
+        result = WeightedEnsemble().combine([f1, f2])
+
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+
+    def test_weight_length_mismatch(self):
+        f1 = _make_forecast([1.0])
+        f2 = _make_forecast([2.0])
+        ens = WeightedEnsemble(weights=[0.5, 0.3, 0.2])
+        with pytest.raises(ValueError, match="Expected 2 weights"):
+            ens.combine([f1, f2])
+
+    def test_mismatched_forecast_rows(self):
+        f1 = _make_forecast([1.0, 2.0])
+        f2 = _make_forecast([1.0])  # Different length
+        ens = WeightedEnsemble()
+        with pytest.raises(ValueError, match="different"):
+            ens.combine([f1, f2])
+
+    def test_inverse_error_no_validation(self):
+        f1 = _make_forecast([1.0])
+        f2 = _make_forecast([2.0])
+        ens = WeightedEnsemble(weights="inverse_error")
+        with pytest.raises(ValueError, match="validation_dfs"):
+            ens.combine([f1, f2])
+
+    def test_single_forecast_rejected(self):
+        f1 = _make_forecast([1.0])
+        ens = WeightedEnsemble()
+        with pytest.raises(ValueError, match="at least 2"):
+            ens.combine([f1])
+
+    def test_empty_forecasts_rejected(self):
+        ens = WeightedEnsemble()
+        with pytest.raises(ValueError, match="non-empty"):
+            ens.combine([])
+
+
+def test_top_level_import():
+    import polars_ts
+
+    assert polars_ts.WeightedEnsemble is WeightedEnsemble
+
+
+def test_submodule_import():
+    from polars_ts.ensemble import WeightedEnsemble as WE
+
+    assert callable(WE)


### PR DESCRIPTION
## Summary

- **WeightedEnsemble** — combine multiple forecast DataFrames using equal weights, manual weights, or inverse-error-optimized weights (1/MAE per model, normalized)
- **StackingForecaster** — train a meta-learner (any sklearn-compatible estimator) on out-of-fold base model predictions, then combine new forecasts through the fitted meta-learner

Implements roadmap priority #8 (Book Ch 9 — Ensembling).

## Files

| New | Purpose |
|-----|---------|
| `polars_ts/ensemble/__init__.py` | Lazy-loading subpackage init |
| `polars_ts/ensemble/weighted.py` | WeightedEnsemble class + `_join_forecasts` helper |
| `polars_ts/ensemble/stacking.py` | StackingForecaster class |
| `tests/ensemble/test_weighted.py` | 14 tests for WeightedEnsemble |
| `tests/ensemble/test_stacking.py` | 11 tests for StackingForecaster |

| Modified | Change |
|----------|--------|
| `polars_ts/__init__.py` | `__getattr__` + `__all__` entries for 2 new exports |

## Test plan

- [x] `ruff check` passes on all new/modified files
- [x] 25 tests pass covering all classes, weight modes, edge cases, and imports
- [x] Stacking beats individual biased models (test_stacking_beats_individual)
- [x] Inverse-error weights correctly weight better models higher
- [x] Group-aware: works with multiple time series
- [ ] CI passes on push