### PR TITLE
feat: add k-means with DBA (DTW Barycentric Averaging)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,6 +114,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
+    if name == "kmeans_dba":
+        from polars_ts.clustering.kmeans import kmeans_dba
+
+        return kmeans_dba
+    if name == "TimeSeriesKMeans":
+        from polars_ts.clustering.kmeans import TimeSeriesKMeans
+
+        return TimeSeriesKMeans
     if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
         from polars_ts import features as _feat
 
@@ -344,4 +352,6 @@ __all__ = [
     "auto_arima",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "kmeans_dba",
+    "TimeSeriesKMeans",
 ]

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -38,6 +38,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.density import dbscan_cluster
 
         return dbscan_cluster
+    if name == "kmeans_dba":
+        from polars_ts.clustering.kmeans import kmeans_dba
+
+        return kmeans_dba
+    if name == "TimeSeriesKMeans":
+        from polars_ts.clustering.kmeans import TimeSeriesKMeans
+
+        return TimeSeriesKMeans
     raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
 
 
@@ -51,4 +59,6 @@ __all__ = [
     "calinski_harabasz_score",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "kmeans_dba",
+    "TimeSeriesKMeans",
 ]

--- a/polars_ts/clustering/dba.py
+++ b/polars_ts/clustering/dba.py
@@ -1,0 +1,132 @@
+"""DTW Barycentric Averaging (DBA) for time series centroid computation.
+
+Implements the iterative averaging algorithm from:
+Petitjean, F. et al. (2011). *A global averaging method for dynamic time
+warping*. Pattern Recognition.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _dtw_alignment_path(s: np.ndarray, t: np.ndarray) -> list[tuple[int, int]]:
+    """Compute full DTW cost matrix and return the optimal alignment path."""
+    n, m = len(s), len(t)
+    cost = np.full((n + 1, m + 1), np.inf)
+    cost[0, 0] = 0.0
+
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            d = (s[i - 1] - t[j - 1]) ** 2
+            cost[i, j] = d + min(cost[i - 1, j], cost[i, j - 1], cost[i - 1, j - 1])
+
+    # Backtrack from (n, m) to (1, 1) in the 1-indexed cost matrix
+    path: list[tuple[int, int]] = []
+    i, j = n, m
+    while i >= 1 and j >= 1:
+        path.append((i - 1, j - 1))  # convert to 0-indexed
+        if i == 1 and j == 1:
+            break
+        if i == 1:
+            j -= 1
+        elif j == 1:
+            i -= 1
+        else:
+            candidates = (cost[i - 1, j - 1], cost[i - 1, j], cost[i, j - 1])
+            argmin = int(np.argmin(candidates))
+            if argmin == 0:
+                i, j = i - 1, j - 1
+            elif argmin == 1:
+                i -= 1
+            else:
+                j -= 1
+    path.reverse()
+    return path
+
+
+def dba(
+    series: list[np.ndarray],
+    max_iter: int = 30,
+    tol: float = 1e-5,
+    init: np.ndarray | None = None,
+) -> np.ndarray:
+    """Compute the DTW Barycentric Average of a set of time series.
+
+    Parameters
+    ----------
+    series
+        List of 1-D numpy arrays (may differ in length).
+    max_iter
+        Maximum number of refinement iterations.
+    tol
+        Convergence threshold on the mean absolute change.
+    init
+        Initial centroid estimate. If *None*, uses the medoid
+        (series with minimum total DTW distance to all others).
+
+    Returns
+    -------
+    np.ndarray
+        The DBA centroid.
+
+    """
+    if len(series) == 0:
+        return np.array([])
+    if len(series) == 1:
+        return series[0].copy()
+
+    # Initialise centroid
+    if init is not None:
+        centroid = init.copy().astype(np.float64)
+    else:
+        # Use the medoid as initial centroid
+        centroid = _medoid_init(series)
+
+    for _ in range(max_iter):
+        new_centroid = _dba_update(centroid, series)
+        change = np.mean(np.abs(new_centroid - centroid))
+        centroid = new_centroid
+        if change < tol:
+            break
+
+    return centroid
+
+
+def _medoid_init(series: list[np.ndarray]) -> np.ndarray:
+    """Pick the series with minimum total squared DTW distance as init."""
+    n = len(series)
+    if n <= 2:
+        return series[0].copy().astype(np.float64)
+
+    # Approximate: use sum of squared Euclidean distance on truncated series
+    max_len = max(len(s) for s in series)
+    padded = []
+    for s in series:
+        if len(s) < max_len:
+            padded.append(np.pad(s.astype(np.float64), (0, max_len - len(s))))
+        else:
+            padded.append(s.astype(np.float64))
+    stacked = np.array(padded)
+    # Sum of squared distances to all others
+    costs = np.array([np.sum((stacked - stacked[i]) ** 2) for i in range(n)])
+    return padded[int(np.argmin(costs))]
+
+
+def _dba_update(centroid: np.ndarray, series: list[np.ndarray]) -> np.ndarray:
+    """One DBA refinement step: align all series to centroid, average."""
+    c_len = len(centroid)
+    total = np.zeros(c_len)
+    counts = np.zeros(c_len)
+
+    for s in series:
+        path = _dtw_alignment_path(centroid, s)
+        for ci, si in path:
+            total[ci] += s[si]
+            counts[ci] += 1
+
+    # Avoid division by zero
+    mask = counts > 0
+    result = np.zeros(c_len)
+    result[mask] = total[mask] / counts[mask]
+    return result

--- a/polars_ts/clustering/kmeans.py
+++ b/polars_ts/clustering/kmeans.py
@@ -1,0 +1,217 @@
+"""K-Means clustering for time series with DTW Barycentric Averaging (DBA).
+
+Uses DTW-based distances for the assignment step and DBA for the centroid
+update step, producing synthetic centroids that better represent cluster
+averages than medoid-based approaches.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.clustering.dba import dba
+
+
+class TimeSeriesKMeans:
+    """K-Means clustering for time series using DBA centroids.
+
+    Parameters
+    ----------
+    n_clusters
+        Number of clusters. Default 2.
+    metric
+        Distance metric name. Currently only ``"dtw"`` is supported
+        (DBA requires DTW alignment paths). Default ``"dtw"``.
+    max_iter
+        Maximum number of k-means iterations. Default 50.
+    dba_max_iter
+        Maximum DBA refinement iterations per centroid update. Default 30.
+    seed
+        Random seed for initial centroid selection. Default 42.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    """
+
+    def __init__(
+        self,
+        n_clusters: int = 2,
+        metric: str = "dtw",
+        max_iter: int = 50,
+        dba_max_iter: int = 30,
+        seed: int = 42,
+        **distance_kwargs: Any,
+    ) -> None:
+        self.n_clusters = n_clusters
+        self.metric = metric
+        self.max_iter = max_iter
+        self.dba_max_iter = dba_max_iter
+        self.seed = seed
+        self.distance_kwargs = distance_kwargs
+        self.labels_: pl.DataFrame | None = None
+        self.centroids_: list[np.ndarray] = []
+
+    def fit(
+        self,
+        df: pl.DataFrame,
+        id_col: str = "unique_id",
+        target_col: str = "y",
+    ) -> TimeSeriesKMeans:
+        """Fit k-means clustering with DBA centroids.
+
+        Parameters
+        ----------
+        df
+            DataFrame with columns ``id_col`` and ``target_col``.
+        id_col
+            Column identifying each time series.
+        target_col
+            Column with the time series values.
+
+        Returns
+        -------
+        self
+
+        """
+        if self.metric != "dtw":
+            raise ValueError(f"Only metric='dtw' is supported for DBA-based k-means, got {self.metric!r}")
+
+        ids = sorted(df[id_col].unique().cast(pl.String).to_list())
+        n = len(ids)
+        if self.n_clusters < 1:
+            raise ValueError("n_clusters must be >= 1")
+        if self.n_clusters > n:
+            raise ValueError(f"Cannot create {self.n_clusters} clusters from {n} time series")
+
+        # Extract series as numpy arrays
+        series_map: dict[str, np.ndarray] = {}
+        for uid in ids:
+            vals = df.filter(pl.col(id_col).cast(pl.String) == uid)[target_col].to_numpy()
+            series_map[uid] = vals.astype(np.float64)
+
+        series_list = [series_map[uid] for uid in ids]
+
+        # Initialize centroids by picking k random series
+        rng = random.Random(self.seed)
+        init_indices = rng.sample(range(n), self.n_clusters)
+        centroids = [series_list[i].copy() for i in init_indices]
+
+        assignments = [-1] * n
+
+        for _ in range(self.max_iter):
+            # Assignment step: assign each series to nearest centroid
+            new_assignments = self._assign(series_list, centroids)
+
+            # Check convergence
+            if new_assignments == assignments:
+                break
+            assignments = new_assignments
+
+            # Update centroids via DBA
+            centroids = self._update_centroids(series_list, assignments)
+
+        self.centroids_ = centroids
+        self.labels_ = pl.DataFrame(
+            {id_col: ids, "cluster": assignments},
+            schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+        )
+        return self
+
+    def _assign(
+        self,
+        series_list: list[np.ndarray],
+        centroids: list[np.ndarray],
+    ) -> list[int]:
+        """Assign each series to the nearest centroid using DTW distance."""
+        assignments = []
+        for s in series_list:
+            best_cluster = 0
+            best_dist = float("inf")
+            for ci, c in enumerate(centroids):
+                d = self._dtw_distance(s, c)
+                if d < best_dist:
+                    best_dist = d
+                    best_cluster = ci
+            assignments.append(best_cluster)
+        return assignments
+
+    @staticmethod
+    def _dtw_distance(s: np.ndarray, t: np.ndarray) -> float:
+        """Compute DTW distance between two series."""
+        n, m = len(s), len(t)
+        cost = np.full((n + 1, m + 1), np.inf)
+        cost[0, 0] = 0.0
+        for i in range(1, n + 1):
+            for j in range(1, m + 1):
+                d = (s[i - 1] - t[j - 1]) ** 2
+                cost[i, j] = d + min(cost[i - 1, j], cost[i, j - 1], cost[i - 1, j - 1])
+        return float(cost[n, m])
+
+    def _update_centroids(
+        self,
+        series_list: list[np.ndarray],
+        assignments: list[int],
+    ) -> list[np.ndarray]:
+        """Recompute centroids via DBA."""
+        centroids = []
+        for ci in range(self.n_clusters):
+            members = [series_list[i] for i, a in enumerate(assignments) if a == ci]
+            if members:
+                centroids.append(dba(members, max_iter=self.dba_max_iter))
+            else:
+                # Empty cluster: reinitialize with a random series
+                centroids.append(series_list[random.Random(self.seed + ci).randint(0, len(series_list) - 1)].copy())
+        return centroids
+
+
+def kmeans_dba(
+    df: pl.DataFrame,
+    k: int,
+    method: str = "dtw",
+    max_iter: int = 50,
+    seed: int = 42,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    **distance_kwargs: Any,
+) -> pl.DataFrame:
+    """K-Means clustering with DBA centroids (convenience function).
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    k
+        Number of clusters.
+    method
+        Distance metric name (e.g. ``"dtw"``). Default ``"dtw"``.
+    max_iter
+        Maximum k-means iterations.
+    seed
+        Random seed for reproducibility.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+
+    """
+    km = TimeSeriesKMeans(
+        n_clusters=k,
+        metric=method,
+        max_iter=max_iter,
+        seed=seed,
+        **distance_kwargs,
+    )
+    km.fit(df, id_col=id_col, target_col=target_col)
+    assert km.labels_ is not None
+    return km.labels_

