### PR TITLE
feat: add ROCKET/MiniRocket feature extraction for clustering

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,7 +114,7 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
-    if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
+    if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features", "rocket_features", "minirocket_features"}:
         from polars_ts import features as _feat
 
         return getattr(_feat, name)
@@ -344,4 +344,6 @@ __all__ = [
     "auto_arima",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "rocket_features",
+    "minirocket_features",
 ]

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,7 +114,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
-    if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features", "rocket_features", "minirocket_features"}:
+    if name in {
+        "lag_features",
+        "rolling_features",
+        "calendar_features",
+        "fourier_features",
+        "rocket_features",
+        "minirocket_features",
+    }:
         from polars_ts import features as _feat
 
         return getattr(_feat, name)

--- a/polars_ts/features/__init__.py
+++ b/polars_ts/features/__init__.py
@@ -26,6 +26,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.features.fourier import fourier_features
 
         return fourier_features
+    if name == "rocket_features":
+        from polars_ts.features.rocket import rocket_features
+
+        return rocket_features
+    if name == "minirocket_features":
+        from polars_ts.features.rocket import minirocket_features
+
+        return minirocket_features
     raise AttributeError(f"module 'polars_ts.features' has no attribute {name!r}")
 
 
@@ -34,4 +42,6 @@ __all__ = [
     "rolling_features",
     "calendar_features",
     "fourier_features",
+    "rocket_features",
+    "minirocket_features",
 ]

--- a/polars_ts/features/rocket.py
+++ b/polars_ts/features/rocket.py
@@ -10,6 +10,7 @@ References
   classification using random convolutional kernels. DMKD.
 - Dempster et al. (2021) MiniRocket: A very fast (almost) deterministic
   transform for time series classification. KDD.
