### PR TITLE
feat: add Chronos/MOMENT embedding adapters for clustering

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -174,6 +174,8 @@ def __getattr__(name: str) -> Any:
         "from_pytorch_forecasting",
         "to_hf_dataset",
         "ForecastEnv",
+        "to_chronos_embeddings",
+        "to_moment_embeddings",
     }:
         from polars_ts import adapters as _adapt
 
@@ -311,6 +313,8 @@ __all__ = [
     "from_pytorch_forecasting",
     "to_hf_dataset",
     "ForecastEnv",
+    "to_chronos_embeddings",
+    "to_moment_embeddings",
     "target_encode",
     "holiday_features",
     "interaction_features",

--- a/polars_ts/adapters/__init__.py
+++ b/polars_ts/adapters/__init__.py
@@ -22,6 +22,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts.adapters.rl_env import ForecastEnv
 
         return ForecastEnv
+    if name in {"to_chronos_embeddings", "to_moment_embeddings"}:
+        from polars_ts.adapters import embeddings as _emb
+
+        return getattr(_emb, name)
     raise AttributeError(f"module 'polars_ts.adapters' has no attribute {name!r}")
 
 
@@ -32,4 +36,6 @@ __all__ = [
     "from_pytorch_forecasting",
     "to_hf_dataset",
     "ForecastEnv",
+    "to_chronos_embeddings",
+    "to_moment_embeddings",
 ]

--- a/polars_ts/adapters/embeddings.py
+++ b/polars_ts/adapters/embeddings.py
@@ -1,0 +1,188 @@
+"""Foundation model embedding adapters (Chronos, MOMENT).
+
+Extract fixed-length embedding vectors from pre-trained time series
+foundation models, returning a polars DataFrame suitable for downstream
+clustering or classification.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+
+def _extract_series(
+    df: pl.DataFrame,
+    target_col: str,
+    id_col: str,
+    time_col: str,
+) -> tuple[list[str], list[np.ndarray]]:
+    """Extract per-series arrays, preserving variable lengths."""
+    sort_cols = [id_col, time_col] if time_col in df.columns else [id_col]
+    sorted_df = df.sort(sort_cols)
+    ids: list[str] = []
+    arrays: list[np.ndarray] = []
+    for key, group in sorted_df.group_by(id_col, maintain_order=True):
+        ids.append(str(key[0] if isinstance(key, tuple) else key))
+        arrays.append(group[target_col].to_numpy().astype(np.float32))
+    return ids, arrays
+
+
+def _arrays_to_result(
+    ids: list[str],
+    embeddings: np.ndarray,
+    id_col: str,
+    prefix: str,
+) -> pl.DataFrame:
+    """Convert id list + embedding matrix to a polars DataFrame."""
+    n_dim = embeddings.shape[1]
+    data: dict[str, Any] = {id_col: ids}
+    for i in range(n_dim):
+        data[f"{prefix}_{i}"] = embeddings[:, i].tolist()
+    return pl.DataFrame(data)
+
+
+def to_chronos_embeddings(
+    df: pl.DataFrame,
+    model_name: str = "amazon/chronos-t5-small",
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    device: str = "cpu",
+    batch_size: int = 32,
+) -> pl.DataFrame:
+    """Extract embeddings from a Chronos foundation model.
+
+    Loads the specified Chronos model and extracts encoder embeddings
+    for each time series, mean-pooled over the time dimension.
+
+    Requires ``torch`` and ``transformers``.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame with time series data.
+    model_name
+        HuggingFace model identifier for a Chronos model.
+    target_col
+        Column with the values to embed.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    device
+        Torch device (``"cpu"``, ``"cuda"``, etc.).
+    batch_size
+        Number of series to process at once.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, emb_0, emb_1, ..., emb_d]``.
+
+    """
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("torch is required for Chronos embeddings. Install with: pip install torch") from None
+
+    try:
+        from transformers import AutoModel, AutoTokenizer
+    except ImportError:
+        raise ImportError(
+            "transformers is required for Chronos embeddings. Install with: pip install transformers"
+        ) from None
+
+    ids, arrays = _extract_series(df, target_col, id_col, time_col)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModel.from_pretrained(model_name, trust_remote_code=True).to(device)
+    model.eval()
+
+    all_embeddings: list[np.ndarray] = []
+    for start in range(0, len(arrays), batch_size):
+        batch = arrays[start : start + batch_size]
+        # Tokenize: Chronos tokenizer expects list of 1-D tensors
+        inputs = tokenizer(
+            [torch.tensor(a, dtype=torch.float32) for a in batch],
+            return_tensors="pt",
+            padding=True,
+        )
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            outputs = model(**inputs)
+        # Mean-pool over sequence dimension
+        hidden = outputs.last_hidden_state  # (batch, seq_len, hidden_dim)
+        pooled = hidden.mean(dim=1).cpu().numpy()  # (batch, hidden_dim)
+        all_embeddings.append(pooled)
+
+    embeddings = np.concatenate(all_embeddings, axis=0)
+    return _arrays_to_result(ids, embeddings, id_col, "emb")
+
+
+def to_moment_embeddings(
+    df: pl.DataFrame,
+    model_name: str = "AutonLab/MOMENT-1-large",
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    device: str = "cpu",
+) -> pl.DataFrame:
+    """Extract embeddings from a MOMENT foundation model.
+
+    Loads the specified MOMENT model and extracts representation
+    embeddings for each time series.
+
+    Requires ``torch`` and ``momentfm``.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame with time series data.
+    model_name
+        HuggingFace model identifier for a MOMENT model.
+    target_col
+        Column with the values to embed.
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps for ordering.
+    device
+        Torch device (``"cpu"``, ``"cuda"``, etc.).
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, emb_0, emb_1, ..., emb_d]``.
+
+    """
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("torch is required for MOMENT embeddings. Install with: pip install torch") from None
+
+    try:
+        from momentfm import MOMENTPipeline
+    except ImportError:
+        raise ImportError("momentfm is required for MOMENT embeddings. Install with: pip install momentfm") from None
+
+    ids, arrays = _extract_series(df, target_col, id_col, time_col)
+
+    model = MOMENTPipeline.from_pretrained(model_name, model_task="embedding")
+    model.init()
+    model = model.to(device)
+
+    # Pad/truncate to uniform length and stack
+    max_len = max(a.shape[0] for a in arrays)
+    padded = np.zeros((len(arrays), max_len), dtype=np.float32)
+    for i, a in enumerate(arrays):
+        padded[i, : a.shape[0]] = a
+
+    with torch.no_grad():
+        input_tensor = torch.tensor(padded, dtype=torch.float32).unsqueeze(1).to(device)  # (N, 1, T)
+        output = model(input_tensor)
+        embeddings = output.embeddings.cpu().numpy()  # (N, d)
+
+    return _arrays_to_result(ids, embeddings, id_col, "emb")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -235,7 +235,7 @@ class TestExtractSeriesNoDsColumn:
 
 class TestChronosImportErrorTransformers:
     def test_import_error_transformers(self):
-        torch = pytest.importorskip("torch")
+        pytest.importorskip("torch")
         with patch.dict("sys.modules", {"transformers": None}):
             with pytest.raises(ImportError, match="transformers"):
                 import importlib
@@ -258,7 +258,7 @@ class TestMomentImportErrors:
                 embeddings.to_moment_embeddings(_make_df())
 
     def test_import_error_momentfm(self):
-        torch = pytest.importorskip("torch")
+        pytest.importorskip("torch")
         with patch.dict("sys.modules", {"momentfm": None}):
             with pytest.raises(ImportError, match="momentfm"):
                 import importlib

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,220 @@
+"""Tests for foundation model embedding adapters.
+
+These tests use lightweight mocks to avoid downloading large models
+during CI. Integration tests requiring real models are marked with
+``pytest.mark.slow``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.adapters.embeddings import _arrays_to_result, _extract_series
+
+
+def _make_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 10 + ["B"] * 10 + ["C"] * 10,
+            "ds": [date(2024, 1, i + 1) for i in range(10)] * 3,
+            "y": [float(i) for i in range(10)] + [float(10 - i) for i in range(10)] + [float(i % 3) for i in range(10)],
+        }
+    )
+
+
+# ── Helper tests ─────────────────────────────────────────────────────────
+
+
+class TestExtractSeries:
+    def test_ids_and_count(self):
+        df = _make_df()
+        ids, arrays = _extract_series(df, "y", "unique_id", "ds")
+        assert sorted(ids) == ["A", "B", "C"]
+        assert len(arrays) == 3
+
+    def test_array_dtype(self):
+        df = _make_df()
+        _, arrays = _extract_series(df, "y", "unique_id", "ds")
+        assert arrays[0].dtype == np.float32
+
+    def test_variable_length(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 5 + ["B"] * 10,
+                "ds": [date(2024, 1, i + 1) for i in range(5)] + [date(2024, 1, i + 1) for i in range(10)],
+                "y": [1.0] * 5 + [2.0] * 10,
+            }
+        )
+        ids, arrays = _extract_series(df, "y", "unique_id", "ds")
+        assert len(arrays[0]) == 5
+        assert len(arrays[1]) == 10
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 3, "t": [1, 2, 3], "val": [1.0, 2.0, 3.0]})
+        ids, arrays = _extract_series(df, "val", "sid", "t")
+        assert ids == ["X"]
+        assert len(arrays[0]) == 3
+
+
+class TestArraysToResult:
+    def test_output_shape(self):
+        ids = ["A", "B"]
+        emb = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        result = _arrays_to_result(ids, emb, "unique_id", "emb")
+        assert result.shape == (2, 4)  # id + 3 dims
+        assert result.columns == ["unique_id", "emb_0", "emb_1", "emb_2"]
+
+    def test_values_preserved(self):
+        ids = ["X"]
+        emb = np.array([[0.5, 1.5]])
+        result = _arrays_to_result(ids, emb, "sid", "feat")
+        assert result["sid"].to_list() == ["X"]
+        assert result["feat_0"].to_list() == [0.5]
+        assert result["feat_1"].to_list() == [1.5]
+
+
+# ── Chronos adapter tests (mocked) ──────────────────────────────────────
+
+
+class TestChronosEmbeddings:
+    def test_import_error_torch(self):
+        with patch.dict("sys.modules", {"torch": None}):
+            with pytest.raises(ImportError, match="torch"):
+                # Force reimport
+                import importlib
+
+                from polars_ts.adapters import embeddings
+
+                importlib.reload(embeddings)
+                embeddings.to_chronos_embeddings(_make_df())
+
+    def test_mocked_chronos(self):
+        torch = pytest.importorskip("torch")
+
+        hidden_dim = 8
+        mock_output = MagicMock()
+        mock_output.last_hidden_state = torch.randn(3, 5, hidden_dim)
+
+        mock_model = MagicMock()
+        mock_model.eval = MagicMock(return_value=None)
+        mock_model.to = MagicMock(return_value=mock_model)
+        mock_model.__call__ = MagicMock(return_value=mock_output)
+        mock_model.return_value = mock_output
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {"input_ids": torch.ones(3, 5, dtype=torch.long)}
+
+        with (
+            patch("polars_ts.adapters.embeddings.AutoModel") as MockAutoModel,
+            patch("polars_ts.adapters.embeddings.AutoTokenizer") as MockAutoTokenizer,
+        ):
+            MockAutoModel.from_pretrained.return_value = mock_model
+            MockAutoTokenizer.from_pretrained.return_value = mock_tokenizer
+
+            from polars_ts.adapters.embeddings import to_chronos_embeddings
+
+            result = to_chronos_embeddings(_make_df(), model_name="fake/model")
+
+        assert result.shape == (3, 1 + hidden_dim)
+        assert result.columns[0] == "unique_id"
+        assert all(c.startswith("emb_") for c in result.columns[1:])
+        assert sorted(result["unique_id"].to_list()) == ["A", "B", "C"]
+
+    def test_mocked_chronos_batch_size(self):
+        torch = pytest.importorskip("torch")
+
+        hidden_dim = 4
+
+        def make_output(n):
+            out = MagicMock()
+            out.last_hidden_state = torch.randn(n, 3, hidden_dim)
+            return out
+
+        call_count = {"n": 0}
+
+        def model_call(**kwargs):
+            input_ids = kwargs.get("input_ids", list(kwargs.values())[0])
+            n = input_ids.shape[0]
+            call_count["n"] += 1
+            return make_output(n)
+
+        mock_model = MagicMock()
+        mock_model.eval = MagicMock(return_value=None)
+        mock_model.to = MagicMock(return_value=mock_model)
+        mock_model.side_effect = model_call
+
+        mock_tokenizer = MagicMock()
+
+        def tokenize(tensors, **_kw):
+            n = len(tensors)
+            return {"input_ids": torch.ones(n, 3, dtype=torch.long)}
+
+        mock_tokenizer.side_effect = tokenize
+
+        with (
+            patch("polars_ts.adapters.embeddings.AutoModel") as MockAutoModel,
+            patch("polars_ts.adapters.embeddings.AutoTokenizer") as MockAutoTokenizer,
+        ):
+            MockAutoModel.from_pretrained.return_value = mock_model
+            MockAutoTokenizer.from_pretrained.return_value = mock_tokenizer
+
+            from polars_ts.adapters.embeddings import to_chronos_embeddings
+
+            result = to_chronos_embeddings(_make_df(), model_name="fake/model", batch_size=2)
+
+        assert result.shape[0] == 3
+        assert call_count["n"] == 2  # 2 + 1 batches
+
+
+# ── MOMENT adapter tests (mocked) ───────────────────────────────────────
+
+
+class TestMomentEmbeddings:
+    def test_mocked_moment(self):
+        torch = pytest.importorskip("torch")
+
+        emb_dim = 16
+        mock_output = MagicMock()
+        mock_output.embeddings = torch.randn(3, emb_dim)
+
+        mock_model = MagicMock()
+        mock_model.init = MagicMock(return_value=None)
+        mock_model.to = MagicMock(return_value=mock_model)
+        mock_model.__call__ = MagicMock(return_value=mock_output)
+        mock_model.return_value = mock_output
+
+        mock_pipeline_cls = MagicMock()
+        mock_pipeline_cls.from_pretrained.return_value = mock_model
+
+        with patch.dict("sys.modules", {"momentfm": MagicMock(MOMENTPipeline=mock_pipeline_cls)}):
+
+            import importlib
+
+            from polars_ts.adapters import embeddings
+
+            importlib.reload(embeddings)
+            result = embeddings.to_moment_embeddings(_make_df(), model_name="fake/moment")
+
+        assert result.shape == (3, 1 + emb_dim)
+        assert result.columns[0] == "unique_id"
+        assert sorted(result["unique_id"].to_list()) == ["A", "B", "C"]
+
+
+# ── Integration: top-level imports ───────────────────────────────────────
+
+
+def test_chronos_importable_from_polars_ts():
+    from polars_ts import to_chronos_embeddings
+
+    assert callable(to_chronos_embeddings)
+
+
+def test_moment_importable_from_polars_ts():
+    from polars_ts import to_moment_embeddings
+
+    assert callable(to_moment_embeddings)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -192,7 +192,6 @@ class TestMomentEmbeddings:
         mock_pipeline_cls.from_pretrained.return_value = mock_model
 
         with patch.dict("sys.modules", {"momentfm": MagicMock(MOMENTPipeline=mock_pipeline_cls)}):
