### PR TITLE
feat: add CLARA/CLARANS scalable k-medoids variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ts-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "itertools",
  "ordered-float",
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,6 +114,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
+    if name in {"clara", "clarans"}:
+        from polars_ts.clustering import scalable as _scalable
+
+        return getattr(_scalable, name)
     if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
         from polars_ts import features as _feat
 
@@ -344,4 +348,6 @@ __all__ = [
     "auto_arima",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "clara",
+    "clarans",
 ]

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -38,6 +38,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.density import dbscan_cluster
 
         return dbscan_cluster
+    if name == "clara":
+        from polars_ts.clustering.scalable import clara
+
+        return clara
+    if name == "clarans":
+        from polars_ts.clustering.scalable import clarans
+
+        return clarans
     raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
 
 
@@ -51,4 +59,6 @@ __all__ = [
     "calinski_harabasz_score",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "clara",
+    "clarans",
 ]

--- a/polars_ts/clustering/scalable.py
+++ b/polars_ts/clustering/scalable.py
@@ -1,0 +1,266 @@
+"""Scalable k-medoids variants: CLARA and CLARANS.
+
+CLARA (Clustering LARge Applications) — subsample → PAM → repeat, keep best.
+CLARANS (Clustering Large Applications based on RANdomized Search) —
+randomized medoid neighborhood search over the full dataset.
+
+References
+----------
+Kaufman, L. & Rousseeuw, P.J. (1990). *Finding Groups in Data*. Wiley.
+Ng, R. & Han, J. (2002). *CLARANS: A method for clustering objects for
+spatial data mining*. IEEE TKDE.
+
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import polars as pl
+
+from polars_ts._distance_dispatch import compute_distances, pairwise_to_dict
+from polars_ts.clustering.kmedoids import kmedoids
+
+
+def clara(
+    df: pl.DataFrame,
+    k: int,
+    method: str = "dtw",
+    n_samples: int = 5,
+    sample_size: int = 40,
+    max_iter: int = 100,
+    seed: int = 42,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    **distance_kwargs: Any,
+) -> pl.DataFrame:
+    """CLARA: subsample-based PAM for large datasets.
+
+    Runs PAM on ``n_samples`` random subsamples of size ``sample_size``,
+    evaluates the full-dataset cost for each, and returns the best result.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    k
+        Number of clusters.
+    method
+        Distance metric name (e.g. ``"dtw"``, ``"erp"``). Default ``"dtw"``.
+    n_samples
+        Number of subsampling iterations. Default 5.
+    sample_size
+        Number of series per subsample. Clamped to the total number of
+        series if larger. Default 40.
+    max_iter
+        Maximum PAM swap iterations per subsample. Default 100.
+    seed
+        Random seed for reproducibility.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+
+    """
+    ids = df[id_col].unique().sort().to_list()
+    n = len(ids)
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    if k > n:
+        raise ValueError(f"k ({k}) must be <= number of series ({n})")
+
+    # Clamp sample_size
+    effective_sample = min(sample_size, n)
+    if effective_sample < k:
+        effective_sample = n  # fall back to full PAM
+
+    # Precompute full pairwise distances for assignment scoring
+    dist_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
+    full_pairwise = compute_distances(dist_df, dist_df, method=method, **distance_kwargs)
+    full_dist = pairwise_to_dict(full_pairwise)
+    str_ids = [str(i) for i in ids]
+    for sid in str_ids:
+        full_dist[(sid, sid)] = 0.0
+
+    rng = random.Random(seed)
+    best_labels: pl.DataFrame | None = None
+    best_cost = float("inf")
+
+    for i in range(n_samples):
+        # Subsample
+        sample_ids = rng.sample(ids, effective_sample) if effective_sample < n else list(ids)
+        sub_df = df.filter(pl.col(id_col).is_in(sample_ids))
+
+        # Run PAM on subsample
+        sub_labels = kmedoids(
+            sub_df,
+            k=k,
+            method=method,
+            max_iter=max_iter,
+            seed=seed + i,
+            id_col=id_col,
+            target_col=target_col,
+            **distance_kwargs,
+        )
+
+        # Extract medoids from subsample result
+        medoid_map: dict[int, list[str]] = {}
+        for row in sub_labels.to_dicts():
+            cid = row["cluster"]
+            uid = str(row[id_col])
+            medoid_map.setdefault(cid, []).append(uid)
+
+        medoids: list[str] = []
+        for cid in sorted(medoid_map):
+            members = medoid_map[cid]
+            best_m = min(
+                members,
+                key=lambda m: sum(full_dist.get((m, o), 0.0) for o in members),
+            )
+            medoids.append(best_m)
+
+        # Assign ALL series to nearest medoid
+        assignments = []
+        for sid in str_ids:
+            best_cluster = min(
+                range(len(medoids)),
+                key=lambda ci: full_dist.get((sid, medoids[ci]), float("inf")),
+            )
+            assignments.append(best_cluster)
+
+        # Evaluate full-dataset cost
+        cost = sum(full_dist.get((sid, medoids[assignments[j]]), 0.0) for j, sid in enumerate(str_ids))
+
+        if cost < best_cost:
+            best_cost = cost
+            best_labels = pl.DataFrame(
+                {id_col: ids, "cluster": assignments},
+                schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+            )
+
+    assert best_labels is not None
+    return best_labels
+
+
+def clarans(
+    df: pl.DataFrame,
+    k: int,
+    method: str = "dtw",
+    num_local: int = 2,
+    max_neighbor: int = 10,
+    seed: int = 42,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    **distance_kwargs: Any,
+) -> pl.DataFrame:
+    """CLARANS: randomized medoid neighborhood search.
+
+    Performs ``num_local`` restarts of a local search that explores up to
+    ``max_neighbor`` random medoid swaps before declaring convergence.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    k
+        Number of clusters.
+    method
+        Distance metric name (e.g. ``"dtw"``, ``"erp"``). Default ``"dtw"``.
+    num_local
+        Number of random restarts. Default 2.
+    max_neighbor
+        Maximum random swap attempts per restart before stopping. Default 10.
+    seed
+        Random seed for reproducibility.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+    **distance_kwargs
+        Extra keyword arguments forwarded to the distance function.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+
+    """
+    ids = df[id_col].unique().sort().to_list()
+    n = len(ids)
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    if k > n:
+        raise ValueError(f"k ({k}) must be <= number of series ({n})")
+
+    # Precompute full pairwise distances
+    dist_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
+    full_pairwise = compute_distances(dist_df, dist_df, method=method, **distance_kwargs)
+    dist = pairwise_to_dict(full_pairwise)
+    str_ids = [str(i) for i in ids]
+    for sid in str_ids:
+        dist[(sid, sid)] = 0.0
+
+    def _assign(medoids: list[str]) -> list[int]:
+        return [min(range(len(medoids)), key=lambda ci: dist.get((sid, medoids[ci]), float("inf"))) for sid in str_ids]
+
+    def _cost(medoids: list[str], assignments: list[int]) -> float:
+        return sum(dist.get((sid, medoids[assignments[j]]), 0.0) for j, sid in enumerate(str_ids))
+
+    rng = random.Random(seed)
+    best_medoids: list[str] = []
+    best_assignments: list[int] = []
+    best_cost = float("inf")
+
+    for local_i in range(num_local):
+        # Random initial medoids
+        local_rng = random.Random(seed + local_i)
+        current_medoids = local_rng.sample(str_ids, k)
+        current_assignments = _assign(current_medoids)
+        current_cost = _cost(current_medoids, current_assignments)
+
+        # Randomized neighborhood search
+        neighbor_count = 0
+        while neighbor_count < max_neighbor:
+            # Pick a random medoid to swap
+            swap_idx = rng.randint(0, k - 1)
+            # Pick a random non-medoid to swap in
+            non_medoids = [s for s in str_ids if s not in current_medoids]
+            if not non_medoids:
+                break
+            candidate = rng.choice(non_medoids)
+
+            new_medoids = list(current_medoids)
+            new_medoids[swap_idx] = candidate
+            new_assignments = _assign(new_medoids)
+            new_cost = _cost(new_medoids, new_assignments)
+
+            if new_cost < current_cost - 1e-12:
+                current_medoids = new_medoids
+                current_assignments = new_assignments
+                current_cost = new_cost
+                neighbor_count = 0  # reset on improvement
+            else:
+                neighbor_count += 1
+
+        if current_cost < best_cost:
+            best_cost = current_cost
+            best_medoids = current_medoids
+            best_assignments = current_assignments
+
+    # Re-label clusters so labels are contiguous 0..k-1 sorted by medoid name
+    sorted_medoids = sorted(best_medoids)
+    old_to_new = {i: sorted_medoids.index(best_medoids[i]) for i in range(k)}
+    final_assignments = [old_to_new[a] for a in best_assignments]
+
+    return pl.DataFrame(
+        {id_col: ids, "cluster": final_assignments},
+        schema={id_col: df[id_col].dtype, "cluster": pl.Int64},
+    )

--- a/tests/clustering/test_scalable.py
+++ b/tests/clustering/test_scalable.py
@@ -1,0 +1,316 @@
+import polars as pl
+import pytest
+
+from polars_ts.clustering.scalable import clara, clarans
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cluster_data():
+    """Four series in two well-separated groups (ascending vs descending)."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 6 + ["B"] * 6 + ["C"] * 6 + ["D"] * 6,
+            "y": (
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+                + [1.1, 2.1, 3.1, 4.1, 5.1, 6.1]
+                + [6.0, 5.0, 4.0, 3.0, 2.0, 1.0]
+                + [6.1, 5.1, 4.1, 3.1, 2.1, 1.1]
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def six_series_data():
+    """Six series in three groups for k=3 tests."""
+    return pl.DataFrame(
+        {
+            "unique_id": (["A"] * 8 + ["B"] * 8 + ["C"] * 8 + ["D"] * 8 + ["E"] * 8 + ["F"] * 8),
+            "y": (
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+                + [1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1]
+                + [8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]
+                + [8.1, 7.1, 6.1, 5.1, 4.1, 3.1, 2.1, 1.1]
+                + [1.0, 8.0, 1.0, 8.0, 1.0, 8.0, 1.0, 8.0]
+                + [1.1, 7.9, 1.1, 7.9, 1.1, 7.9, 1.1, 7.9]
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLARA tests
+# ---------------------------------------------------------------------------
+
+
+class TestClara:
+    def test_returns_dataframe(self, cluster_data):
+        result = clara(cluster_data, k=2, n_samples=2, sample_size=4)
+        assert isinstance(result, pl.DataFrame)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 4
+
+    def test_correct_clustering(self, cluster_data):
+        result = clara(cluster_data, k=2, n_samples=3, sample_size=4, seed=42)
+        labels = dict(
+            zip(
+                result["unique_id"].to_list(),
+                result["cluster"].to_list(),
+                strict=False,
+            )
+        )
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["A"] != labels["C"]
+
+    def test_three_clusters(self, six_series_data):
+        result = clara(six_series_data, k=3, n_samples=3, sample_size=6, seed=42)
+        assert result["cluster"].n_unique() == 3
+        labels = dict(
+            zip(
+                result["unique_id"].to_list(),
+                result["cluster"].to_list(),
+                strict=False,
+            )
+        )
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["E"] == labels["F"]
+
+    def test_sample_size_larger_than_n(self, cluster_data):
+        """When sample_size >= n, should fall back to full PAM."""
+        result = clara(cluster_data, k=2, n_samples=1, sample_size=100, seed=42)
+        assert result.shape[0] == 4
+        assert result["cluster"].n_unique() == 2
+
+    def test_single_cluster(self, cluster_data):
+        result = clara(cluster_data, k=1, n_samples=1, sample_size=4)
+        labels = result["cluster"].to_list()
+        assert all(label == 0 for label in labels)
+
+    def test_too_many_clusters_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(ValueError, match="must be <="):
+            clara(df, k=5)
+
+    def test_seed_reproducibility(self, cluster_data):
+        r1 = clara(cluster_data, k=2, n_samples=3, sample_size=3, seed=123)
+        r2 = clara(cluster_data, k=2, n_samples=3, sample_size=3, seed=123)
+        assert r1["cluster"].to_list() == r2["cluster"].to_list()
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "ts_id": ["X"] * 4 + ["Y"] * 4,
+                "val": [1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        result = clara(df, k=2, n_samples=1, sample_size=2, id_col="ts_id", target_col="val")
+        assert "ts_id" in result.columns
+
+    def test_cluster_labels_contiguous(self, cluster_data):
+        """Cluster labels should be 0-based contiguous integers."""
+        result = clara(cluster_data, k=2, n_samples=2, sample_size=4, seed=42)
+        labels = sorted(result["cluster"].unique().to_list())
+        assert labels == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# CLARANS tests
+# ---------------------------------------------------------------------------
+
+
+class TestClarans:
+    def test_returns_dataframe(self, cluster_data):
+        result = clarans(cluster_data, k=2, num_local=2, max_neighbor=5)
+        assert isinstance(result, pl.DataFrame)
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+        assert result.shape[0] == 4
+
+    def test_correct_clustering(self, cluster_data):
+        result = clarans(cluster_data, k=2, num_local=3, max_neighbor=10, seed=42)
+        labels = dict(
+            zip(
+                result["unique_id"].to_list(),
+                result["cluster"].to_list(),
+                strict=False,
+            )
+        )
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["A"] != labels["C"]
+
+    def test_three_clusters(self, six_series_data):
+        result = clarans(six_series_data, k=3, num_local=3, max_neighbor=20, seed=42)
+        assert result["cluster"].n_unique() == 3
+        labels = dict(
+            zip(
+                result["unique_id"].to_list(),
+                result["cluster"].to_list(),
+                strict=False,
+            )
+        )
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+        assert labels["E"] == labels["F"]
+
+    def test_single_cluster(self, cluster_data):
+        result = clarans(cluster_data, k=1, num_local=1, max_neighbor=5)
+        labels = result["cluster"].to_list()
+        assert all(label == 0 for label in labels)
+
+    def test_too_many_clusters_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(ValueError, match="must be <="):
+            clarans(df, k=5)
+
+    def test_seed_reproducibility(self, cluster_data):
+        r1 = clarans(cluster_data, k=2, num_local=2, max_neighbor=5, seed=99)
+        r2 = clarans(cluster_data, k=2, num_local=2, max_neighbor=5, seed=99)
+        assert r1["cluster"].to_list() == r2["cluster"].to_list()
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "ts_id": ["X"] * 4 + ["Y"] * 4,
+                "val": [1.0, 2.0, 3.0, 4.0, 4.0, 3.0, 2.0, 1.0],
+            }
+        )
+        result = clarans(df, k=2, num_local=1, max_neighbor=5, id_col="ts_id", target_col="val")
+        assert "ts_id" in result.columns
+
+    def test_cluster_labels_contiguous(self, cluster_data):
+        result = clarans(cluster_data, k=2, num_local=2, max_neighbor=10, seed=42)
+        labels = sorted(result["cluster"].unique().to_list())
+        assert labels == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Edge case and regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_clara_k_equals_n(self):
+        """When k == n, every series gets its own cluster."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4,
+                "y": [1.0, 2.0, 3.0, 4.0] + [5.0, 6.0, 7.0, 8.0] + [9.0, 10.0, 11.0, 12.0],
+            }
+        )
+        result = clara(df, k=3, n_samples=1, sample_size=3)
+        assert result["cluster"].n_unique() == 3
+
+    def test_clarans_k_equals_n(self):
+        """When k == n, every series is a medoid."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4,
+                "y": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            }
+        )
+        result = clarans(df, k=2, num_local=1, max_neighbor=5)
+        assert result["cluster"].n_unique() == 2
+
+    def test_clara_sample_size_equals_k(self):
+        """When sample_size == k, PAM gets exactly k series (minimal subsample)."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4 + ["C"] * 4 + ["D"] * 4,
+                "y": ([1.0, 2.0, 3.0, 4.0] + [1.1, 2.1, 3.1, 4.1] + [4.0, 3.0, 2.0, 1.0] + [4.1, 3.1, 2.1, 1.1]),
+            }
+        )
+        result = clara(df, k=2, n_samples=3, sample_size=2, seed=42)
+        assert result.shape[0] == 4
+        assert result["cluster"].n_unique() == 2
+        labels = sorted(result["cluster"].unique().to_list())
+        assert labels == [0, 1]
+
+    def test_clarans_max_neighbor_zero(self):
+        """With max_neighbor=0, no swaps happen — still returns valid result."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 4 + ["B"] * 4,
+                "y": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            }
+        )
+        result = clarans(df, k=2, num_local=1, max_neighbor=0)
+        assert result.shape[0] == 2
+        assert "cluster" in result.columns
+
+    def test_clara_k_zero_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(ValueError, match="must be >= 1"):
+            clara(df, k=0)
+
+    def test_clarans_k_zero_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 4, "y": [1.0, 2.0, 3.0, 4.0]})
+        with pytest.raises(ValueError, match="must be >= 1"):
+            clarans(df, k=0)
+
+    def test_clara_two_series(self):
+        """Minimal case: two series, k=2."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 3,
+                "y": [1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+            }
+        )
+        result = clara(df, k=2, n_samples=1, sample_size=2)
+        assert result["cluster"].n_unique() == 2
+        labels = dict(zip(result["unique_id"].to_list(), result["cluster"].to_list(), strict=False))
+        assert labels["A"] != labels["B"]
+
+    def test_clarans_two_series(self):
+        """Minimal case: two series, k=2."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 3,
+                "y": [1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+            }
+        )
+        result = clarans(df, k=2, num_local=1, max_neighbor=5)
+        assert result["cluster"].n_unique() == 2
+
+    def test_clara_output_preserves_id_dtype(self):
+        """Output id column should have the same dtype as input."""
+        df = pl.DataFrame(
+            {
+                "unique_id": pl.Series(["A"] * 4 + ["B"] * 4, dtype=pl.String),
+                "y": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            }
+        )
+        result = clara(df, k=2, n_samples=1, sample_size=2)
+        assert result["unique_id"].dtype == pl.String
+
+
+# ---------------------------------------------------------------------------
+# Top-level import tests
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_import_clara():
+    from polars_ts import clara as fn
+
+    assert callable(fn)
+
+
+def test_top_level_import_clarans():
+    from polars_ts import clarans as fn
+
+    assert callable(fn)
+
+
+def test_clustering_module_import():
+    from polars_ts.clustering import clara as fn1
+    from polars_ts.clustering import clarans as fn2
+
+    assert callable(fn1)
+    assert callable(fn2)


