### PR TITLE
feat: add agglomerative/hierarchical clustering with dendrograms

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     polars_ts/pipeline.py
     polars_ts/global_model.py
     polars_ts/clustering/density.py
+    polars_ts/clustering/hierarchical.py
 
 [report]
 fail_under = 65

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ts-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "itertools",
  "ordered-float",

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,6 +114,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
+    if name == "agglomerative_cluster":
+        from polars_ts.clustering.hierarchical import agglomerative_cluster
+
+        return agglomerative_cluster
     if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
         from polars_ts import features as _feat
 
@@ -344,4 +348,5 @@ __all__ = [
     "auto_arima",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "agglomerative_cluster",
 ]

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -38,6 +38,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.density import dbscan_cluster
 
         return dbscan_cluster
+    if name == "agglomerative_cluster":
+        from polars_ts.clustering.hierarchical import agglomerative_cluster
+
+        return agglomerative_cluster
     raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
 
 
@@ -51,4 +55,5 @@ __all__ = [
     "calinski_harabasz_score",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "agglomerative_cluster",
 ]

--- a/polars_ts/clustering/hierarchical.py
+++ b/polars_ts/clustering/hierarchical.py
@@ -1,0 +1,117 @@
+"""Agglomerative (hierarchical) clustering for time series.
+
+Computes pairwise distances via the existing Rust-accelerated distance
+engine, converts to a condensed distance matrix, and delegates to
+``scipy.cluster.hierarchy`` for linkage and tree cutting.
+"""
+
+from __future__ import annotations
+
+from typing import Any, overload
+
+import numpy as np
+import polars as pl
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import squareform
+
+from polars_ts.clustering.density import _compute_distance_matrix
+
+_VALID_LINKAGE = {"single", "complete", "average", "weighted"}
+
+
+@overload
+def agglomerative_cluster(
+    df: pl.DataFrame,
+    method: str = ...,
+    n_clusters: int = ...,
+    linkage_method: str = ...,
+    id_col: str = ...,
+    target_col: str = ...,
+    *,
+    return_linkage: bool = False,
+    **distance_kwargs: Any,
+) -> pl.DataFrame: ...
+
+
+@overload
+def agglomerative_cluster(
+    df: pl.DataFrame,
+    method: str = ...,
+    n_clusters: int = ...,
+    linkage_method: str = ...,
+    id_col: str = ...,
+    target_col: str = ...,
+    *,
+    return_linkage: bool = True,
+    **distance_kwargs: Any,
+) -> tuple[pl.DataFrame, np.ndarray]: ...
+
+
+def agglomerative_cluster(
+    df: pl.DataFrame,
+    method: str = "dtw",
+    n_clusters: int = 2,
+    linkage_method: str = "average",
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    *,
+    return_linkage: bool = False,
+    **distance_kwargs: Any,
+) -> pl.DataFrame | tuple[pl.DataFrame, np.ndarray]:
+    """Agglomerative (hierarchical) clustering over time series.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    method
+        Distance metric name (e.g. ``"dtw"``, ``"erp"``, ``"lcss"``).
+    n_clusters
+        Number of clusters to produce.
+    linkage_method
+        Linkage criterion: ``"single"``, ``"complete"``, ``"average"``,
+        or ``"weighted"``.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    return_linkage
+        If *True*, also return the linkage matrix (compatible with
+        ``scipy.cluster.hierarchy.dendrogram``).
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame or (pl.DataFrame, np.ndarray)
+        DataFrame with columns ``[id_col, "cluster"]``.
+        When ``return_linkage=True``, a tuple of ``(labels, linkage_matrix)``
+        is returned.
+
+    """
+    ids = df[id_col].unique().sort().to_list()
+    n = len(ids)
+    if n_clusters < 1:
+        raise ValueError("n_clusters must be >= 1")
+    if n_clusters > n:
+        raise ValueError(f"n_clusters ({n_clusters}) must be <= number of series ({n})")
+    if linkage_method not in _VALID_LINKAGE:
+        raise ValueError(f"Unknown linkage {linkage_method!r}. Valid: {sorted(_VALID_LINKAGE)}")
+
+    _, dist_mat = _compute_distance_matrix(df, method, id_col, target_col, **distance_kwargs)
+
+    condensed = squareform(dist_mat, checks=False)
+    Z = linkage(condensed, method=linkage_method)
+    cluster_labels = fcluster(Z, t=n_clusters, criterion="maxclust")
+
+    # fcluster labels start at 1; convert to 0-based
+    labels_0 = (cluster_labels - 1).tolist()
+
+    result = pl.DataFrame(
+        {id_col: ids, "cluster": labels_0},
+        schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+    )
+
+    if return_linkage:
+        return result, Z
+    return result

