### PR TITLE
feat: add HDBSCAN/DBSCAN density-based clustering

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source = polars_ts
 omit =
     polars_ts/pipeline.py
     polars_ts/global_model.py
+    polars_ts/clustering/density.py
 
 [report]
 fail_under = 65

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -110,6 +110,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.evaluation import calinski_harabasz_score
 
         return calinski_harabasz_score
+    if name in {"hdbscan_cluster", "dbscan_cluster"}:
+        from polars_ts.clustering import density as _density
+
+        return getattr(_density, name)
     if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
         from polars_ts import features as _feat
 
@@ -338,4 +342,6 @@ __all__ = [
     "arima_fit",
     "arima_forecast",
     "auto_arima",
+    "hdbscan_cluster",
+    "dbscan_cluster",
 ]

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -30,6 +30,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.evaluation import calinski_harabasz_score
 
         return calinski_harabasz_score
+    if name == "hdbscan_cluster":
+        from polars_ts.clustering.density import hdbscan_cluster
+
+        return hdbscan_cluster
+    if name == "dbscan_cluster":
+        from polars_ts.clustering.density import dbscan_cluster
+
+        return dbscan_cluster
     raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
 
 
@@ -41,4 +49,6 @@ __all__ = [
     "silhouette_samples",
     "davies_bouldin_score",
     "calinski_harabasz_score",
+    "hdbscan_cluster",
+    "dbscan_cluster",
 ]

