### PR TITLE
fix: bump rand 0.8.5 → 0.8.6 (GHSA-cq8v-f236-94qc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
  "polars-arrow",
  "polars-error",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ryu",
  "serde",
  "skiplist",
@@ -1549,7 +1549,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr",
  "rayon",
  "regex",
@@ -1593,7 +1593,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "recursive",
 ]
@@ -1833,7 +1833,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "sqlparser",
@@ -1868,7 +1868,7 @@ dependencies = [
  "polars-parquet",
  "polars-plan",
  "polars-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "recursive",
  "slotmap",
@@ -1932,7 +1932,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "polars-error",
- "rand 0.8.5",
+ "rand 0.8.6",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2191,9 +2191,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2255,7 +2255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2675,7 +2675,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eec25f46463fcdc5e02f388c2780b1b58e01be81a8378e62ec60931beccc3f6"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps transitive dependency `rand` from 0.8.5 to 0.8.6 in `Cargo.lock`
- Resolves [Dependabot alert #26](https://github.com/drumtorben/polars-ts/security/dependabot/26) (GHSA-cq8v-f236-94qc): soundness issue with aliased mutable references in `ThreadRng`

## Test plan
- [x] `cargo check` passes with updated dependency
- [ ] CI green