-
             import importlib
 
             from polars_ts.adapters import embeddings
@@ -218,3 +217,53 @@ def test_moment_importable_from_polars_ts():
     from polars_ts import to_moment_embeddings
 
     assert callable(to_moment_embeddings)
+
+
+# ── Additional coverage tests ────────────────────────────────────────────
+
+
+class TestExtractSeriesNoDsColumn:
+    """_extract_series falls back to sorting by id_col only when time_col is absent."""
+
+    def test_no_time_column(self):
+        df = pl.DataFrame({"unique_id": ["A", "A", "B"], "y": [1.0, 2.0, 3.0]})
+        ids, arrays = _extract_series(df, "y", "unique_id", "ds")
+        assert sorted(ids) == ["A", "B"]
+        assert len(arrays[0]) == 2
+        assert len(arrays[1]) == 1
+
+
+class TestChronosImportErrorTransformers:
+    def test_import_error_transformers(self):
+        torch = pytest.importorskip("torch")
+        with patch.dict("sys.modules", {"transformers": None}):
+            with pytest.raises(ImportError, match="transformers"):
+                import importlib
+
+                from polars_ts.adapters import embeddings
+
+                importlib.reload(embeddings)
+                embeddings.to_chronos_embeddings(_make_df())
+
+
+class TestMomentImportErrors:
+    def test_import_error_torch(self):
+        with patch.dict("sys.modules", {"torch": None}):
+            with pytest.raises(ImportError, match="torch"):
+                import importlib
+
+                from polars_ts.adapters import embeddings
+
+                importlib.reload(embeddings)
+                embeddings.to_moment_embeddings(_make_df())
+
+    def test_import_error_momentfm(self):
+        torch = pytest.importorskip("torch")
+        with patch.dict("sys.modules", {"momentfm": None}):
+            with pytest.raises(ImportError, match="momentfm"):
+                import importlib
+
+                from polars_ts.adapters import embeddings
+
+                importlib.reload(embeddings)
+                embeddings.to_moment_embeddings(_make_df())


### PR DESCRIPTION
## Summary
- Adds `to_chronos_embeddings()` and `to_moment_embeddings()` adapters that extract fixed-length embedding vectors from pre-trained time series foundation models
- Returns tidy `pl.DataFrame` with `[id_col, emb_0, ..., emb_d]` — plug directly into any clustering algorithm
- Optional dependencies (`torch`, `transformers`, `momentfm`) with clear `ImportError` messages
- Shared helpers (`_extract_series`, `_arrays_to_result`) keep both adapters DRY

Closes #97

## Test plan
- [x] 12 tests (9 pass, 3 skip when torch not installed)
- [x] Helper tests: series extraction, result assembly, variable-length, custom columns
- [x] Mocked Chronos/MOMENT tests: output shape, column names, batching
- [x] ImportError handling for missing torch
- [x] Top-level import works (`from polars_ts import to_chronos_embeddings`)
- [x] Ruff format + lint clean
- [ ] CI passes