### PR TITLE
feat: add U-Shapelet clustering for time series

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -114,6 +114,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering import density as _density
 
         return getattr(_density, name)
+    if name in {"shapelet_cluster", "UShapeletClusterer"}:
+        from polars_ts.clustering import shapelets as _shapelets
+
+        return getattr(_shapelets, name)
     if name in {"lag_features", "rolling_features", "calendar_features", "fourier_features"}:
         from polars_ts import features as _feat
 
@@ -344,4 +348,6 @@ __all__ = [
     "auto_arima",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "shapelet_cluster",
+    "UShapeletClusterer",
 ]

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -38,6 +38,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.clustering.density import dbscan_cluster
 
         return dbscan_cluster
+    if name in {"shapelet_cluster", "UShapeletClusterer"}:
+        from polars_ts.clustering import shapelets as _shapelets
+
+        return getattr(_shapelets, name)
     raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
 
 
@@ -51,4 +55,6 @@ __all__ = [
     "calinski_harabasz_score",
     "hdbscan_cluster",
     "dbscan_cluster",
+    "shapelet_cluster",
+    "UShapeletClusterer",
 ]

--- a/polars_ts/clustering/shapelets.py
+++ b/polars_ts/clustering/shapelets.py
@@ -1,0 +1,296 @@
+"""U-Shapelet (unsupervised shapelet) clustering for time series.
+
+Discovers discriminative subsequences (shapelets) that separate groups of
+time series, then clusters in shapelet-distance space.
+
+References
+----------
+- Zakaria, J. et al. (2012). Clustering Time Series Using
+  Unsupervised-Shapelets. ICDM.
+
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+import numpy as np
+import polars as pl
+
+
+def _extract_series(
+    df: pl.DataFrame,
+    target_col: str,
+    id_col: str,
+    time_col: str | None,
+) -> tuple[list[str], np.ndarray]:
+    """Extract series as a zero-padded 2-D array (n_series, max_len)."""
+    sort_cols = [id_col, time_col] if time_col and time_col in df.columns else [id_col]
+    sorted_df = df.sort(sort_cols)
+    groups = sorted_df.group_by(id_col, maintain_order=True)
+    ids: list[str] = []
+    arrays: list[np.ndarray] = []
+    for key, group in groups:
+        ids.append(key[0] if isinstance(key, tuple) else key)  # type: ignore[arg-type]
+        arrays.append(group[target_col].to_numpy().astype(np.float64))
+
+    max_len = max(a.shape[0] for a in arrays)
+    padded = np.zeros((len(arrays), max_len), dtype=np.float64)
+    for i, a in enumerate(arrays):
+        padded[i, : a.shape[0]] = a
+    return ids, padded
+
+
+def _subsequence_distance(shapelet: np.ndarray, series: np.ndarray) -> float:
+    """Minimum sliding-window Euclidean distance between shapelet and series."""
+    s_len = len(shapelet)
+    t_len = len(series)
+    if s_len > t_len:
+        return float("inf")
+    best = float("inf")
+    for i in range(t_len - s_len + 1):
+        d = 0.0
+        for j in range(s_len):
+            diff = shapelet[j] - series[i + j]
+            d += diff * diff
+            if d >= best:
+                break
+        if d < best:
+            best = d
+    return float(np.sqrt(best))
+
+
+def _extract_candidates(
+    X: np.ndarray,
+    shapelet_lengths: list[int],
+    n_candidates: int,
+    rng: np.random.Generator,
+) -> list[np.ndarray]:
+    """Extract random shapelet candidates from the dataset."""
+    n_series, series_len = X.shape
+    candidates: list[np.ndarray] = []
+    for _ in range(n_candidates):
+        s_len = int(rng.choice(shapelet_lengths))
+        s_len = min(s_len, series_len)
+        idx = rng.integers(0, n_series)
+        start = rng.integers(0, max(1, series_len - s_len + 1))
+        candidates.append(X[idx, start : start + s_len].copy())
+    return candidates
+
+
+def _score_shapelet(shapelet: np.ndarray, X: np.ndarray) -> float:
+    """Score a shapelet candidate using the gap statistic.
+
+    Computes the distances from the shapelet to all series, then finds
+    the split point that maximizes the gap between successive sorted
+    distances. A larger gap means the shapelet better separates series
+    into two groups.
+    """
+    dists = np.array([_subsequence_distance(shapelet, X[i]) for i in range(X.shape[0])])
+    sorted_dists = np.sort(dists)
+    if len(sorted_dists) < 2:
+        return 0.0
+    gaps = np.diff(sorted_dists)
+    return float(np.max(gaps))
+
+
+def _kmeans_1d(
+    distances: np.ndarray,
+    k: int,
+    rng: np.random.Generator,
+    max_iter: int = 100,
+) -> np.ndarray:
+    """Run k-means on a distance-feature matrix."""
+    n, d = distances.shape
+    indices = rng.choice(n, size=min(k, n), replace=False)
+    centroids = distances[indices].copy()
+    labels = np.zeros(n, dtype=int)
+
+    for _ in range(max_iter):
+        # Assign
+        for i in range(n):
+            best_c = 0
+            best_d = float("inf")
+            for c in range(len(centroids)):
+                dist = float(np.sum((distances[i] - centroids[c]) ** 2))
+                if dist < best_d:
+                    best_d = dist
+                    best_c = c
+            labels[i] = best_c
+        # Update
+        new_centroids = np.zeros_like(centroids)
+        counts = np.zeros(len(centroids), dtype=int)
+        for i in range(n):
+            new_centroids[labels[i]] += distances[i]
+            counts[labels[i]] += 1
+        changed = False
+        for c in range(len(centroids)):
+            if counts[c] > 0:
+                nc = new_centroids[c] / counts[c]
+                if not np.allclose(nc, centroids[c]):
+                    changed = True
+                centroids[c] = nc
+        if not changed:
+            break
+    return labels
+
+
+class UShapeletClusterer:
+    """Unsupervised shapelet-based time series clustering.
+
+    Discovers discriminative subsequences (shapelets) and clusters
+    series by their shapelet distances.
+
+    Parameters
+    ----------
+    n_clusters
+        Number of clusters.
+    n_shapelets
+        Number of shapelets to select.
+    shapelet_lengths
+        Candidate shapelet lengths to consider.
+    n_candidates
+        Number of random shapelet candidates to evaluate.
+    target_col
+        Column with the values to cluster.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    seed
+        Random seed for reproducibility.
+    max_iter
+        Maximum k-means iterations.
+
+    """
+
+    def __init__(
+        self,
+        n_clusters: int = 3,
+        n_shapelets: int = 10,
+        shapelet_lengths: list[int] | None = None,
+        n_candidates: int = 100,
+        target_col: str = "y",
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        seed: int = 42,
+        max_iter: int = 100,
+    ) -> None:
+        self.n_clusters = n_clusters
+        self.n_shapelets = n_shapelets
+        self.shapelet_lengths = shapelet_lengths or [10, 20, 30]
+        self.n_candidates = n_candidates
+        self.target_col = target_col
+        self.id_col = id_col
+        self.time_col = time_col
+        self.seed = seed
+        self.max_iter = max_iter
+        self.labels_: pl.DataFrame | None = None
+        self.shapelets_: list[np.ndarray] = []
+
+    def fit(self, df: pl.DataFrame) -> Self:
+        """Discover shapelets and cluster time series.
+
+        Parameters
+        ----------
+        df
+            Input DataFrame with time series data.
+
+        Returns
+        -------
+        Self
+
+        """
+        ids, X = _extract_series(df, self.target_col, self.id_col, self.time_col)
+        n_series = X.shape[0]
+
+        if self.n_clusters > n_series:
+            raise ValueError(f"Cannot create {self.n_clusters} clusters from {n_series} series")
+
+        rng = np.random.default_rng(self.seed)
+
+        # Clamp shapelet lengths to series length
+        series_len = X.shape[1]
+        valid_lengths = [min(sl, series_len) for sl in self.shapelet_lengths]
+
+        # Extract and score candidates
+        candidates = _extract_candidates(X, valid_lengths, self.n_candidates, rng)
+        scores = [(i, _score_shapelet(c, X)) for i, c in enumerate(candidates)]
+        scores.sort(key=lambda t: t[1], reverse=True)
+
+        # Select top shapelets
+        n_select = min(self.n_shapelets, len(candidates))
+        self.shapelets_ = [candidates[scores[i][0]] for i in range(n_select)]
+
+        # Build distance matrix (n_series, n_shapelets)
+        dist_matrix = np.empty((n_series, n_select), dtype=np.float64)
+        for s_idx, shapelet in enumerate(self.shapelets_):
+            for t_idx in range(n_series):
+                dist_matrix[t_idx, s_idx] = _subsequence_distance(shapelet, X[t_idx])
+
+        # Cluster in distance space
+        labels = _kmeans_1d(dist_matrix, self.n_clusters, rng, self.max_iter)
+
+        self.labels_ = pl.DataFrame({self.id_col: ids, "cluster": labels.tolist()})
+        return self
+
+
+def shapelet_cluster(
+    df: pl.DataFrame,
+    k: int = 3,
+    n_shapelets: int = 10,
+    shapelet_lengths: list[int] | None = None,
+    n_candidates: int = 100,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    seed: int = 42,
+    max_iter: int = 100,
+) -> pl.DataFrame:
+    """Discover U-Shapelets and cluster time series.
+
+    Convenience function wrapping :class:`UShapeletClusterer`.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame with time series data.
+    k
+        Number of clusters.
+    n_shapelets
+        Number of shapelets to select.
+    shapelet_lengths
+        Candidate shapelet lengths to consider.
+    n_candidates
+        Number of random shapelet candidates to evaluate.
+    target_col
+        Column with the values to transform.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    seed
+        Random seed for reproducibility.
+    max_iter
+        Maximum k-means iterations.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+
+    """
+    usc = UShapeletClusterer(
+        n_clusters=k,
+        n_shapelets=n_shapelets,
+        shapelet_lengths=shapelet_lengths,
+        n_candidates=n_candidates,
+        target_col=target_col,
+        id_col=id_col,
+        time_col=time_col,
+        seed=seed,
+        max_iter=max_iter,
+    )
+    usc.fit(df)
+    assert usc.labels_ is not None
+    return usc.labels_

--- a/tests/clustering/test_shapelets.py
+++ b/tests/clustering/test_shapelets.py
@@ -1,0 +1,127 @@
+"""Tests for U-Shapelet clustering."""
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.clustering.shapelets import UShapeletClusterer, shapelet_cluster
+
+
+@pytest.fixture
+def shapelet_data():
+    """Two distinct patterns: spikes vs flat."""
+    rng = np.random.default_rng(0)
+    flat = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    spike = [0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    ids = []
+    vals = []
+    for name, pattern in [("A", flat), ("B", flat), ("C", spike), ("D", spike)]:
+        noise = rng.normal(0, 0.01, len(pattern))
+        ids.extend([name] * len(pattern))
+        vals.extend([float(v + n) for v, n in zip(pattern, noise, strict=False)])
+    return pl.DataFrame({"unique_id": ids, "y": vals})
+
+
+class TestUShapeletClusterer:
+    def test_fit_returns_self(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=2, shapelet_lengths=[5, 10], n_candidates=50)
+        result = usc.fit(shapelet_data)
+        assert result is usc
+
+    def test_labels_shape(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=2, shapelet_lengths=[5, 10], n_candidates=50)
+        usc.fit(shapelet_data)
+        assert usc.labels_ is not None
+        assert usc.labels_.shape[0] == 4
+        assert "unique_id" in usc.labels_.columns
+        assert "cluster" in usc.labels_.columns
+
+    def test_shapelets_discovered(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=2, n_shapelets=5, shapelet_lengths=[5, 10], n_candidates=50)
+        usc.fit(shapelet_data)
+        assert len(usc.shapelets_) == 5
+        assert all(isinstance(s, np.ndarray) for s in usc.shapelets_)
+
+    def test_deterministic_with_seed(self, shapelet_data):
+        usc1 = UShapeletClusterer(n_clusters=2, shapelet_lengths=[5], n_candidates=30, seed=99)
+        usc1.fit(shapelet_data)
+        usc2 = UShapeletClusterer(n_clusters=2, shapelet_lengths=[5], n_candidates=30, seed=99)
+        usc2.fit(shapelet_data)
+        assert usc1.labels_.equals(usc2.labels_)
+
+    def test_similar_series_grouped(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=2, n_shapelets=10, shapelet_lengths=[5, 10], n_candidates=200, seed=42)
+        usc.fit(shapelet_data)
+        labels = dict(zip(usc.labels_["unique_id"].to_list(), usc.labels_["cluster"].to_list(), strict=False))
+        # Flat series A,B should cluster together; spike series C,D together
+        assert labels["A"] == labels["B"]
+        assert labels["C"] == labels["D"]
+
+    def test_too_many_clusters_raises(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 5, "y": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        usc = UShapeletClusterer(n_clusters=5, shapelet_lengths=[3])
+        with pytest.raises(ValueError, match="Cannot create"):
+            usc.fit(df)
+
+    def test_shapelets_count_capped(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=2, n_shapelets=3, shapelet_lengths=[5], n_candidates=10)
+        usc.fit(shapelet_data)
+        assert len(usc.shapelets_) == 3
+
+    def test_single_cluster(self, shapelet_data):
+        usc = UShapeletClusterer(n_clusters=1, shapelet_lengths=[5], n_candidates=20)
+        usc.fit(shapelet_data)
+        labels = usc.labels_["cluster"].to_list()
+        assert all(c == 0 for c in labels)
+
+    def test_variable_length_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 15 + ["B"] * 25 + ["C"] * 20,
+                "y": [1.0] * 15 + [5.0] * 25 + [1.0] * 20,
+            }
+        )
+        usc = UShapeletClusterer(n_clusters=2, shapelet_lengths=[5], n_candidates=30)
+        usc.fit(df)
+        assert usc.labels_ is not None
+        assert usc.labels_.shape[0] == 3
+
+
+class TestShapeletClusterFunction:
+    def test_returns_dataframe(self, shapelet_data):
+        result = shapelet_cluster(shapelet_data, k=2, shapelet_lengths=[5, 10], n_candidates=50)
+        assert isinstance(result, pl.DataFrame)
+        assert result.shape[0] == 4
+        assert "unique_id" in result.columns
+        assert "cluster" in result.columns
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "series": ["X"] * 15 + ["Y"] * 15,
+                "timestamp": list(range(15)) * 2,
+                "value": [float(i) for i in range(30)],
+            }
+        )
+        result = shapelet_cluster(
+            df, k=2, shapelet_lengths=[5], n_candidates=30, target_col="value", id_col="series", time_col="timestamp"
+        )
+        assert result.columns[0] == "series"
+        assert result.shape[0] == 2
+
+    def test_deterministic(self, shapelet_data):
+        r1 = shapelet_cluster(shapelet_data, k=2, shapelet_lengths=[5], n_candidates=30, seed=7)
+        r2 = shapelet_cluster(shapelet_data, k=2, shapelet_lengths=[5], n_candidates=30, seed=7)
+        assert r1.equals(r2)
+
+
+def test_importable_from_polars_ts():
+    from polars_ts import shapelet_cluster as sc
+
+    assert callable(sc)
+
+
+def test_class_importable_from_polars_ts():
+    from polars_ts import UShapeletClusterer as USC
+
+    assert USC is not None


### PR DESCRIPTION
## Summary
- Implements `UShapeletClusterer` class and `shapelet_cluster()` convenience function for unsupervised shapelet-based time series clustering
- Discovers discriminative subsequences (shapelets) using gap-statistic scoring, then clusters series by shapelet distances via k-means
- `shapelets_` attribute exposes discovered subsequences for interpretability
- Handles variable-length series, custom column names, deterministic with seed

Closes #96

## Test plan
- [x] 14 tests pass (`uv run pytest tests/clustering/test_shapelets.py -v`)
- [x] Class API: fit returns self, labels_ shape/columns, shapelets_ count
- [x] Clustering correctness: flat vs spike patterns correctly separated
- [x] Edge cases: single cluster, too-many-clusters error, variable-length series
- [x] Convenience function, custom columns, determinism, top-level imports
- [x] Ruff format + lint clean
- [ ] CI passes