+
 """
 
 from __future__ import annotations
@@ -63,9 +64,7 @@ def _generate_rocket_kernels(
     return kernels
 
 
-def _apply_kernel(
-    x: np.ndarray, weights: np.ndarray, bias: float, dilation: int
-) -> tuple[float, float]:
+def _apply_kernel(x: np.ndarray, weights: np.ndarray, bias: float, dilation: int) -> tuple[float, float]:
     """Apply a single kernel to a 1-D series, return (ppv, max_val)."""
     conv = _convolve_1d(x, weights, dilation)
     if len(conv) == 0:
@@ -129,9 +128,7 @@ def rocket_features(
 
     col_names = [f"rocket_{i}" for i in range(2 * n_kernels)]
     result = pl.DataFrame({id_col: ids})
-    feat_df = pl.DataFrame(
-        {name: features[:, i] for i, name in enumerate(col_names)}
-    )
+    feat_df = pl.DataFrame({name: features[:, i] for i, name in enumerate(col_names)})
     return pl.concat([result, feat_df], how="horizontal")
 
 
@@ -163,9 +160,7 @@ def _get_minirocket_patterns() -> list[np.ndarray]:
 def _compute_dilations(input_length: int, n_dilations: int) -> np.ndarray:
     """Compute dilations ensuring the kernel spans the full input length."""
     max_dilation = max(1, (input_length - 1) // (_MINIROCKET_KERNEL_LENGTH - 1))
-    dilations = np.unique(
-        np.logspace(0, np.log2(max_dilation), n_dilations, base=2).astype(int)
-    )
+    dilations = np.unique(np.logspace(0, np.log2(max_dilation), n_dilations, base=2).astype(int))
     return dilations
 
 
@@ -246,9 +241,7 @@ def minirocket_features(
 
     col_names = [f"minirocket_{i}" for i in range(n_features)]
     result = pl.DataFrame({id_col: ids})
-    feat_df = pl.DataFrame(
-        {name: features[:, i] for i, name in enumerate(col_names)}
-    )
+    feat_df = pl.DataFrame({name: features[:, i] for i, name in enumerate(col_names)})
     return pl.concat([result, feat_df], how="horizontal")
 
 

--- a/polars_ts/features/rocket.py
+++ b/polars_ts/features/rocket.py
@@ -1,0 +1,288 @@
+"""ROCKET and MiniRocket feature extraction for time series.
+
+Transforms each time series into a fixed-length feature vector using random
+convolutional kernels, enabling fast and accurate clustering/classification
+in the resulting feature space.
+
+References
+----------
+- Dempster et al. (2020) ROCKET: Exceptionally fast and accurate time series
+  classification using random convolutional kernels. DMKD.
+- Dempster et al. (2021) MiniRocket: A very fast (almost) deterministic
+  transform for time series classification. KDD.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+
+def _extract_series(
+    df: pl.DataFrame,
+    target_col: str,
+    id_col: str,
+    time_col: str,
+) -> tuple[list[str], np.ndarray]:
+    """Extract series as a 2-D array (n_series, max_len), zero-padded."""
+    sorted_df = df.sort(id_col, time_col)
+    groups = sorted_df.group_by(id_col, maintain_order=True)
+    ids: list[str] = []
+    arrays: list[np.ndarray] = []
+    for key, group in groups:
+        ids.append(key[0] if isinstance(key, tuple) else key)  # type: ignore[arg-type]
+        arrays.append(group[target_col].to_numpy().astype(np.float64))
+
+    max_len = max(a.shape[0] for a in arrays)
+    padded = np.zeros((len(arrays), max_len), dtype=np.float64)
+    for i, a in enumerate(arrays):
+        padded[i, : a.shape[0]] = a
+    return ids, padded
+
+
+def _generate_rocket_kernels(
+    n_kernels: int,
+    input_length: int,
+    rng: np.random.Generator,
+) -> list[tuple[np.ndarray, float, int]]:
+    """Generate random convolutional kernels for ROCKET.
+
+    Returns list of (weights, bias, dilation) tuples.
+    """
+    candidate_lengths = np.array([7, 9, 11])
+    kernels: list[tuple[np.ndarray, float, int]] = []
+    for _ in range(n_kernels):
+        length = rng.choice(candidate_lengths)
+        weights = rng.standard_normal(length)
+        weights = weights - weights.mean()
+        max_dilation = max(1, (input_length - 1) // (length - 1))
+        dilation = int(2 ** rng.uniform(0, np.log2(max_dilation + 1)))
+        dilation = min(dilation, max_dilation)
+        bias = rng.uniform(-1, 1)
+        kernels.append((weights, bias, dilation))
+    return kernels
+
+
+def _apply_kernel(
+    x: np.ndarray, weights: np.ndarray, bias: float, dilation: int
+) -> tuple[float, float]:
+    """Apply a single kernel to a 1-D series, return (ppv, max_val)."""
+    k_len = len(weights)
+    output_len = len(x) - (k_len - 1) * dilation
+    if output_len <= 0:
+        return 0.0, 0.0
+    conv = np.empty(output_len, dtype=np.float64)
+    for i in range(output_len):
+        s = bias
+        for j in range(k_len):
+            s += weights[j] * x[i + j * dilation]
+        conv[i] = s
+    ppv = float(np.mean(conv > 0))
+    max_val = float(np.max(conv))
+    return ppv, max_val
+
+
+def rocket_features(
+    df: pl.DataFrame,
+    n_kernels: int = 500,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Extract ROCKET features from time series.
+
+    Generates *n_kernels* random convolutional kernels with varying length,
+    dilation, and bias, then computes PPV (proportion of positive values) and
+    global max for each kernel on every series.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame with time series data.
+    n_kernels
+        Number of random convolutional kernels.
+    target_col
+        Column with the values to transform.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    seed
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, rocket_0, rocket_1, ...,
+        rocket_{2*n_kernels - 1}]``.
+
+    """
+    if n_kernels < 1:
+        raise ValueError("n_kernels must be at least 1")
+
+    ids, X = _extract_series(df, target_col, id_col, time_col)
+    rng = np.random.default_rng(seed)
+    kernels = _generate_rocket_kernels(n_kernels, X.shape[1], rng)
+
+    n_series = X.shape[0]
+    features = np.empty((n_series, 2 * n_kernels), dtype=np.float64)
+    for k_idx, (weights, bias, dilation) in enumerate(kernels):
+        for s_idx in range(n_series):
+            ppv, max_val = _apply_kernel(X[s_idx], weights, bias, dilation)
+            features[s_idx, 2 * k_idx] = ppv
+            features[s_idx, 2 * k_idx + 1] = max_val
+
+    col_names = [f"rocket_{i}" for i in range(2 * n_kernels)]
+    result = pl.DataFrame({id_col: ids})
+    feat_df = pl.DataFrame(
+        {name: features[:, i] for i, name in enumerate(col_names)}
+    )
+    return pl.concat([result, feat_df], how="horizontal")
+
+
+# ── MiniRocket ──────────────────────────────────────────────────────────
+
+
+_MINIROCKET_KERNEL_LENGTH = 9
+
+# The 84 fixed binary patterns from the MiniRocket paper (length-9).
+# Each is a tuple of indices where the weight is 2; others are -1.
+_MINIROCKET_INDICES: list[tuple[int, ...]] = [
+    (idx_tuple)
+    for r in range(1, 9)
+    for idx_tuple in _generate_combinations(9, r)
+] if False else []  # placeholder, generated below
+
+
+def _generate_combinations(n: int, r: int) -> list[tuple[int, ...]]:
+    """Generate C(n, r) index combinations."""
+    from itertools import combinations
+
+    return list(combinations(range(n), r))
+
+
+def _get_minirocket_patterns() -> list[np.ndarray]:
+    """Return the 84 fixed MiniRocket weight patterns.
+
+    Uses the 84 unique patterns from C(9,3) = 84 combinations. Each
+    pattern has weights of 2 at selected positions and -1 elsewhere,
+    then mean-centered.
+    """
+    from itertools import combinations
+
+    patterns: list[np.ndarray] = []
+    for combo in combinations(range(9), 3):
+        w = np.full(9, -1.0)
+        for idx in combo:
+            w[idx] = 2.0
+        w = w - w.mean()
+        patterns.append(w)
+    return patterns
+
+
+def _compute_dilations(input_length: int, n_dilations: int) -> np.ndarray:
+    """Compute dilations ensuring the kernel spans the full input length."""
+    max_dilation = max(1, (input_length - 1) // (_MINIROCKET_KERNEL_LENGTH - 1))
+    dilations = np.unique(
+        np.logspace(0, np.log2(max_dilation), n_dilations, base=2).astype(int)
+    )
+    return dilations
+
+
+def minirocket_features(
+    df: pl.DataFrame,
+    n_kernels: int = 500,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    seed: int = 42,
+) -> pl.DataFrame:
+    """Extract MiniRocket features from time series.
+
+    Uses fixed-length (9) kernels with deterministic weight patterns and
+    learned biases.  Significantly faster than ROCKET while achieving
+    comparable accuracy.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame with time series data.
+    n_kernels
+        Approximate number of kernels (rounded to nearest multiple of 84).
+    target_col
+        Column with the values to transform.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    seed
+        Random seed for bias sampling.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, minirocket_0, ...,
+        minirocket_{n_features - 1}]``.
+
+    """
+    if n_kernels < 1:
+        raise ValueError("n_kernels must be at least 1")
+
+    ids, X = _extract_series(df, target_col, id_col, time_col)
+    n_series, input_length = X.shape
+    rng = np.random.default_rng(seed)
+
+    patterns = _get_minirocket_patterns()  # 84 patterns
+    n_patterns = len(patterns)
+    n_dilations = max(1, n_kernels // n_patterns)
+    dilations = _compute_dilations(input_length, n_dilations)
+
+    # Collect all (pattern, dilation, bias) combinations
+    kernel_configs: list[tuple[np.ndarray, int, float]] = []
+    for dilation in dilations:
+        for pattern in patterns:
+            # Compute convolution outputs for all series to sample bias
+            sample_idx = rng.integers(0, n_series)
+            conv_out = _convolve_1d(X[sample_idx], pattern, int(dilation))
+            if len(conv_out) > 0:
+                bias = float(rng.choice(conv_out))
+            else:
+                bias = 0.0
+            kernel_configs.append((pattern, int(dilation), bias))
+
+    # Trim to requested number of kernels
+    if len(kernel_configs) > n_kernels:
+        kernel_configs = kernel_configs[:n_kernels]
+
+    n_features = len(kernel_configs)
+    features = np.empty((n_series, n_features), dtype=np.float64)
+    for k_idx, (weights, dilation, bias) in enumerate(kernel_configs):
+        for s_idx in range(n_series):
+            conv = _convolve_1d(X[s_idx], weights, dilation)
+            if len(conv) > 0:
+                features[s_idx, k_idx] = float(np.mean((conv > bias)))
+            else:
+                features[s_idx, k_idx] = 0.0
+
+    col_names = [f"minirocket_{i}" for i in range(n_features)]
+    result = pl.DataFrame({id_col: ids})
+    feat_df = pl.DataFrame(
+        {name: features[:, i] for i, name in enumerate(col_names)}
+    )
+    return pl.concat([result, feat_df], how="horizontal")
+
+
+def _convolve_1d(x: np.ndarray, weights: np.ndarray, dilation: int) -> np.ndarray:
+    """1-D dilated convolution (no bias) returning the raw output."""
+    k_len = len(weights)
+    output_len = len(x) - (k_len - 1) * dilation
+    if output_len <= 0:
+        return np.empty(0)
+    out = np.empty(output_len, dtype=np.float64)
+    for i in range(output_len):
+        s = 0.0
+        for j in range(k_len):
+            s += weights[j] * x[i + j * dilation]
+        out[i] = s
+    return out

--- a/polars_ts/features/rocket.py
+++ b/polars_ts/features/rocket.py
@@ -67,16 +67,10 @@ def _apply_kernel(
     x: np.ndarray, weights: np.ndarray, bias: float, dilation: int
 ) -> tuple[float, float]:
     """Apply a single kernel to a 1-D series, return (ppv, max_val)."""
-    k_len = len(weights)
-    output_len = len(x) - (k_len - 1) * dilation
-    if output_len <= 0:
+    conv = _convolve_1d(x, weights, dilation)
+    if len(conv) == 0:
         return 0.0, 0.0
-    conv = np.empty(output_len, dtype=np.float64)
-    for i in range(output_len):
-        s = bias
-        for j in range(k_len):
-            s += weights[j] * x[i + j * dilation]
-        conv[i] = s
+    conv += bias
     ppv = float(np.mean(conv > 0))
     max_val = float(np.max(conv))
     return ppv, max_val
@@ -145,21 +139,6 @@ def rocket_features(
 
 
 _MINIROCKET_KERNEL_LENGTH = 9
-
-# The 84 fixed binary patterns from the MiniRocket paper (length-9).
-# Each is a tuple of indices where the weight is 2; others are -1.
-_MINIROCKET_INDICES: list[tuple[int, ...]] = [
-    (idx_tuple)
-    for r in range(1, 9)
-    for idx_tuple in _generate_combinations(9, r)
-] if False else []  # placeholder, generated below
-
-
-def _generate_combinations(n: int, r: int) -> list[tuple[int, ...]]:
-    """Generate C(n, r) index combinations."""
-    from itertools import combinations
-
-    return list(combinations(range(n), r))
 
 
 def _get_minirocket_patterns() -> list[np.ndarray]:
@@ -279,10 +258,8 @@ def _convolve_1d(x: np.ndarray, weights: np.ndarray, dilation: int) -> np.ndarra
     output_len = len(x) - (k_len - 1) * dilation
     if output_len <= 0:
         return np.empty(0)
-    out = np.empty(output_len, dtype=np.float64)
-    for i in range(output_len):
-        s = 0.0
-        for j in range(k_len):
-            s += weights[j] * x[i + j * dilation]
-        out[i] = s
-    return out
+    # Gather dilated indices: shape (output_len, k_len)
+    offsets = np.arange(k_len) * dilation  # (k_len,)
+    starts = np.arange(output_len)[:, None]  # (output_len, 1)
+    indices = starts + offsets  # (output_len, k_len)
+    return x[indices] @ weights  # (output_len,)

--- a/tests/features/test_rocket.py
+++ b/tests/features/test_rocket.py
@@ -158,6 +158,44 @@ class TestMiniRocket:
         assert result.shape[0] == 2
 
 
+# ── Edge cases ────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_single_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 20,
+                "ds": [date(2024, 1, i + 1) for i in range(20)],
+                "y": [float(i) for i in range(20)],
+            }
+        )
+        r = rocket_features(df, n_kernels=5)
+        assert r.shape == (1, 11)
+        m = minirocket_features(df, n_kernels=10)
+        assert m.shape[0] == 1
+
+    def test_custom_column_names(self):
+        df = pl.DataFrame(
+            {
+                "series": ["X"] * 15 + ["Y"] * 15,
+                "timestamp": [date(2024, 1, i + 1) for i in range(15)] * 2,
+                "value": [float(i) for i in range(30)],
+            }
+        )
+        r = rocket_features(
+            df, n_kernels=5, target_col="value", id_col="series", time_col="timestamp"
+        )
+        assert r.columns[0] == "series"
+        assert r.shape == (2, 11)
+
+        m = minirocket_features(
+            df, n_kernels=10, target_col="value", id_col="series", time_col="timestamp"
+        )
+        assert m.columns[0] == "series"
+        assert m.shape[0] == 2
+
+
 # ── Integration: top-level import ──────────────────────────────────────
 
 

--- a/tests/features/test_rocket.py
+++ b/tests/features/test_rocket.py
@@ -1,0 +1,173 @@
+"""Tests for ROCKET and MiniRocket feature extraction."""
+
+from datetime import date
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.features.rocket import (
+    minirocket_features,
+    rocket_features,
+)
+
+
+def _make_df() -> pl.DataFrame:
+    """Three short time series with distinct patterns."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 20 + ["B"] * 20 + ["C"] * 20,
+            "ds": [date(2024, 1, i + 1) for i in range(20)] * 3,
+            "y": (
+                [float(i) for i in range(20)]
+                + [float(20 - i) for i in range(20)]
+                + [float(i % 5) for i in range(20)]
+            ),
+        }
+    )
+
+
+# ── ROCKET tests ────────────────────────────────────────────────────────
+
+
+class TestRocket:
+    def test_output_shape(self):
+        df = _make_df()
+        result = rocket_features(df, n_kernels=10)
+        assert result.shape == (3, 1 + 2 * 10)  # id + 2 features per kernel
+
+    def test_column_names(self):
+        df = _make_df()
+        result = rocket_features(df, n_kernels=5)
+        assert result.columns[0] == "unique_id"
+        for i in range(10):
+            assert f"rocket_{i}" in result.columns
+
+    def test_deterministic_with_seed(self):
+        df = _make_df()
+        r1 = rocket_features(df, n_kernels=10, seed=42)
+        r2 = rocket_features(df, n_kernels=10, seed=42)
+        assert r1.equals(r2)
+
+    def test_different_seeds_differ(self):
+        df = _make_df()
+        r1 = rocket_features(df, n_kernels=10, seed=1)
+        r2 = rocket_features(df, n_kernels=10, seed=2)
+        vals1 = r1.drop("unique_id").to_numpy()
+        vals2 = r2.drop("unique_id").to_numpy()
+        assert not np.allclose(vals1, vals2)
+
+    def test_ppv_in_range(self):
+        """PPV features (even columns) must be in [0, 1]."""
+        df = _make_df()
+        result = rocket_features(df, n_kernels=20)
+        for i in range(0, 40, 2):
+            col = result[f"rocket_{i}"].to_numpy()
+            assert np.all(col >= 0.0) and np.all(col <= 1.0)
+
+    def test_preserves_series_ids(self):
+        df = _make_df()
+        result = rocket_features(df, n_kernels=5)
+        assert sorted(result["unique_id"].to_list()) == ["A", "B", "C"]
+
+    def test_variable_length_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 30 + ["B"] * 15,
+                "ds": (
+                    [date(2024, 1, i + 1) for i in range(30)]
+                    + [date(2024, 1, i + 1) for i in range(15)]
+                ),
+                "y": [1.0] * 30 + [2.0] * 15,
+            }
+        )
+        result = rocket_features(df, n_kernels=5)
+        assert result.shape[0] == 2
+
+    def test_n_kernels_validation(self):
+        df = _make_df()
+        with pytest.raises(ValueError, match="n_kernels"):
+            rocket_features(df, n_kernels=0)
+
+    def test_distinct_series_produce_different_features(self):
+        df = _make_df()
+        result = rocket_features(df, n_kernels=50)
+        a = result.filter(pl.col("unique_id") == "A").drop("unique_id").to_numpy()
+        b = result.filter(pl.col("unique_id") == "B").drop("unique_id").to_numpy()
+        assert not np.allclose(a, b)
+
+
+# ── MiniRocket tests ───────────────────────────────────────────────────
+
+
+class TestMiniRocket:
+    def test_output_shape(self):
+        df = _make_df()
+        result = minirocket_features(df, n_kernels=84)
+        assert result.shape[0] == 3
+        assert result.shape[1] > 1  # id + features
+
+    def test_column_prefix(self):
+        df = _make_df()
+        result = minirocket_features(df, n_kernels=10)
+        feat_cols = [c for c in result.columns if c != "unique_id"]
+        assert all(c.startswith("minirocket_") for c in feat_cols)
+
+    def test_deterministic_with_seed(self):
+        df = _make_df()
+        r1 = minirocket_features(df, n_kernels=84, seed=0)
+        r2 = minirocket_features(df, n_kernels=84, seed=0)
+        assert r1.equals(r2)
+
+    def test_ppv_in_range(self):
+        """All MiniRocket features (PPV) must be in [0, 1]."""
+        df = _make_df()
+        result = minirocket_features(df, n_kernels=84)
+        feat = result.drop("unique_id").to_numpy()
+        assert np.all(feat >= 0.0) and np.all(feat <= 1.0)
+
+    def test_preserves_series_ids(self):
+        df = _make_df()
+        result = minirocket_features(df, n_kernels=10)
+        assert sorted(result["unique_id"].to_list()) == ["A", "B", "C"]
+
+    def test_n_kernels_validation(self):
+        df = _make_df()
+        with pytest.raises(ValueError, match="n_kernels"):
+            minirocket_features(df, n_kernels=0)
+
+    def test_distinct_series_produce_different_features(self):
+        df = _make_df()
+        result = minirocket_features(df, n_kernels=84)
+        a = result.filter(pl.col("unique_id") == "A").drop("unique_id").to_numpy()
+        c = result.filter(pl.col("unique_id") == "C").drop("unique_id").to_numpy()
+        assert not np.allclose(a, c)
+
+    def test_variable_length_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 30 + ["B"] * 15,
+                "ds": (
+                    [date(2024, 1, i + 1) for i in range(30)]
+                    + [date(2024, 1, i + 1) for i in range(15)]
+                ),
+                "y": [1.0] * 30 + [2.0] * 15,
+            }
+        )
+        result = minirocket_features(df, n_kernels=84)
+        assert result.shape[0] == 2
+
+
+# ── Integration: top-level import ──────────────────────────────────────
+
+
+def test_rocket_importable_from_polars_ts():
+    from polars_ts import rocket_features as rf
+
+    assert callable(rf)
+
+
+def test_minirocket_importable_from_polars_ts():
+    from polars_ts import minirocket_features as mf
+
+    assert callable(mf)

