### PR TITLE
chore: bump version to v0.7.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## v0.7.0 (2026-04-25)
+
+### Features
+
+- Add HDBSCAN/DBSCAN density-based clustering with precomputed distance matrices (#106).
+- Add agglomerative/hierarchical clustering with dendrograms (#107).
+- Add k-means with DBA (DTW Barycentric Averaging) clustering (#108).
+- Add CLARA/CLARANS scalable k-medoids variants (#109).
+- Add ROCKET/MiniRocket feature extraction for clustering (#111).
+- Add U-Shapelet clustering for time series (#112).
+- Add Chronos/MOMENT embedding adapters for clustering (#113).
+- Add spectral clustering with SBD kernel (K-Spectral Centroid) (#125).
+- Add `auto_cluster` automated clustering pipeline selection (#126).
+
+### Fixes
+
+- Bump `rand` 0.8.5 → 0.8.6 to resolve GHSA-cq8v-f236-94qc (#124).
+- Upgrade `rustls-webpki` 0.103.12 → 0.103.13 for GHSA-82j2-j2ch-gfr8 (#110).
+- Add `scipy` to `clustering` optional dependency (required by spectral clustering).
+- Add `pytest.importorskip` guards for tests requiring `scipy`/`sklearn`.
+- Fix mypy type errors in `auto_cluster` module.
+
+### Documentation
+
+- Replace 7 API-demo notebooks with 10 theme-based tutorials (#89).
+- Add polars-ts logo image for README banner (#88).
+
+### Tests
+
+- Add SCUM ensemble model tests (#90).
+
 ## v0.6.0 (2026-04-21)
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-ts-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/polars_ts/clustering/auto.py
+++ b/polars_ts/clustering/auto.py
@@ -66,19 +66,22 @@ def _run_clustering(
         if method == "kmedoids":
             from polars_ts.clustering.kmedoids import kmedoids
 
+            assert k is not None
             return kmedoids(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "spectral":
             from polars_ts.clustering.spectral import spectral_cluster
 
+            assert k is not None
             return spectral_cluster(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "kshape":
             from polars_ts.clustering.kshape import KShape
 
+            assert k is not None
             ks_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
             ks = KShape(n_clusters=k).fit(ks_df)
-            labels = ks.labels_
+            labels: pl.DataFrame = ks.labels_
             if id_col != "unique_id":
                 id_map = dict(
                     zip(

--- a/polars_ts/clustering/auto.py
+++ b/polars_ts/clustering/auto.py
@@ -81,7 +81,8 @@ def _run_clustering(
             assert k is not None
             ks_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
             ks = KShape(n_clusters=k).fit(ks_df)
-            labels: pl.DataFrame = ks.labels_
+            assert ks.labels_ is not None
+            labels = ks.labels_
             if id_col != "unique_id":
                 id_map = dict(
                     zip(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polars-timeseries"
-version = "0.6.0"
+version = "0.7.0"
 description = "Polars Time Series Extension"
 authors = [
     { name = "Torben Windler" },
@@ -15,7 +15,7 @@ dependencies = [
 [project.optional-dependencies]
 forecast = ["statsforecast>=2.0.0", "utilsforecast>=0.2.0"]
 decomposition = ["polars-ds>=0.10.0"]
-clustering = ["scikit-learn>=1.3.0"]
+clustering = ["scikit-learn>=1.3.0", "scipy>=1.11.0"]
 all = ["polars-timeseries[forecast,decomposition,clustering]"]
 
 [project.urls]

--- a/tests/clustering/test_auto.py
+++ b/tests/clustering/test_auto.py
@@ -1,7 +1,12 @@
+import importlib
+
 import polars as pl
 import pytest
 
 from polars_ts.clustering.auto import AutoClusterResult, auto_cluster
+
+_has_scipy = importlib.util.find_spec("scipy") is not None
+_has_sklearn = importlib.util.find_spec("sklearn") is not None
 
 
 @pytest.fixture
@@ -60,6 +65,7 @@ class TestAutoClusterMethods:
         assert result.best_method == "kmedoids"
         assert result.best_k == 2
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_spectral_method(self, well_separated_data):
         result = auto_cluster(well_separated_data, methods=["spectral"], distances=["sbd"], k_range=range(2, 3))
         assert result.best_method == "spectral"
@@ -79,6 +85,7 @@ class TestAutoClusterMethods:
         # Only SBD rows should appear in results
         assert all(row["distance"] == "sbd" for row in result.results_table.to_dicts())
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_hdbscan_no_k(self, well_separated_data):
         """HDBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -92,6 +99,7 @@ class TestAutoClusterMethods:
         assert result.results_table.shape[0] == 1
         assert result.results_table["k"][0] is None
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_dbscan_no_k(self, well_separated_data):
         """DBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -106,6 +114,7 @@ class TestAutoClusterMethods:
 
 
 class TestAutoClusterMultipleCombinations:
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_multiple_methods_and_distances(self, well_separated_data):
         result = auto_cluster(
             well_separated_data,
@@ -116,6 +125,7 @@ class TestAutoClusterMultipleCombinations:
         # 2 methods x 2 distances x 2 k values = 8 rows
         assert result.results_table.shape[0] == 8
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_best_is_optimal(self, well_separated_data):
         """Best score should be the max silhouette in the results table."""
         result = auto_cluster(


### PR DESCRIPTION
## Summary

Bump version to v0.7.0 and add changelog entry for the clustering expansion release.

### Version bump
- `pyproject.toml`: 0.6.0 → 0.7.0
- `Cargo.toml`: 0.6.0 → 0.7.0

### Changelog (v0.7.0)
**9 new clustering features:**
- HDBSCAN/DBSCAN density-based clustering (#106)
- Agglomerative/hierarchical clustering (#107)
- K-Means with DBA (#108)
- CLARA/CLARANS scalable k-medoids (#109)
- ROCKET/MiniRocket feature extraction (#111)
- U-Shapelet clustering (#112)
- Chronos/MOMENT embedding adapters (#113)
- Spectral clustering with SBD kernel (#125)
- `auto_cluster` automated pipeline selection (#126)

**2 security fixes:** rand GHSA-cq8v-f236-94qc (#124), rustls-webpki GHSA-82j2-j2ch-gfr8 (#110)

### Bug fixes included
- Add `scipy>=1.11.0` to `clustering` optional dependency (required by `spectral_cluster`)
- Fix mypy type errors in `auto_cluster` module (`k: int | None` narrowing)
- Add `pytest.mark.skipif` guards for tests requiring `scipy`/`sklearn`

## Test plan
- [ ] All CI checks pass
- [ ] Version strings match in pyproject.toml and Cargo.toml