### PR TITLE
feat: add ARIMA/SARIMA wrapper (statsmodels + statsforecast)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## Unreleased
+## v0.6.0 (2026-04-21)
+
+### Features
+
+- Add ARIMA/SARIMA forecasting with explicit `(p,d,q)` order control via `statsmodels.SARIMAX` (`arima_fit`, `arima_forecast`).
+- Add automatic ARIMA order selection via `statsforecast.AutoARIMA` (`auto_arima`).
+- Both ARIMA backends raise helpful `ImportError` when optional dependencies are missing.
+
+### Performance
+
+- Accelerate exponential smoothing (SES, Holt, Holt-Winters) with Rust implementation (#86).
+- Accelerate k-medoids PAM clustering with Rust implementation (#84).
 
 ### Improvements
 
@@ -6,6 +17,12 @@
 - CI: add [ty](https://github.com/astral-sh/ty) type checker as non-blocking informational job alongside mypy.
 - Add `[tool.ty]` configuration section in `pyproject.toml`.
 - Document `prek` and `ty` local developer workflows in README.
+
+### Tests
+
+- Expand coverage for HF adapter, clustering, calibration, and adapters (#85).
+- Expand coverage for changepoint, clustering, adapters, and standalone modules (#83).
+- Add 8 ARIMA tests (5 statsmodels, 3 statsforecast-gated).
 
 ## v0.5.0 (2026-04-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-ts-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# Polars Time Series Extension
+<p align="center">
+  <img src="images/polars_ts_complete.png" alt="Polars TS" width="600">
+</p>
 
-A high-performance time series analysis toolkit for [Polars](https://pola.rs), with Rust-powered distance metrics and Python analytics.
-
----
-
-**Documentation**: [https://drumtorben.github.io/polars-ts](https://drumtorben.github.io/polars-ts)
-
-**Source Code**: [https://github.com/drumtorben/polars-ts](https://github.com/drumtorben/polars-ts)
-
-**PyPI**: [https://pypi.org/project/polars-timeseries](https://pypi.org/project/polars-timeseries)
+<p align="center">
+  <a href="https://drumtorben.github.io/polars-ts">Documentation</a> &bull;
+  <a href="https://github.com/drumtorben/polars-ts">Source Code</a> &bull;
+  <a href="https://pypi.org/project/polars-timeseries">PyPI</a>
+</p>
 
 ---
 
@@ -79,6 +77,7 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 ### Forecasting
 
 - **SCUM** &mdash; ensemble model combining AutoARIMA, AutoETS, AutoCES, and DynamicOptimizedTheta
+- **ARIMA/SARIMA** &mdash; explicit `(p,d,q)` order via `statsmodels` (`arima_fit`/`arima_forecast`) or automatic selection via `statsforecast` (`auto_arima`)
 - **Baseline models** &mdash; naive, seasonal naive, moving average, and FFT-based forecasts
 - **Exponential smoothing** &mdash; SES, Holt's linear, Holt-Winters (additive/multiplicative)
 - **Multi-step strategies** &mdash; `RecursiveForecaster` and `DirectForecaster`
@@ -179,6 +178,19 @@ pipe = pts.ForecastPipeline(
 )
 pipe.fit(train_df)
 forecasts = pipe.predict(train_df, h=7)
+```
+
+### ARIMA forecasting
+
+```python
+import polars_ts as pts
+
+# Fit ARIMA(1,1,1) and forecast 12 steps ahead
+fitted = pts.arima_fit(df, order=(1, 1, 1))
+forecast = pts.arima_forecast(fitted, h=12)
+
+# Or use automatic order selection
+forecast = pts.auto_arima(df, h=12, season_length=12)
 ```
 
 ### Exponential smoothing

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -226,6 +226,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts import probabilistic as _prob
 
         return getattr(_prob, name)
+    if name in {"arima_fit", "arima_forecast", "auto_arima"}:
+        from polars_ts import models as _models
+
+        return getattr(_models, name)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 
@@ -331,4 +335,7 @@ __all__ = [
     "QuantileRegressor",
     "conformal_interval",
     "EnbPI",
+    "arima_fit",
+    "arima_forecast",
+    "auto_arima",
 ]

--- a/polars_ts/models/__init__.py
+++ b/polars_ts/models/__init__.py
@@ -3,6 +3,7 @@ from typing import Any
 _BASELINE_NAMES = {"naive_forecast", "seasonal_naive_forecast", "moving_average_forecast", "fft_forecast"}
 _MULTISTEP_NAMES = {"RecursiveForecaster", "DirectForecaster"}
 _ES_NAMES = {"ses_forecast", "holt_forecast", "holt_winters_forecast"}
+_ARIMA_NAMES = {"arima_fit", "arima_forecast", "auto_arima"}
 
 
 def __getattr__(name: str) -> Any:
@@ -26,6 +27,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.models import exponential_smoothing
 
         return getattr(exponential_smoothing, name)
+    if name in _ARIMA_NAMES:
+        from polars_ts.models import arima
+
+        return getattr(arima, name)
     raise AttributeError(f"module 'polars_ts.models' has no attribute {name!r}")
 
 
@@ -40,4 +45,7 @@ __all__ = [
     "ses_forecast",
     "holt_forecast",
     "holt_winters_forecast",
+    "arima_fit",
+    "arima_forecast",
+    "auto_arima",
 ]

--- a/polars_ts/models/arima.py
+++ b/polars_ts/models/arima.py
@@ -1,0 +1,206 @@
+"""ARIMA / SARIMA wrappers for polars-ts.
+
+* ``arima_fit`` / ``arima_forecast`` -- explicit order control via
+  ``statsmodels.tsa.statespace.sarimax.SARIMAX``.
+* ``auto_arima`` -- automatic order selection via
+  ``statsforecast.models.AutoARIMA``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import polars as pl
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _infer_freq(dates: pl.Series) -> timedelta:
+    """Return the most common time delta in a sorted date/datetime column."""
+    diffs = dates.diff().drop_nulls()
+    if diffs.dtype == pl.Duration:
+        # datetime column – diffs are already durations
+        return diffs.mode().to_list()[0]
+    # date column – diffs are i32 day counts
+    day_count = diffs.cast(pl.Int64).mode().to_list()[0]
+    return timedelta(days=int(day_count))
+
+
+def _make_future_dates(
+    last_date: Any,
+    freq: timedelta,
+    h: int,
+) -> list[Any]:
+    """Generate *h* future timestamps starting one step after *last_date*."""
+    return [last_date + freq * (i + 1) for i in range(h)]
+
+
+# ---------------------------------------------------------------------------
+# auto_arima  (statsforecast backend)
+# ---------------------------------------------------------------------------
+
+
+def auto_arima(
+    df: pl.DataFrame,
+    h: int,
+    season_length: int = 1,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Fit an AutoARIMA model per series and return *h*-step forecasts.
+
+    Uses ``statsforecast.models.AutoARIMA`` under the hood.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]``.
+
+    """
+    try:
+        from statsforecast import StatsForecast
+        from statsforecast.models import AutoARIMA as _AutoARIMA
+    except ImportError:
+        raise ImportError(
+            "statsforecast is required for auto_arima. " "Install it with: pip install polars-timeseries[forecast]"
+        ) from None
+
+    # Validate minimum series length per group
+    group_lens = df.group_by(id_col).agg(pl.col(target_col).len().alias("_n"))
+    too_short = group_lens.filter(pl.col("_n") < 3)
+    if too_short.height > 0:
+        short_ids = too_short[id_col].to_list()
+        raise ValueError(f"Series too short for ARIMA estimation (need >= 3 observations): {short_ids}")
+
+    # Build the statsforecast-compatible DataFrame
+    sf_df = df.select(
+        pl.col(id_col).alias("unique_id"),
+        pl.col(time_col).alias("ds"),
+        pl.col(target_col).cast(pl.Float64).alias("y"),
+    ).to_pandas()
+
+    sf = StatsForecast(
+        models=[_AutoARIMA(season_length=season_length)],
+        freq=1,
+    )
+    sf_result = sf.forecast(h=h, df=sf_df)
+
+    # sf_result may have "unique_id" as index – reset it
+    if "unique_id" not in sf_result.columns:
+        sf_result = sf_result.reset_index()
+
+    result = pl.from_pandas(sf_result)
+
+    # Rename columns back to the caller's naming convention
+    rename_map: dict[str, str] = {}
+    if id_col != "unique_id":
+        rename_map["unique_id"] = id_col
+    if time_col != "ds":
+        rename_map["ds"] = time_col
+    # statsforecast names the prediction column after the model
+    pred_col = [c for c in result.columns if c not in {"unique_id", "ds"}][0]
+    rename_map[pred_col] = "y_hat"
+
+    if rename_map:
+        result = result.rename(rename_map)
+
+    return result.select(id_col, time_col, "y_hat")
+
+
+# ---------------------------------------------------------------------------
+# arima_fit / arima_forecast  (statsmodels backend)
+# ---------------------------------------------------------------------------
+
+
+def arima_fit(
+    df: pl.DataFrame,
+    order: tuple[int, int, int] = (1, 1, 1),
+    seasonal_order: tuple[int, int, int, int] | None = None,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> dict[str, Any]:
+    """Fit a SARIMAX model per group and return a dict of fitted models.
+
+    Parameters
+    ----------
+    df
+        Long-format DataFrame with at least ``[id_col, time_col, target_col]``.
+    order
+        ``(p, d, q)`` for the non-seasonal component.
+    seasonal_order
+        ``(P, D, Q, s)`` for the seasonal component.  ``None`` means no
+        seasonal component.
+
+    Returns
+    -------
+    dict
+        Mapping ``group_id -> fitted SARIMAXResults``.
+
+    """
+    try:
+        from statsmodels.tsa.statespace.sarimax import SARIMAX
+    except ImportError:
+        raise ImportError(
+            "statsmodels is required for arima_fit/arima_forecast. " "Install it with: pip install statsmodels"
+        ) from None
+
+    fitted: dict[str, Any] = {}
+    for key, group in df.group_by(id_col):
+        group_id = str(key[0]) if isinstance(key, tuple) else str(key)
+        group_sorted = group.sort(time_col)
+        endog = group_sorted[target_col].to_numpy().astype(float)
+
+        if len(endog) < 3:
+            raise ValueError(
+                f"Series {group_id!r} is too short for ARIMA estimation " f"(got {len(endog)} observations, need >= 3)."
+            )
+
+        kw: dict[str, Any] = {"order": order}
+        if seasonal_order is not None:
+            kw["seasonal_order"] = seasonal_order
+
+        model = SARIMAX(endog, **kw)
+        fitted[group_id] = model.fit(disp=False)
+
+    return fitted
+
+
+def arima_forecast(
+    fitted: dict[str, Any],
+    h: int,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Produce *h*-step-ahead forecasts from previously fitted models.
+
+    Parameters
+    ----------
+    fitted
+        Output of :func:`arima_fit`.
+    h
+        Forecast horizon.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]``.
+
+    """
+    parts: list[pl.DataFrame] = []
+    for group_id, model_result in fitted.items():
+        forecast_values = model_result.forecast(steps=h)
+        part = pl.DataFrame(
+            {
+                id_col: [group_id] * h,
+                time_col: list(range(1, h + 1)),
+                "y_hat": forecast_values.tolist(),
+            }
+        )
+        parts.append(part)
+
+    return pl.concat(parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polars-timeseries"
-version = "0.5.0"
+version = "0.6.0"
 description = "Polars Time Series Extension"
 authors = [
     { name = "Torben Windler" },

--- a/tests/models/test_arima.py
+++ b/tests/models/test_arima.py
@@ -1,0 +1,148 @@
+"""Tests for polars_ts.models.arima (ARIMA / SARIMA wrappers)."""
+
+from __future__ import annotations
+
+import random
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+
+def _make_df(
+    n: int = 50,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+    series_ids: list[str] | None = None,
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Create a simple trending series with some noise."""
+    rng = random.Random(seed)
+    if series_ids is None:
+        series_ids = ["A"]
+
+    parts: list[pl.DataFrame] = []
+    for sid in series_ids:
+        noise = [rng.gauss(0, 1) for _ in range(n)]
+        parts.append(
+            pl.DataFrame(
+                {
+                    id_col: [sid] * n,
+                    time_col: [date(2024, 1, 1) + timedelta(days=i) for i in range(n)],
+                    target_col: [10.0 + 0.5 * i + noise[i] for i in range(n)],
+                }
+            )
+        )
+    return pl.concat(parts)
+
+
+# ---------------------------------------------------------------------------
+# auto_arima tests (statsforecast backend)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoArima:
+    def test_auto_arima_basic(self) -> None:
+        sf = pytest.importorskip("statsforecast")  # noqa: F841
+        from polars_ts.models.arima import auto_arima
+
+        df = _make_df(n=50)
+        result = auto_arima(df, h=3)
+
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+        assert result.height == 3
+
+    def test_auto_arima_multi_series(self) -> None:
+        sf = pytest.importorskip("statsforecast")  # noqa: F841
+        from polars_ts.models.arima import auto_arima
+
+        df = _make_df(n=50, series_ids=["A", "B"])
+        result = auto_arima(df, h=3)
+
+        assert result.height == 6
+        assert set(result["unique_id"].unique().to_list()) == {"A", "B"}
+
+    def test_auto_arima_with_season_length(self) -> None:
+        sf = pytest.importorskip("statsforecast")  # noqa: F841
+        from polars_ts.models.arima import auto_arima
+
+        df = _make_df(n=60)
+        result = auto_arima(df, h=5, season_length=12)
+
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+        assert result.height == 5
+
+
+# ---------------------------------------------------------------------------
+# arima_fit / arima_forecast tests (statsmodels backend)
+# ---------------------------------------------------------------------------
+
+
+class TestArimaFitForecast:
+    def test_arima_fit_forecast_roundtrip(self) -> None:
+        sm = pytest.importorskip("statsmodels")  # noqa: F841
+        from polars_ts.models.arima import arima_fit, arima_forecast
+
+        df = _make_df(n=50)
+        fitted = arima_fit(df)
+
+        assert isinstance(fitted, dict)
+        assert "A" in fitted
+
+        result = arima_forecast(fitted, h=3)
+        assert result.columns == ["unique_id", "ds", "y_hat"]
+        assert result.height == 3
+
+    def test_arima_seasonal(self) -> None:
+        sm = pytest.importorskip("statsmodels")  # noqa: F841
+        from polars_ts.models.arima import arima_fit, arima_forecast
+
+        df = _make_df(n=60)
+        fitted = arima_fit(df, order=(1, 0, 0), seasonal_order=(1, 0, 0, 12))
+        result = arima_forecast(fitted, h=5)
+
+        assert result.height == 5
+
+    def test_arima_custom_columns(self) -> None:
+        sm = pytest.importorskip("statsmodels")  # noqa: F841
+        from polars_ts.models.arima import arima_fit, arima_forecast
+
+        df = _make_df(
+            n=50,
+            id_col="series",
+            time_col="timestamp",
+            target_col="value",
+        )
+        fitted = arima_fit(
+            df,
+            target_col="value",
+            id_col="series",
+            time_col="timestamp",
+        )
+
+        assert isinstance(fitted, dict)
+
+        result = arima_forecast(fitted, h=3, id_col="series", time_col="timestamp")
+        assert result.columns == ["series", "timestamp", "y_hat"]
+        assert result.height == 3
+
+    def test_arima_short_series_raises(self) -> None:
+        sm = pytest.importorskip("statsmodels")  # noqa: F841
+        from polars_ts.models.arima import arima_fit
+
+        df = _make_df(n=2)
+        with pytest.raises(ValueError, match="too short"):
+            arima_fit(df)
+
+
+# ---------------------------------------------------------------------------
+# Top-level import test
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_import() -> None:
+    import polars_ts
+
+    assert hasattr(polars_ts, "auto_arima")
+    assert callable(polars_ts.auto_arima)


### PR DESCRIPTION
## Summary
- Add `polars_ts/models/arima.py` with three public functions:
  - `arima_fit` / `arima_forecast` — explicit `(p,d,q)` order control via `statsmodels.SARIMAX`
  - `auto_arima` — automatic order selection via `statsforecast.AutoARIMA`
  - Both backends raise helpful `ImportError` if dependencies are missing
- Register lazy imports in `polars_ts/models/__init__.py` and `polars_ts/__init__.py`
- Add 8 tests (5 pass with statsmodels, 3 skip when statsforecast not installed)

Closes #81

## Test plan
- [x] `pytest tests/models/test_arima.py -v` — 5 passed, 3 skipped
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy polars_ts/models/arima.py` — no issues