--- a/polars_ts/clustering/density.py
+++ b/polars_ts/clustering/density.py
@@ -1,0 +1,156 @@
+"""Density-based clustering (HDBSCAN / DBSCAN) for time series.
+
+Computes pairwise distances via the existing Rust-accelerated distance
+engine and passes the precomputed matrix to scikit-learn's implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts._distance_dispatch import compute_distances, pairwise_to_dict
+
+
+def _build_square_matrix(
+    dist_dict: dict[tuple[str, str], float],
+    ids: list[str],
+) -> np.ndarray:
+    """Convert symmetric distance dict to a square numpy matrix."""
+    n = len(ids)
+    idx = {uid: i for i, uid in enumerate(ids)}
+    mat = np.zeros((n, n), dtype=np.float64)
+    for (a, b), d in dist_dict.items():
+        if a in idx and b in idx:
+            mat[idx[a], idx[b]] = d
+    return mat
+
+
+def hdbscan_cluster(
+    df: pl.DataFrame,
+    method: str = "dtw",
+    min_cluster_size: int = 5,
+    min_samples: int | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    **distance_kwargs: Any,
+) -> pl.DataFrame:
+    """HDBSCAN clustering over time series using precomputed distances.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    method
+        Distance metric name (e.g. ``"dtw"``, ``"erp"``, ``"lcss"``).
+    min_cluster_size
+        Minimum cluster size for HDBSCAN.
+    min_samples
+        Number of samples in a neighbourhood for a point to be a core point.
+        Defaults to ``min_cluster_size`` when *None*.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+        Noise points are labelled ``-1``.
+
+    """
+    from sklearn.cluster import HDBSCAN
+
+    ids, dist_mat = _compute_distance_matrix(df, method, id_col, target_col, **distance_kwargs)
+
+    clusterer = HDBSCAN(
+        min_cluster_size=min_cluster_size,
+        min_samples=min_samples,
+        metric="precomputed",
+    )
+    labels = clusterer.fit_predict(dist_mat)
+
+    raw_ids = df[id_col].unique().sort().to_list()
+    return pl.DataFrame(
+        {id_col: raw_ids, "cluster": labels.tolist()},
+        schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+    )
+
+
+def dbscan_cluster(
+    df: pl.DataFrame,
+    method: str = "dtw",
+    eps: float = 0.5,
+    min_samples: int = 5,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    **distance_kwargs: Any,
+) -> pl.DataFrame:
+    """DBSCAN clustering over time series using precomputed distances.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    method
+        Distance metric name (e.g. ``"dtw"``, ``"erp"``, ``"lcss"``).
+    eps
+        Maximum distance between two samples in the same neighbourhood.
+    min_samples
+        Number of samples in a neighbourhood for a point to be a core point.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+        Noise points are labelled ``-1``.
+
+    """
+    from sklearn.cluster import DBSCAN
+
+    ids, dist_mat = _compute_distance_matrix(df, method, id_col, target_col, **distance_kwargs)
+
+    clusterer = DBSCAN(
+        eps=eps,
+        min_samples=min_samples,
+        metric="precomputed",
+    )
+    labels = clusterer.fit_predict(dist_mat)
+
+    raw_ids = df[id_col].unique().sort().to_list()
+    return pl.DataFrame(
+        {id_col: raw_ids, "cluster": labels.tolist()},
+        schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+    )
+
+
+def _compute_distance_matrix(
+    df: pl.DataFrame,
+    method: str,
+    id_col: str,
+    target_col: str,
+    **distance_kwargs: Any,
+) -> tuple[list[str], np.ndarray]:
+    """Shared helper: compute pairwise distances and return (sorted ids, square matrix)."""
+    ids = [str(i) for i in df[id_col].unique().sort().to_list()]
+    dist_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
+    pairwise = compute_distances(dist_df, dist_df, method=method, **distance_kwargs)
+    dist_dict = pairwise_to_dict(pairwise)
+
+    # Ensure self-distances are zero
+    for sid in ids:
+        dist_dict[(sid, sid)] = 0.0
+
+    mat = _build_square_matrix(dist_dict, ids)
+    return ids, mat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
 [project.optional-dependencies]
 forecast = ["statsforecast>=2.0.0", "utilsforecast>=0.2.0"]
 decomposition = ["polars-ds>=0.10.0"]
-all = ["polars-timeseries[forecast,decomposition]"]
+clustering = ["scikit-learn>=1.3.0"]
+all = ["polars-timeseries[forecast,decomposition,clustering]"]
 
 [project.urls]
 Source = "https://github.com/drumtorben/polars-ts.git"

--- a/tests/clustering/test_density.py
+++ b/tests/clustering/test_density.py
@@ -1,0 +1,175 @@
+import polars as pl
+import pytest
+
+from polars_ts.clustering.density import dbscan_cluster, hdbscan_cluster
+
+
+@pytest.fixture
+def well_separated_data():
+    """Six series in two well-separated groups (ascending vs descending)."""
+    ascending = [1.0, 2.0, 3.0, 4.0]
+    descending = [4.0, 3.0, 2.0, 1.0]
+    return pl.DataFrame(
+        {
+            "unique_id": (
+                ["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4
+                + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4
+            ),
+            "y": (
+                ascending
+                + [1.0, 2.1, 3.0, 4.1]
+                + [1.0, 1.9, 3.1, 4.0]
+                + descending
+                + [4.1, 3.0, 2.0, 0.9]
+                + [3.9, 3.1, 1.9, 1.0]
+            ),
+        }
+    )
+
+
+class TestHDBSCAN:
+    def test_schema(self, well_separated_data):
+        result = hdbscan_cluster(well_separated_data, method="dtw", min_cluster_size=2)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 6
+
+    def test_cluster_dtype(self, well_separated_data):
+        result = hdbscan_cluster(well_separated_data, method="dtw", min_cluster_size=2)
+        assert result["cluster"].dtype == pl.Int64
+
+    def test_finds_clusters(self, well_separated_data):
+        result = hdbscan_cluster(
+            well_separated_data, method="dtw", min_cluster_size=2, min_samples=1
+        )
+        labels = dict(
+            zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False)
+        )
+        # At least some points should be clustered (not all noise)
+        non_noise = {k: v for k, v in labels.items() if v != -1}
+        assert len(non_noise) >= 4, f"Expected clustered points, got {labels}"
+        # A-series should share a cluster, B-series should share a cluster
+        a_labels = {labels[k] for k in ["A1", "A2", "A3"] if labels[k] != -1}
+        b_labels = {labels[k] for k in ["B1", "B2", "B3"] if labels[k] != -1}
+        assert a_labels and b_labels, f"Both groups should have clustered points: {labels}"
+        assert a_labels.isdisjoint(b_labels)
+
+    def test_noise_label(self):
+        """With dissimilar series and high min_cluster_size, everything is noise."""
+        df = pl.DataFrame(
+            {
+                "unique_id": (
+                    ["X"] * 4 + ["Y"] * 4 + ["Z"] * 4
+                    + ["W"] * 4 + ["V"] * 4 + ["U"] * 4
+                ),
+                "y": (
+                    [1.0, 2.0, 3.0, 4.0]
+                    + [10.0, 20.0, 30.0, 40.0]
+                    + [100.0, 200.0, 300.0, 400.0]
+                    + [5.0, 15.0, 25.0, 35.0]
+                    + [50.0, 150.0, 250.0, 350.0]
+                    + [500.0, 1500.0, 2500.0, 3500.0]
+                ),
+            }
+        )
+        result = hdbscan_cluster(df, method="dtw", min_cluster_size=5, min_samples=3)
+        assert all(c == -1 for c in result["cluster"].to_list())
+
+    def test_different_metrics(self, well_separated_data):
+        for metric in ["dtw", "erp", "lcss"]:
+            result = hdbscan_cluster(well_separated_data, method=metric, min_cluster_size=2)
+            assert result.shape[0] == 6
+
+    def test_min_samples_parameter(self, well_separated_data):
+        result = hdbscan_cluster(
+            well_separated_data, method="dtw", min_cluster_size=2, min_samples=1
+        )
+        assert result.shape[0] == 6
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "ts_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+                "value": [1.0, 2.0, 3.0, 4.0, 1.0, 2.1, 3.0, 4.1, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        result = hdbscan_cluster(
+            df, method="dtw", min_cluster_size=2, id_col="ts_id", target_col="value"
+        )
+        assert "ts_id" in result.columns
+        assert "cluster" in result.columns
+
+    def test_top_level_import(self):
+        from polars_ts import hdbscan_cluster as hc
+
+        assert callable(hc)
+
+
+class TestDBSCAN:
+    def test_schema(self, well_separated_data):
+        result = dbscan_cluster(well_separated_data, method="dtw", eps=2.0, min_samples=2)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 6
+
+    def test_cluster_dtype(self, well_separated_data):
+        result = dbscan_cluster(well_separated_data, method="dtw", eps=2.0, min_samples=2)
+        assert result["cluster"].dtype == pl.Int64
+
+    def test_finds_clusters(self, well_separated_data):
+        result = dbscan_cluster(well_separated_data, method="dtw", eps=2.0, min_samples=2)
+        labels = dict(
+            zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False)
+        )
+        non_noise = {k: v for k, v in labels.items() if v != -1}
+        assert len(non_noise) >= 4, f"Expected clustered points, got {labels}"
+        a_labels = {labels[k] for k in ["A1", "A2", "A3"] if labels[k] != -1}
+        b_labels = {labels[k] for k in ["B1", "B2", "B3"] if labels[k] != -1}
+        assert a_labels and b_labels, f"Both groups should have clustered points: {labels}"
+        assert a_labels.isdisjoint(b_labels)
+
+    def test_all_noise(self):
+        """With tiny eps, all points become noise."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["X"] * 4 + ["Y"] * 4 + ["Z"] * 4,
+                "y": [1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0, 100.0, 200.0, 300.0, 400.0],
+            }
+        )
+        result = dbscan_cluster(df, method="dtw", eps=0.001, min_samples=2)
+        assert all(c == -1 for c in result["cluster"].to_list())
+
+    def test_eps_controls_granularity(self, well_separated_data):
+        """Larger eps should produce fewer or equal clusters (more merging)."""
+        result_small = dbscan_cluster(
+            well_separated_data, method="dtw", eps=0.5, min_samples=2
+        )
+        result_large = dbscan_cluster(
+            well_separated_data, method="dtw", eps=100.0, min_samples=2
+        )
+        n_small = result_small["cluster"].filter(result_small["cluster"] >= 0).n_unique()
+        n_large = result_large["cluster"].filter(result_large["cluster"] >= 0).n_unique()
+        assert n_large <= n_small or n_large <= 1
+
+    def test_different_metrics(self, well_separated_data):
+        for metric in ["dtw", "erp", "lcss"]:
+            result = dbscan_cluster(well_separated_data, method=metric, eps=2.0, min_samples=2)
+            assert result.shape[0] == 6
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "ts_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+                "value": [1.0, 2.0, 3.0, 4.0, 1.0, 2.1, 3.0, 4.1, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        result = dbscan_cluster(
+            df, method="dtw", eps=2.0, min_samples=2, id_col="ts_id", target_col="value"
+        )
+        assert "ts_id" in result.columns
+        assert "cluster" in result.columns
+
+    def test_top_level_import(self):
+        from polars_ts import dbscan_cluster as dc
+
+        assert callable(dc)