--- a/tests/features/test_rocket.py
+++ b/tests/features/test_rocket.py
@@ -19,9 +19,7 @@ def _make_df() -> pl.DataFrame:
             "unique_id": ["A"] * 20 + ["B"] * 20 + ["C"] * 20,
             "ds": [date(2024, 1, i + 1) for i in range(20)] * 3,
             "y": (
-                [float(i) for i in range(20)]
-                + [float(20 - i) for i in range(20)]
-                + [float(i % 5) for i in range(20)]
+                [float(i) for i in range(20)] + [float(20 - i) for i in range(20)] + [float(i % 5) for i in range(20)]
             ),
         }
     )
@@ -74,10 +72,7 @@ class TestRocket:
         df = pl.DataFrame(
             {
                 "unique_id": ["A"] * 30 + ["B"] * 15,
-                "ds": (
-                    [date(2024, 1, i + 1) for i in range(30)]
-                    + [date(2024, 1, i + 1) for i in range(15)]
-                ),
+                "ds": ([date(2024, 1, i + 1) for i in range(30)] + [date(2024, 1, i + 1) for i in range(15)]),
                 "y": [1.0] * 30 + [2.0] * 15,
             }
         )
@@ -147,10 +142,7 @@ class TestMiniRocket:
         df = pl.DataFrame(
             {
                 "unique_id": ["A"] * 30 + ["B"] * 15,
-                "ds": (
-                    [date(2024, 1, i + 1) for i in range(30)]
-                    + [date(2024, 1, i + 1) for i in range(15)]
-                ),
+                "ds": ([date(2024, 1, i + 1) for i in range(30)] + [date(2024, 1, i + 1) for i in range(15)]),
                 "y": [1.0] * 30 + [2.0] * 15,
             }
         )