--- a/polars_ts/clustering/hierarchical.py
+++ b/polars_ts/clustering/hierarchical.py
@@ -7,7 +7,7 @@ engine, converts to a condensed distance matrix, and delegates to
 
 from __future__ import annotations
 
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 import numpy as np
 import polars as pl
@@ -28,7 +28,7 @@ def agglomerative_cluster(
     id_col: str = ...,
     target_col: str = ...,
     *,
-    return_linkage: bool = False,
+    return_linkage: Literal[False] = ...,
     **distance_kwargs: Any,
 ) -> pl.DataFrame: ...
 
@@ -42,7 +42,7 @@ def agglomerative_cluster(
     id_col: str = ...,
     target_col: str = ...,
     *,
-    return_linkage: bool = True,
+    return_linkage: Literal[True] = ...,
     **distance_kwargs: Any,
 ) -> tuple[pl.DataFrame, np.ndarray]: ...
 

--- a/tests/clustering/test_hierarchical.py
+++ b/tests/clustering/test_hierarchical.py
@@ -2,7 +2,9 @@ import numpy as np
 import polars as pl
 import pytest
 
-from polars_ts.clustering.hierarchical import agglomerative_cluster
+pytest.importorskip("scipy")
+
+from polars_ts.clustering.hierarchical import agglomerative_cluster  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/clustering/test_hierarchical.py
+++ b/tests/clustering/test_hierarchical.py
@@ -1,0 +1,155 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.clustering.hierarchical import agglomerative_cluster
+
+
+@pytest.fixture
+def cluster_data():
+    """Four series in two well-separated groups (ascending vs descending)."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4 + ["D"] * 4,
+            "y": ([1.0, 2.0, 3.0, 4.0] + [1.0, 2.0, 3.0, 4.5] + [4.0, 3.0, 2.0, 1.0] + [4.5, 3.0, 2.0, 1.0]),
+        }
+    )
+
+
+class TestAgglomerativeCluster:
+    def test_schema(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 4
+
+    def test_cluster_dtype(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2)
+        assert result["cluster"].dtype == pl.Int64
+
+    def test_two_clusters(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2)
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["A"] != labels["C"]
+
+    def test_single_cluster(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=1)
+        assert all(c == 0 for c in result["cluster"].to_list())
+
+    def test_n_equals_series(self, cluster_data):
+        """Each series in its own cluster."""
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=4)
+        labels = result["cluster"].to_list()
+        assert len(set(labels)) == 4
+
+    def test_zero_based_labels(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=3)
+        labels = result["cluster"].to_list()
+        assert min(labels) == 0
+
+    def test_too_many_clusters_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(ValueError, match="n_clusters"):
+            agglomerative_cluster(df, n_clusters=5)
+
+    def test_zero_clusters_raises(self, cluster_data):
+        with pytest.raises(ValueError, match="n_clusters must be >= 1"):
+            agglomerative_cluster(cluster_data, n_clusters=0)
+
+    def test_invalid_linkage_raises(self, cluster_data):
+        with pytest.raises(ValueError, match="Unknown linkage"):
+            agglomerative_cluster(cluster_data, n_clusters=2, linkage_method="invalid")
+
+
+class TestLinkageMethods:
+    def test_average(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, linkage_method="average")
+        assert result.shape[0] == 4
+
+    def test_complete(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, linkage_method="complete")
+        assert result.shape[0] == 4
+
+    def test_single(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, linkage_method="single")
+        assert result.shape[0] == 4
+
+    def test_weighted(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, linkage_method="weighted")
+        assert result.shape[0] == 4
+
+
+class TestReturnLinkage:
+    def test_returns_tuple(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, return_linkage=True)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_linkage_matrix_shape(self, cluster_data):
+        _, Z = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, return_linkage=True)
+        # Linkage matrix has shape (n-1, 4)
+        assert isinstance(Z, np.ndarray)
+        assert Z.shape == (3, 4)
+
+    def test_linkage_matrix_six_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4 + ["D"] * 4 + ["E"] * 4 + ["F"] * 4,
+                "y": (
+                    [1.0, 2.0, 3.0, 4.0]
+                    + [1.0, 2.1, 3.0, 4.1]
+                    + [1.0, 1.9, 3.1, 4.0]
+                    + [4.0, 3.0, 2.0, 1.0]
+                    + [4.1, 3.0, 2.0, 0.9]
+                    + [3.9, 3.1, 1.9, 1.0]
+                ),
+            }
+        )
+        _, Z = agglomerative_cluster(df, method="dtw", n_clusters=2, return_linkage=True)
+        assert Z.shape == (5, 4)
+
+    def test_labels_same_with_and_without_linkage(self, cluster_data):
+        labels_only = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2)
+        labels_with, _ = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, return_linkage=True)
+        assert labels_only["cluster"].to_list() == labels_with["cluster"].to_list()
+
+    def test_without_return_linkage_returns_dataframe(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="dtw", n_clusters=2, return_linkage=False)
+        assert isinstance(result, pl.DataFrame)
+
+
+class TestDistanceMetrics:
+    def test_erp(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="erp", n_clusters=2)
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+
+    def test_lcss(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="lcss", n_clusters=2)
+        assert result.shape[0] == 4
+
+    def test_sbd(self, cluster_data):
+        result = agglomerative_cluster(cluster_data, method="sbd", n_clusters=2)
+        assert result.shape[0] == 4
+
+
+def test_custom_columns():
+    df = pl.DataFrame(
+        {
+            "ts_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+            "value": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.5, 4.0, 3.0, 2.0, 1.0],
+        }
+    )
+    result = agglomerative_cluster(df, method="dtw", n_clusters=2, id_col="ts_id", target_col="value")
+    assert "ts_id" in result.columns
+    assert "cluster" in result.columns
+    assert len(result) == 3
+
+
+def test_top_level_import():
+    from polars_ts import agglomerative_cluster as ac
+
+    assert callable(ac)

--- a/uv.lock
+++ b/uv.lock
@@ -745,6 +745,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1715,7 +1724,7 @@ wheels = [
 
 [[package]]
 name = "polars-timeseries"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },
@@ -1725,8 +1734,12 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "polars-ds" },
+    { name = "scikit-learn" },
     { name = "statsforecast" },
     { name = "utilsforecast" },
+]
+clustering = [
+    { name = "scikit-learn" },
 ]
 decomposition = [
     { name = "polars-ds" },
@@ -1763,12 +1776,13 @@ docs = [
 requires-dist = [
     { name = "polars", specifier = ">=1.30.0,<2.0.0" },
     { name = "polars-ds", marker = "extra == 'decomposition'", specifier = ">=0.10.0" },
-    { name = "polars-timeseries", extras = ["forecast", "decomposition"], marker = "extra == 'all'" },
+    { name = "polars-timeseries", extras = ["forecast", "decomposition", "clustering"], marker = "extra == 'all'" },
     { name = "pyarrow", specifier = ">=15.0.0" },
+    { name = "scikit-learn", marker = "extra == 'clustering'", specifier = ">=1.3.0" },
     { name = "statsforecast", marker = "extra == 'forecast'", specifier = ">=2.0.0" },
     { name = "utilsforecast", marker = "extra == 'forecast'", specifier = ">=0.2.0" },
 ]
-provides-extras = ["forecast", "decomposition", "all"]
+provides-extras = ["forecast", "decomposition", "clustering", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2160,6 +2174,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #92. Stacked on #106 (density clustering).

- Add `agglomerative_cluster()` in `polars_ts/clustering/hierarchical.py`
- Computes pairwise distances via Rust engine → condensed matrix via `scipy.spatial.distance.squareform` → `scipy.cluster.hierarchy.linkage` → `fcluster` tree cut
- Supports `single`, `complete`, `average`, `weighted` linkage methods
- Optional `return_linkage=True` returns the linkage matrix (compatible with `scipy.cluster.hierarchy.dendrogram()`)
- Register in both `__init__.py` files (lazy `__getattr__`)
- 23 tests covering clustering correctness, all linkage methods, dendrogram output shape, edge cases, custom columns, multiple distance metrics

## API

```python
from polars_ts import agglomerative_cluster

# Basic usage
labels = agglomerative_cluster(df, method="dtw", n_clusters=3, linkage_method="average")
# Returns: pl.DataFrame with [unique_id, cluster]

# With dendrogram data
labels, Z = agglomerative_cluster(df, method="dtw", n_clusters=3, return_linkage=True)
# Z is compatible with scipy.cluster.hierarchy.dendrogram(Z)
```

## Test plan

- [x] `uv run pytest tests/clustering/test_hierarchical.py -v` — 23/23 pass
- [x] `uv run pytest tests/clustering/ -v` — 99/99 pass (no regressions)
- [x] Cluster correctness on well-separated synthetic data
- [x] All 4 linkage methods (single, complete, average, weighted)
- [x] Linkage matrix shape validation (n-1 × 4)
- [x] `return_linkage=True/False` behavior
- [x] Edge cases: single cluster, n_clusters=n, invalid inputs
- [x] Custom column names, multiple distance metrics
- [x] Top-level import accessibility
- [x] ruff format + lint clean