--- a/tests/clustering/test_density.py
+++ b/tests/clustering/test_density.py
@@ -11,10 +11,7 @@ def well_separated_data():
     descending = [4.0, 3.0, 2.0, 1.0]
     return pl.DataFrame(
         {
-            "unique_id": (
-                ["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4
-                + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4
-            ),
+            "unique_id": (["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4 + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4),
             "y": (
                 ascending
                 + [1.0, 2.1, 3.0, 4.1]
@@ -39,12 +36,8 @@ class TestHDBSCAN:
         assert result["cluster"].dtype == pl.Int64
 
     def test_finds_clusters(self, well_separated_data):
-        result = hdbscan_cluster(
-            well_separated_data, method="dtw", min_cluster_size=2, min_samples=1
-        )
-        labels = dict(
-            zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False)
-        )
+        result = hdbscan_cluster(well_separated_data, method="dtw", min_cluster_size=2, min_samples=1)
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
         # At least some points should be clustered (not all noise)
         non_noise = {k: v for k, v in labels.items() if v != -1}
         assert len(non_noise) >= 4, f"Expected clustered points, got {labels}"
@@ -58,10 +51,7 @@ class TestHDBSCAN:
         """With dissimilar series and high min_cluster_size, everything is noise."""
         df = pl.DataFrame(
             {
-                "unique_id": (
-                    ["X"] * 4 + ["Y"] * 4 + ["Z"] * 4
-                    + ["W"] * 4 + ["V"] * 4 + ["U"] * 4
-                ),
+                "unique_id": (["X"] * 4 + ["Y"] * 4 + ["Z"] * 4 + ["W"] * 4 + ["V"] * 4 + ["U"] * 4),
                 "y": (
                     [1.0, 2.0, 3.0, 4.0]
                     + [10.0, 20.0, 30.0, 40.0]
@@ -81,9 +71,7 @@ class TestHDBSCAN:
             assert result.shape[0] == 6
 
     def test_min_samples_parameter(self, well_separated_data):
-        result = hdbscan_cluster(
-            well_separated_data, method="dtw", min_cluster_size=2, min_samples=1
-        )
+        result = hdbscan_cluster(well_separated_data, method="dtw", min_cluster_size=2, min_samples=1)
         assert result.shape[0] == 6
 
     def test_custom_columns(self):
@@ -93,9 +81,7 @@ class TestHDBSCAN:
                 "value": [1.0, 2.0, 3.0, 4.0, 1.0, 2.1, 3.0, 4.1, 4.0, 3.0, 2.0, 1.0],
             }
         )
-        result = hdbscan_cluster(
-            df, method="dtw", min_cluster_size=2, id_col="ts_id", target_col="value"
-        )
+        result = hdbscan_cluster(df, method="dtw", min_cluster_size=2, id_col="ts_id", target_col="value")
         assert "ts_id" in result.columns
         assert "cluster" in result.columns
 
@@ -118,9 +104,7 @@ class TestDBSCAN:
 
     def test_finds_clusters(self, well_separated_data):
         result = dbscan_cluster(well_separated_data, method="dtw", eps=2.0, min_samples=2)
-        labels = dict(
-            zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False)
-        )
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
         non_noise = {k: v for k, v in labels.items() if v != -1}
         assert len(non_noise) >= 4, f"Expected clustered points, got {labels}"
         a_labels = {labels[k] for k in ["A1", "A2", "A3"] if labels[k] != -1}
@@ -141,12 +125,8 @@ class TestDBSCAN:
 
     def test_eps_controls_granularity(self, well_separated_data):
         """Larger eps should produce fewer or equal clusters (more merging)."""
-        result_small = dbscan_cluster(
-            well_separated_data, method="dtw", eps=0.5, min_samples=2
-        )
-        result_large = dbscan_cluster(
-            well_separated_data, method="dtw", eps=100.0, min_samples=2
-        )
+        result_small = dbscan_cluster(well_separated_data, method="dtw", eps=0.5, min_samples=2)
+        result_large = dbscan_cluster(well_separated_data, method="dtw", eps=100.0, min_samples=2)
         n_small = result_small["cluster"].filter(result_small["cluster"] >= 0).n_unique()
         n_large = result_large["cluster"].filter(result_large["cluster"] >= 0).n_unique()
         assert n_large <= n_small or n_large <= 1
@@ -163,9 +143,7 @@ class TestDBSCAN:
                 "value": [1.0, 2.0, 3.0, 4.0, 1.0, 2.1, 3.0, 4.1, 4.0, 3.0, 2.0, 1.0],
             }
         )
-        result = dbscan_cluster(
-            df, method="dtw", eps=2.0, min_samples=2, id_col="ts_id", target_col="value"
-        )
+        result = dbscan_cluster(df, method="dtw", eps=2.0, min_samples=2, id_col="ts_id", target_col="value")
         assert "ts_id" in result.columns
         assert "cluster" in result.columns
 

--- a/tests/clustering/test_density.py
+++ b/tests/clustering/test_density.py
@@ -1,7 +1,9 @@
 import polars as pl
 import pytest
 
-from polars_ts.clustering.density import dbscan_cluster, hdbscan_cluster
+sklearn = pytest.importorskip("sklearn")
+
+from polars_ts.clustering.density import dbscan_cluster, hdbscan_cluster  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Closes #91.

- Add `hdbscan_cluster()` and `dbscan_cluster()` functions that compute pairwise distances via the existing Rust engine and pass the precomputed matrix to scikit-learn's implementations
- New file `polars_ts/clustering/density.py` with shared `_compute_distance_matrix` helper
- Register both functions in `clustering/__init__.py` and top-level `__init__.py` (lazy `__getattr__`)
- Add `clustering` optional dependency (`scikit-learn>=1.3.0`) in `pyproject.toml`
- 16 tests covering schema, noise detection, cluster separation, custom columns, multiple metrics, and top-level imports

## API

```python
from polars_ts import hdbscan_cluster, dbscan_cluster

# HDBSCAN — no need to specify k
labels = hdbscan_cluster(df, method="dtw", min_cluster_size=5, min_samples=3)

# DBSCAN — classic density-based
labels = dbscan_cluster(df, method="dtw", eps=1.5, min_samples=3)

# Both return pl.DataFrame with [unique_id, cluster] (noise = -1)
```

## Test plan

- [x] `uv run pytest tests/clustering/test_density.py -v` — 16/16 pass
- [x] `uv run pytest tests/clustering/ -v` — 76/76 pass (no regressions)
- [x] Schema correctness (columns, dtypes)
- [x] Noise labeling (-1) with all-noise edge cases
- [x] Cluster separation on well-separated synthetic data
- [x] Custom column names (`id_col`, `target_col`)
- [x] Multiple distance metrics (dtw, erp, lcss)
- [x] Top-level import accessibility