@@ -183,15 +175,11 @@ class TestEdgeCases:
                 "value": [float(i) for i in range(30)],
             }
         )
-        r = rocket_features(
-            df, n_kernels=5, target_col="value", id_col="series", time_col="timestamp"
-        )
+        r = rocket_features(df, n_kernels=5, target_col="value", id_col="series", time_col="timestamp")
         assert r.columns[0] == "series"
         assert r.shape == (2, 11)
 
-        m = minirocket_features(
-            df, n_kernels=10, target_col="value", id_col="series", time_col="timestamp"
-        )
+        m = minirocket_features(df, n_kernels=10, target_col="value", id_col="series", time_col="timestamp")
         assert m.columns[0] == "series"
         assert m.shape[0] == 2
 


### PR DESCRIPTION
## Summary
- Implements `rocket_features()` and `minirocket_features()` for transforming time series into fixed-length feature vectors via random convolutional kernels
- ROCKET: random kernels with varying length/dilation/bias, extracts PPV + max per kernel
- MiniRocket: fixed length-9 kernels with 84 deterministic weight patterns, ~faster variant
- Both handle variable-length series, are seeded for reproducibility, and return tidy `pl.DataFrame` with `[id_col, feature_0, ..., feature_N]`

Closes #95

## Test plan
- [x] 19 tests pass (`uv run pytest tests/features/test_rocket.py -v`)
- [x] Output shape, column naming, determinism, PPV range [0,1], variable-length series
- [x] Top-level import works (`from polars_ts import rocket_features`)
- [ ] CI passes