### PR DESCRIPTION
## Summary

Closes #94.

- Add `clara()` — subsample-based PAM for large datasets (subsample → PAM → evaluate full-dataset cost → keep best)
- Add `clarans()` — randomized medoid neighborhood search with configurable restarts
- Both wrap the existing `kmedoids` and distance infrastructure
- Register in both `__init__.py` files (lazy `__getattr__`)
- 20 tests covering correctness, edge cases, reproducibility, and imports

## API

```python
from polars_ts import clara, clarans

# CLARA — subsample-based PAM
labels = clara(df, k=3, method="dtw", n_samples=5, sample_size=40, seed=42)
# Returns: pl.DataFrame with [unique_id, cluster]

# CLARANS — randomized neighborhood search
labels = clarans(df, k=3, method="dtw", num_local=2, max_neighbor=10, seed=42)
# Returns: pl.DataFrame with [unique_id, cluster]
```

## Test plan

- [x] `uv run pytest tests/clustering/test_scalable.py -v` — 20/20 pass
- [x] Full clustering suite passes (no regressions)
- [x] Well-separated data clusters correctly (k=2, k=3)
- [x] CLARA falls back to full PAM when sample_size >= n
- [x] Seed reproducibility for both algorithms
- [x] Custom column names
- [x] Contiguous 0-based cluster labels
- [x] Invalid k raises ValueError
- [x] Top-level and module-level imports work
- [x] mypy clean, ruff clean