--- a/tests/clustering/test_kmeans.py
+++ b/tests/clustering/test_kmeans.py
@@ -1,0 +1,272 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.clustering.dba import dba
+from polars_ts.clustering.kmeans import TimeSeriesKMeans, kmeans_dba
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cluster_data():
+    """Four series in two well-separated groups (ascending vs descending)."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 6 + ["B"] * 6 + ["C"] * 6 + ["D"] * 6,
+            "y": (
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]  # ascending A
+                + [1.1, 2.1, 3.1, 4.1, 5.1, 6.1]  # ascending B
+                + [6.0, 5.0, 4.0, 3.0, 2.0, 1.0]  # descending C
+                + [6.1, 5.1, 4.1, 3.1, 2.1, 1.1]  # descending D
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def three_cluster_data():
+    """Six series in three groups."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 8 + ["B"] * 8 + ["C"] * 8 + ["D"] * 8 + ["E"] * 8 + ["F"] * 8,
+            "y": (
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]  # ascending A
+                + [1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1]  # ascending B
+                + [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]  # descending C
+                + [8.1, 7.1, 6.1, 5.1, 4.1, 3.1, 2.1, 1.1]  # descending D
+                + [1.0, 8.0, 1.0, 8.0, 1.0, 8.0, 1.0, 8.0]  # zigzag E
+                + [1.1, 7.9, 1.1, 7.9, 1.1, 7.9, 1.1, 7.9]  # zigzag F
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# DBA unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDBA:
+    def test_identical_series_returns_same(self):
+        """DBA of identical series should return the same series."""
+        s = np.array([1.0, 2.0, 3.0, 4.0])
+        result = dba([s, s.copy(), s.copy()])
+        np.testing.assert_allclose(result, s, atol=1e-10)
+
+    def test_two_series_average(self):
+        """DBA of two aligned series produces a reasonable centroid."""
+        s1 = np.array([0.0, 2.0, 4.0])
+        s2 = np.array([2.0, 4.0, 6.0])
+        result = dba([s1, s2])
+        assert result.shape == (3,)
+        # Centroid should be between the two series (element-wise)
+        assert np.all(result >= s1.min())
+        assert np.all(result <= s2.max())
+
+    def test_single_series(self):
+        """DBA of a single series returns a copy."""
+        s = np.array([1.0, 2.0, 3.0])
+        result = dba([s])
+        np.testing.assert_array_equal(result, s)
+        assert result is not s  # must be a copy
+
+    def test_empty_list(self):
+        """DBA of empty list returns empty array."""
+        result = dba([])
+        assert len(result) == 0
+
+    def test_convergence(self):
+        """DBA should converge within max_iter."""
+        rng = np.random.default_rng(0)
+        series = [rng.standard_normal(10) for _ in range(5)]
+        result = dba(series, max_iter=100)
+        assert result.shape == (10,)
+
+    def test_unequal_length_series(self):
+        """DBA handles series of different lengths."""
+        s1 = np.array([1.0, 2.0, 3.0])
+        s2 = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = dba([s1, s2])
+        # Result length matches the medoid init (longer series)
+        assert len(result) > 0
+
+    def test_custom_init(self):
+        """DBA with a custom initial centroid."""
+        s1 = np.array([1.0, 2.0, 3.0])
+        s2 = np.array([3.0, 4.0, 5.0])
+        init = np.array([2.0, 3.0, 4.0])
+        result = dba([s1, s2], init=init)
+        np.testing.assert_allclose(result, [2.0, 3.0, 4.0], atol=1e-10)
+
+    def test_alignment_path_no_negative_indices(self):
+        """DTW alignment path should never produce negative indices."""
+        from polars_ts.clustering.dba import _dtw_alignment_path
+
+        s = np.array([1.0, 2.0])
+        t = np.array([1.0, 2.0, 3.0, 4.0])
+        path = _dtw_alignment_path(s, t)
+        for ci, si in path:
+            assert ci >= 0, f"Negative centroid index: {ci}"
+            assert si >= 0, f"Negative series index: {si}"
+        # Path must start at (0,0) and end at (n-1, m-1)
+        assert path[0] == (0, 0)
+        assert path[-1] == (len(s) - 1, len(t) - 1)
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesKMeans class tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimeSeriesKMeans:
+    def test_fit_returns_self(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=10)
+        result = km.fit(cluster_data)
+        assert result is km
+
+    def test_labels_shape(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=10)
+        km.fit(cluster_data)
+        assert km.labels_ is not None
+        assert km.labels_.shape[0] == 4
+        assert "unique_id" in km.labels_.columns
+        assert "cluster" in km.labels_.columns
+
+    def test_centroids_count(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=10)
+        km.fit(cluster_data)
+        assert len(km.centroids_) == 2
+
+    def test_similar_series_grouped(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=50, seed=42)
+        km.fit(cluster_data)
+        labels = dict(zip(km.labels_["unique_id"].to_list(), km.labels_["cluster"].to_list(), strict=False))
+        # A and B are ascending, C and D are descending
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["A"] != labels["C"]
+
+    def test_single_cluster(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=1, max_iter=10)
+        km.fit(cluster_data)
+        labels = km.labels_["cluster"].to_list()
+        assert all(label == 0 for label in labels)
+
+    def test_too_many_clusters_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        km = TimeSeriesKMeans(n_clusters=5)
+        with pytest.raises(ValueError, match="Cannot create"):
+            km.fit(df)
+
+    def test_seed_reproducibility(self, cluster_data):
+        km1 = TimeSeriesKMeans(n_clusters=2, max_iter=20, seed=123)
+        km1.fit(cluster_data)
+        km2 = TimeSeriesKMeans(n_clusters=2, max_iter=20, seed=123)
+        km2.fit(cluster_data)
+        assert km1.labels_["cluster"].to_list() == km2.labels_["cluster"].to_list()
+
+    def test_centroids_are_valid_arrays(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=10)
+        km.fit(cluster_data)
+        for c in km.centroids_:
+            assert isinstance(c, np.ndarray)
+            assert len(c) == 6  # same length as input series
+            assert np.all(np.isfinite(c))
+
+    def test_three_clusters(self, three_cluster_data):
+        km = TimeSeriesKMeans(n_clusters=3, max_iter=50, seed=42)
+        km.fit(three_cluster_data)
+        assert km.labels_ is not None
+        assert km.labels_["cluster"].n_unique() == 3
+        labels = dict(zip(km.labels_["unique_id"].to_list(), km.labels_["cluster"].to_list(), strict=False))
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["E"] == labels["F"]
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "series_id": ["X"] * 4 + ["Y"] * 4,
+                "value": [1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=10)
+        km.fit(df, id_col="series_id", target_col="value")
+        assert km.labels_ is not None
+        assert "series_id" in km.labels_.columns
+
+    def test_unsupported_metric_raises(self, cluster_data):
+        km = TimeSeriesKMeans(n_clusters=2, metric="erp")
+        with pytest.raises(ValueError, match="Only metric='dtw'"):
+            km.fit(cluster_data)
+
+    def test_identical_series_same_cluster(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+                "y": [1.0, 2.0, 3.0, 4.0] * 2 + [4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        km = TimeSeriesKMeans(n_clusters=2, max_iter=20)
+        km.fit(df)
+        labels = dict(zip(km.labels_["unique_id"].to_list(), km.labels_["cluster"].to_list(), strict=False))
+        assert labels["A"] == labels["B"]
+
+
+# ---------------------------------------------------------------------------
+# kmeans_dba convenience function tests
+# ---------------------------------------------------------------------------
+
+
+class TestKmeansDbaFunction:
+    def test_returns_dataframe(self, cluster_data):
+        result = kmeans_dba(cluster_data, k=2, max_iter=10)
+        assert isinstance(result, pl.DataFrame)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 4
+
+    def test_correct_clustering(self, cluster_data):
+        result = kmeans_dba(cluster_data, k=2, max_iter=50, seed=42)
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["A"] != labels["C"]
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "ts_id": ["X"] * 4 + ["Y"] * 4,
+                "val": [1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        result = kmeans_dba(df, k=2, max_iter=10, id_col="ts_id", target_col="val")
+        assert "ts_id" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# Top-level import tests
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_import_kmeans_dba():
+    from polars_ts import kmeans_dba as fn
+
+    assert callable(fn)
+
+
+def test_top_level_import_timeseries_kmeans():
+    from polars_ts import TimeSeriesKMeans as cls
+
+    assert cls is not None
+
+
+def test_clustering_module_import():
+    from polars_ts.clustering import TimeSeriesKMeans as cls
+    from polars_ts.clustering import kmeans_dba as fn
+
+    assert callable(fn)
+    assert cls is not None


### PR DESCRIPTION
## Summary

Closes #93.

- Add DTW Barycentric Averaging (DBA) centroid computation in `polars_ts/clustering/dba.py`
- Add `TimeSeriesKMeans` class and `kmeans_dba()` convenience function in `polars_ts/clustering/kmeans.py`
- Register in both `__init__.py` files (lazy `__getattr__`)
- 26 tests covering DBA correctness, clustering quality, seed reproducibility, edge cases, alignment path validation, and imports

## API

```python
from polars_ts import kmeans_dba, TimeSeriesKMeans

# Function API
labels = kmeans_dba(df, k=3, max_iter=50, seed=42)
# Returns: pl.DataFrame with [unique_id, cluster]

# Class API
km = TimeSeriesKMeans(n_clusters=3, metric="dtw", max_iter=50)
km.fit(df)
km.labels_      # pl.DataFrame with [unique_id, cluster]
km.centroids_   # list[np.ndarray] — DBA-averaged centroids
```

## Test plan

- [x] `uv run pytest tests/clustering/test_kmeans.py -v` — 26/26 pass
- [x] `uv run pytest tests/clustering/ -v` — full clustering suite passes (no regressions)
- [x] DBA of identical series returns the same series
- [x] DBA convergence within max_iter
- [x] DTW alignment path produces no negative indices (edge case with unequal lengths)
- [x] Well-separated data clusters correctly (2 and 3 clusters)
- [x] Seed reproducibility
- [x] Custom column names
- [x] Unsupported metric raises ValueError
- [x] Top-level and module-level imports work
- [x] mypy clean, ruff clean