### PR TITLE
docs: rewrite README for clarity and update RELEASE_NOTES

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,125 +10,35 @@
 
 ---
 
-## Features
+**polars-ts** is a batteries-included time series toolkit built on [Polars](https://pola.rs/). It gives you Rust-accelerated distance metrics, 10+ clustering algorithms, a full forecasting stack, and diagnostics — all from a single `pip install`, no heavyweight frameworks required.
 
-### Distance Metrics (Rust, parallelized via Rayon)
+### Why polars-ts?
 
-| Metric | Function | Key Parameters |
-|--------|----------|----------------|
-| Dynamic Time Warping | `compute_pairwise_dtw` | `method`: standard, sakoe_chiba, itakura, fast |
-| Derivative DTW | `compute_pairwise_ddtw` | Shape-sensitive comparison |
-| Weighted DTW | `compute_pairwise_wdtw` | `g`: weight sharpness |
-| Move-Split-Merge | `compute_pairwise_msm` | `c`: move cost |
-| Edit Distance (Real Penalty) | `compute_pairwise_erp` | `g`: gap value |
-| Longest Common Subsequence | `compute_pairwise_lcss` | `epsilon`: matching threshold |
-| Time Warp Edit Distance | `compute_pairwise_twe` | `nu`: stiffness, `lambda_`: deletion cost |
-| Multivariate DTW | `compute_pairwise_dtw_multi` | `metric`: manhattan, euclidean |
-| Multivariate MSM | `compute_pairwise_msm_multi` | `c`: move cost |
+| Pain point | How polars-ts helps |
+|---|---|
+| **"I need DTW but scipy is slow"** | 12 distance metrics compiled to native code via Rust + Rayon, orders of magnitude faster on large panels |
+| **"I want to cluster time series but tslearn/sktime have too many deps"** | K-Medoids, K-Shape, HDBSCAN, Spectral, Hierarchical, K-Means DBA, CLARA/CLARANS, U-Shapelets — all built-in, optional `scikit-learn` only for density methods |
+| **"Setting up a forecast pipeline takes too long"** | `ForecastPipeline` wires up lags, rolling stats, calendar features, target transforms, and any sklearn model in 5 lines |
+| **"I don't know which clustering method to pick"** | `auto_cluster` sweeps methods × distances × k values and returns the best result with evaluation scores |
+| **"Polars doesn't have time series functions"** | Mann-Kendall, Sen's slope, CUSUM, PELT, decomposition, ACF/PACF — all group-aware and Polars-native |
 
-### Trend & Changepoint Detection
+### TL;DR — what you can do in 3 lines
 
-- **Mann-Kendall test** &mdash; non-parametric trend detection (Rust)
-- **Sen's slope** &mdash; robust trend magnitude estimation (Rust)
-- **CUSUM** &mdash; cumulative sum changepoint detection (Rust)
-- **PELT** &mdash; multiple changepoints with mean/variance/meanvar cost functions
-- **BOCPD** &mdash; Bayesian Online Changepoint Detection
-- **Regime detection** &mdash; Hidden Markov Model state inference
+```python
+import polars_ts as pts
 
-### Decomposition (Python)
+# Cluster 1 000 series by shape similarity
+labels = pts.auto_cluster(df, methods=["kmedoids", "spectral"], distances=["sbd", "dtw"])
 
-- **Seasonal decomposition** &mdash; additive or multiplicative (classical)
-- **Fourier decomposition** &mdash; harmonic decomposition with configurable frequencies
-- **Decomposition features** &mdash; trend/seasonal strength extraction (simple or MSTL)
-- **Anomaly flagging** &mdash; residual-based anomaly detection from any decomposition
+# Forecast with a full ML pipeline
+pipe = pts.ForecastPipeline(model, lags=[1,7,14], rolling_windows=[7], calendar=["day_of_week"])
+pipe.fit(train); forecasts = pipe.predict(train, h=7)
 
-### Feature Engineering
+# Detect changepoints
+breaks = pts.pelt(df, cost="meanvar", pen=10)
+```
 
-- **Lag features** &mdash; create lagged versions of a target column per group
-- **Rolling features** &mdash; rolling window aggregations (mean, std, min, max, sum, median, var)
-- **Calendar features** &mdash; extract day_of_week, month, quarter, is_weekend, etc.
-- **Fourier features** &mdash; sin/cos pairs for seasonal modelling
-- **Target encoding** &mdash; smoothed categorical encoding by target mean
-- **Holiday features** &mdash; binary holidays + distance-to-holiday (requires `holidays` package)
-- **Interaction features** &mdash; cross-term column generation
-- **Time embeddings** &mdash; cyclical sin/cos encoding for time components
-
-### Target Transforms
-
-- **Log transform** &mdash; log1p / expm1 with automatic validation and lossless inversion
-- **Box-Cox transform** &mdash; parametric power transform with configurable lambda
-- **Differencing** &mdash; configurable order and seasonal period with metadata for lossless inversion
-
-All transforms are group-aware, invertible, and accessible via the `df.pts` namespace.
-
-### Data Preprocessing
-
-- **Missing value imputation** &mdash; forward/backward fill, linear interpolation, mean, median, seasonal
-- **Outlier detection** &mdash; z-score, IQR, Hampel filter, rolling z-score
-- **Outlier treatment** &mdash; clip (winsorize), median replacement, interpolation, null
-- **Temporal resampling** &mdash; downsample/upsample with configurable aggregation
-
-### Validation Strategies
-
-- **Expanding window CV** &mdash; growing training window cross-validation
-- **Sliding window CV** &mdash; fixed-size training window cross-validation
-- **Rolling origin CV** &mdash; general rolling-origin with configurable initial/fixed train size
-
-### Forecasting
-
-- **SCUM** &mdash; ensemble model combining AutoARIMA, AutoETS, AutoCES, and DynamicOptimizedTheta
-- **ARIMA/SARIMA** &mdash; explicit `(p,d,q)` order via `statsmodels` (`arima_fit`/`arima_forecast`) or automatic selection via `statsforecast` (`auto_arima`)
-- **Baseline models** &mdash; naive, seasonal naive, moving average, and FFT-based forecasts
-- **Exponential smoothing** &mdash; SES, Holt's linear, Holt-Winters (additive/multiplicative)
-- **Multi-step strategies** &mdash; `RecursiveForecaster` and `DirectForecaster`
-- **ForecastPipeline** &mdash; end-to-end ML pipeline with feature engineering + transforms
-- **GlobalForecaster** &mdash; cross-series panel model with optional ID encoding
-
-### Probabilistic Forecasting
-
-- **QuantileRegressor** &mdash; one model per quantile level with CRPS-compatible output
-- **Conformal prediction** &mdash; distribution-free intervals with coverage guarantees
-- **EnbPI** &mdash; Ensemble Batch Prediction Intervals with adaptive online updates
-
-### Ensembling
-
-- **WeightedEnsemble** &mdash; equal, manual, or inverse-error-optimized weights
-- **StackingForecaster** &mdash; meta-learner trained on out-of-fold predictions
-
-### Forecast Evaluation & Diagnostics
-
-- **Metrics** &mdash; MAE, RMSE, MAPE, sMAPE, MASE, CRPS
-- **Kaboudan metric** &mdash; model robustness evaluation via block-shuffle backtesting
-- **Bias detection & correction** &mdash; mean, regression, quantile mapping
-- **Calibration diagnostics** &mdash; calibration table, PIT histogram, reliability diagram
-- **Residual diagnostics** &mdash; ACF, PACF, Ljung-Box test
-- **Permutation importance** &mdash; model-agnostic feature importance
-
-### Multivariate & Hierarchical
-
-- **VAR** &mdash; Vector Autoregression with OLS fitting and multi-step forecasts
-- **Granger causality** &mdash; F-test for causal relationships between series
-- **GARCH** &mdash; volatility modelling and conditional variance forecasting
-- **Forecast reconciliation** &mdash; bottom-up, top-down, and MinTrace-OLS
-
-### Clustering & Classification
-
-- **k-Medoids (PAM)** &mdash; supports all 12 distance metrics
-- **KShape** &mdash; shape-based clustering with centroid computation
-- **k-NN classification** &mdash; distance-based time series classification
-- **KShape classifier** &mdash; classification using KShape centroids
-
-### Anomaly Detection
-
-- **Decomposition-based** &mdash; residual threshold anomaly flagging
-- **Isolation Forest** &mdash; unsupervised anomaly detection on engineered features
-
-### Integration Adapters
-
-- **neuralforecast** &mdash; convert to/from N-BEATS, PatchTST, N-HiTS format
-- **pytorch-forecasting** &mdash; convert to/from TFT, DeepAR format
-- **HuggingFace** &mdash; convert to Dataset for Chronos, TimesFM, Lag-Llama
-- **ForecastEnv** &mdash; gymnasium-compatible RL environment for decision making
+---
 
 ## Installation
 
@@ -136,17 +46,20 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 pip install polars-timeseries
 ```
 
-Optional dependencies for specific features:
+Extras for optional features:
 
 ```bash
-pip install "polars-timeseries[forecast]"      # Kaboudan metric, SCUM model
-pip install "polars-timeseries[decomposition]"  # Fourier decomposition
+pip install "polars-timeseries[clustering]"     # HDBSCAN, DBSCAN, spectral (sklearn + scipy)
+pip install "polars-timeseries[forecast]"       # SCUM, auto_arima (statsforecast)
+pip install "polars-timeseries[decomposition]"  # Fourier decomposition (polars-ds)
 pip install "polars-timeseries[all]"            # Everything
 ```
 
-Requires Python 3.12+ and Polars 1.30+.
+Requires **Python 3.12+** and **Polars 1.30+**.
 
-## Quick Start
+---
+
+## Quick start
 
 ### Pairwise DTW distance
 
@@ -161,6 +74,19 @@ df = pl.DataFrame({
 })
 
 result = pts.compute_pairwise_dtw(df, df)
+```
+
+### Auto-cluster time series
+
+```python
+result = pts.auto_cluster(
+    df,
+    methods=["kmedoids", "spectral", "kshape"],
+    distances=["sbd", "dtw"],
+    k_range=range(2, 6),
+)
+print(result.best_method, result.best_k, result.best_score)
+print(result.best_labels)  # DataFrame[unique_id, cluster]
 ```
 
 ### End-to-end forecast pipeline
@@ -251,6 +177,169 @@ df = pl.DataFrame({
 
 result = pts.seasonal_decomposition(df, freq=12, method="additive")
 ```
+
+---
+
+## Features
+
+### Distance metrics <sub>Rust, parallelized via Rayon</sub>
+
+All distance functions return a tidy DataFrame with columns `[id_1, id_2, <metric>]`. A unified `compute_pairwise_distance(method=...)` API lets you swap metrics with a single string.
+
+| Metric | Function | Key Parameters |
+|--------|----------|----------------|
+| Dynamic Time Warping | `compute_pairwise_dtw` | `method`: standard, sakoe_chiba, itakura, fast |
+| Derivative DTW | `compute_pairwise_ddtw` | Shape-sensitive comparison |
+| Weighted DTW | `compute_pairwise_wdtw` | `g`: weight sharpness |
+| Move-Split-Merge | `compute_pairwise_msm` | `c`: move cost |
+| Edit Distance (Real Penalty) | `compute_pairwise_erp` | `g`: gap value |
+| Longest Common Subsequence | `compute_pairwise_lcss` | `epsilon`: matching threshold |
+| Time Warp Edit Distance | `compute_pairwise_twe` | `nu`: stiffness, `lambda_`: deletion cost |
+| Shape-Based Distance | `compute_pairwise_sbd` | Cross-correlation based |
+| Frechet Distance | `compute_pairwise_frechet` | Geometric coupling distance |
+| Edit Distance on Real Sequences | `compute_pairwise_edr` | Edit-operation cost |
+| Multivariate DTW | `compute_pairwise_dtw_multi` | `metric`: manhattan, euclidean |
+| Multivariate MSM | `compute_pairwise_msm_multi` | `c`: move cost |
+
+### Clustering & classification
+
+| Method | Function | When to use |
+|--------|----------|-------------|
+| **K-Medoids (PAM)** | `kmedoids` | Known k, any distance metric, interpretable medoids |
+| **K-Shape** | `KShape` | Shape-based grouping via cross-correlation centroids |
+| **Spectral (KSC)** | `spectral_cluster` | Non-convex clusters, graph Laplacian structure |
+| **HDBSCAN** | `hdbscan_cluster` | Unknown k, varying density, noise detection |
+| **DBSCAN** | `dbscan_cluster` | Fixed-radius neighbourhood, noise detection |
+| **Hierarchical** | `agglomerative_cluster` | Dendrogram visualization, flexible linkage |
+| **K-Means DBA** | `kmeans_dba` | DTW Barycentric Averaging centroids |
+| **CLARA** | `clara` | Scalable k-medoids via sampling |
+| **CLARANS** | `clarans` | Randomized k-medoids neighbourhood search |
+| **U-Shapelets** | `shapelet_cluster` | Interpretable sub-sequence patterns |
+| **ROCKET / MiniRocket** | `rocket_features`, `minirocket_features` | Random convolutional kernel feature extraction |
+| **Auto-cluster** | `auto_cluster` | Sweep methods × distances × k, pick the best |
+
+**Evaluation:** `silhouette_score`, `davies_bouldin_score`, `calinski_harabasz_score`
+
+**Classification:** `knn_classify` (distance-based k-NN), `TimeSeriesKNNClassifier` (OOP), `KShapeClassifier` (centroid-based)
+
+### Trend & changepoint detection
+
+- **Mann-Kendall test** &mdash; non-parametric trend detection (Rust)
+- **Sen's slope** &mdash; robust trend magnitude estimation (Rust)
+- **CUSUM** &mdash; cumulative sum changepoint detection (Rust)
+- **PELT** &mdash; multiple changepoints with mean/variance/meanvar cost functions
+- **BOCPD** &mdash; Bayesian Online Changepoint Detection
+- **Regime detection** &mdash; Hidden Markov Model state inference
+
+### Decomposition
+
+- **Seasonal decomposition** &mdash; additive or multiplicative (classical)
+- **Fourier decomposition** &mdash; harmonic decomposition with configurable frequencies
+- **Decomposition features** &mdash; trend/seasonal strength extraction (simple or MSTL)
+- **Anomaly flagging** &mdash; residual-based anomaly detection from any decomposition
+
+### Feature engineering
+
+- **Lag features** &mdash; create lagged versions of a target column per group
+- **Rolling features** &mdash; rolling window aggregations (mean, std, min, max, sum, median, var)
+- **Calendar features** &mdash; extract day_of_week, month, quarter, is_weekend, etc.
+- **Fourier features** &mdash; sin/cos pairs for seasonal modelling
+- **Target encoding** &mdash; smoothed categorical encoding by target mean
+- **Holiday features** &mdash; binary holidays + distance-to-holiday (requires `holidays` package)
+- **Interaction features** &mdash; cross-term column generation
+- **Time embeddings** &mdash; cyclical sin/cos encoding for time components
+
+### Target transforms
+
+- **Log transform** &mdash; log1p / expm1 with automatic validation and lossless inversion
+- **Box-Cox transform** &mdash; parametric power transform with configurable lambda
+- **Differencing** &mdash; configurable order and seasonal period with metadata for lossless inversion
+
+All transforms are group-aware, invertible, and accessible via the `df.pts` namespace.
+
+### Data preprocessing
+
+- **Missing value imputation** &mdash; forward/backward fill, linear interpolation, mean, median, seasonal
+- **Outlier detection** &mdash; z-score, IQR, Hampel filter, rolling z-score
+- **Outlier treatment** &mdash; clip (winsorize), median replacement, interpolation, null
+- **Temporal resampling** &mdash; downsample/upsample with configurable aggregation
+
+### Validation strategies
+
+- **Expanding window CV** &mdash; growing training window cross-validation
+- **Sliding window CV** &mdash; fixed-size training window cross-validation
+- **Rolling origin CV** &mdash; general rolling-origin with configurable initial/fixed train size
+
+### Forecasting
+
+- **SCUM** &mdash; ensemble model combining AutoARIMA, AutoETS, AutoCES, and DynamicOptimizedTheta
+- **ARIMA/SARIMA** &mdash; explicit `(p,d,q)` order via `statsmodels` (`arima_fit`/`arima_forecast`) or automatic selection via `statsforecast` (`auto_arima`)
+- **Baseline models** &mdash; naive, seasonal naive, moving average, and FFT-based forecasts
+- **Exponential smoothing** &mdash; SES, Holt's linear, Holt-Winters (additive/multiplicative, Rust-accelerated)
+- **Multi-step strategies** &mdash; `RecursiveForecaster` and `DirectForecaster`
+- **ForecastPipeline** &mdash; end-to-end ML pipeline with feature engineering + transforms
+- **GlobalForecaster** &mdash; cross-series panel model with optional ID encoding
+
+### Probabilistic forecasting
+
+- **QuantileRegressor** &mdash; one model per quantile level with CRPS-compatible output
+- **Conformal prediction** &mdash; distribution-free intervals with coverage guarantees
+- **EnbPI** &mdash; Ensemble Batch Prediction Intervals with adaptive online updates
+
+### Ensembling
+
+- **WeightedEnsemble** &mdash; equal, manual, or inverse-error-optimized weights
+- **StackingForecaster** &mdash; meta-learner trained on out-of-fold predictions
+
+### Forecast evaluation & diagnostics
+
+- **Metrics** &mdash; MAE, RMSE, MAPE, sMAPE, MASE, CRPS
+- **Kaboudan metric** &mdash; model robustness evaluation via block-shuffle backtesting
+- **Bias detection & correction** &mdash; mean, regression, quantile mapping
+- **Calibration diagnostics** &mdash; calibration table, PIT histogram, reliability diagram
+- **Residual diagnostics** &mdash; ACF, PACF, Ljung-Box test
+- **Permutation importance** &mdash; model-agnostic feature importance
+
+### Multivariate & hierarchical
+
+- **VAR** &mdash; Vector Autoregression with OLS fitting and multi-step forecasts
+- **Granger causality** &mdash; F-test for causal relationships between series
+- **GARCH** &mdash; volatility modelling and conditional variance forecasting
+- **Forecast reconciliation** &mdash; bottom-up, top-down, and MinTrace-OLS
+
+### Anomaly detection
+
+- **Decomposition-based** &mdash; residual threshold anomaly flagging
+- **Isolation Forest** &mdash; unsupervised anomaly detection on engineered features
+
+### Integration adapters
+
+- **NeuralForecast** &mdash; convert to/from N-BEATS, PatchTST, N-HiTS format
+- **PyTorch Forecasting** &mdash; convert to/from TFT, DeepAR format
+- **HuggingFace** &mdash; convert to Dataset for Chronos, TimesFM, Lag-Llama
+- **Chronos / MOMENT embeddings** &mdash; foundation model feature extraction for clustering
+- **ForecastEnv** &mdash; Gymnasium-compatible RL environment for decision making
+
+---
+
+## Tutorials
+
+The `notebooks/` directory contains 10 end-to-end tutorials:
+
+| # | Topic |
+|---|---|
+| 01 | Data wrangling & exploration |
+| 02 | Feature engineering & transforms |
+| 03 | Forecasting fundamentals |
+| 04 | ML forecasting pipelines |
+| 05 | Uncertainty & calibration |
+| 06 | Changepoint & anomaly detection |
+| 07 | Time series similarity & clustering |
+| 08 | Multivariate & volatility |
+| 09 | Ensembles & reconciliation |
+| 10 | Ecosystem adapters |
+
+---
 
 ## Development
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,57 @@
-# polars-ts v0.7.0 (2026-04-18)
+# polars-ts v0.8.0 (2026-04-25)
+
+The clustering expansion release: polars-ts goes from 2 clustering algorithms to **11**, plus an automated pipeline selector.
+
+## Highlights
+
+- **9 new clustering methods** — HDBSCAN, DBSCAN, spectral (KSC), agglomerative, K-Means DBA, CLARA, CLARANS, U-Shapelets, and `auto_cluster` for automated method/distance/k selection
+- **Feature extraction** — ROCKET/MiniRocket random convolutional kernels, Chronos/MOMENT foundation model embeddings
+- **2 security patches** — rand 0.8.6 (GHSA-cq8v-f236-94qc), rustls-webpki 0.103.13 (GHSA-82j2-j2ch-gfr8)
+
+## New clustering methods
+
+| Method | Function | Key capability |
+|---|---|---|
+| **HDBSCAN** | `hdbscan_cluster` | Automatic k, varying density, noise detection |
+| **DBSCAN** | `dbscan_cluster` | Fixed-radius eps neighbourhood, noise detection |
+| **Spectral (KSC)** | `spectral_cluster` | Graph Laplacian + Gaussian kernel affinity |
+| **Hierarchical** | `agglomerative_cluster` | Dendrograms, flexible linkage criteria |
+| **K-Means DBA** | `kmeans_dba` | DTW Barycentric Averaging centroids |
+| **CLARA** | `clara` | Scalable k-medoids via sampling |
+| **CLARANS** | `clarans` | Randomized k-medoids neighbourhood search |
+| **U-Shapelets** | `shapelet_cluster` | Interpretable sub-sequence patterns |
+| **Auto-cluster** | `auto_cluster` | Sweep methods × distances × k, pick the best |
+
+## Feature extraction for clustering
+
+- **ROCKET / MiniRocket** — random convolutional kernel features (`rocket_features`, `minirocket_features`)
+- **Chronos embeddings** — `to_chronos_embeddings` for Amazon Chronos foundation model
+- **MOMENT embeddings** — `to_moment_embeddings` for CMU MOMENT foundation model
+
+## Fixes
+
+- Add `scipy>=1.11.0` to `clustering` optional dependency (required by spectral clustering)
+- Bump `rand` 0.8.5 → 0.8.6 to resolve GHSA-cq8v-f236-94qc
+- Upgrade `rustls-webpki` 0.103.12 → 0.103.13 for GHSA-82j2-j2ch-gfr8
+
+## Documentation
+
+- Replace 7 API-demo notebooks with 10 theme-based tutorials
+- Add polars-ts logo for README banner
+
+---
+
+# polars-ts v0.7.0 (2026-04-21)
 
 ## CI & Tooling
 
 - **prek** — replaced `pre-commit` with [prek](https://github.com/j178/prek) in CI. 3-5x faster code-quality checks, same `.pre-commit-config.yaml`. Contributors can use either tool locally.
 - **ty** — added [ty](https://github.com/astral-sh/ty) (Astral's Rust-based type checker) as a non-blocking CI job (`continue-on-error: true`). Runs alongside mypy as informational. Will be promoted to blocking when ty reaches stable.
+
+## Performance
+
+- Accelerate exponential smoothing (SES, Holt, Holt-Winters) with Rust implementation
+- Accelerate k-medoids PAM clustering with Rust implementation
 
 ## Features
 

--- a/polars_ts/clustering/auto.py
+++ b/polars_ts/clustering/auto.py
@@ -66,18 +66,22 @@ def _run_clustering(
         if method == "kmedoids":
             from polars_ts.clustering.kmedoids import kmedoids
 
+            assert k is not None
             return kmedoids(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "spectral":
             from polars_ts.clustering.spectral import spectral_cluster
 
+            assert k is not None
             return spectral_cluster(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "kshape":
             from polars_ts.clustering.kshape import KShape
 
+            assert k is not None
             ks_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
             ks = KShape(n_clusters=k).fit(ks_df)
+            assert ks.labels_ is not None
             labels = ks.labels_
             if id_col != "unique_id":
                 id_map = dict(

--- a/tests/clustering/test_auto.py
+++ b/tests/clustering/test_auto.py
@@ -1,7 +1,12 @@
+import importlib
+
 import polars as pl
 import pytest
 
 from polars_ts.clustering.auto import AutoClusterResult, auto_cluster
+
+_has_scipy = importlib.util.find_spec("scipy") is not None
+_has_sklearn = importlib.util.find_spec("sklearn") is not None
 
 
 @pytest.fixture
@@ -60,6 +65,7 @@ class TestAutoClusterMethods:
         assert result.best_method == "kmedoids"
         assert result.best_k == 2
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_spectral_method(self, well_separated_data):
         result = auto_cluster(well_separated_data, methods=["spectral"], distances=["sbd"], k_range=range(2, 3))
         assert result.best_method == "spectral"
@@ -79,6 +85,7 @@ class TestAutoClusterMethods:
         # Only SBD rows should appear in results
         assert all(row["distance"] == "sbd" for row in result.results_table.to_dicts())
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_hdbscan_no_k(self, well_separated_data):
         """HDBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -92,6 +99,7 @@ class TestAutoClusterMethods:
         assert result.results_table.shape[0] == 1
         assert result.results_table["k"][0] is None
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_dbscan_no_k(self, well_separated_data):
         """DBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -106,6 +114,7 @@ class TestAutoClusterMethods:
 
 
 class TestAutoClusterMultipleCombinations:
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_multiple_methods_and_distances(self, well_separated_data):
         result = auto_cluster(
             well_separated_data,
@@ -116,6 +125,7 @@ class TestAutoClusterMultipleCombinations:
         # 2 methods x 2 distances x 2 k values = 8 rows
         assert result.results_table.shape[0] == 8
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_best_is_optimal(self, well_separated_data):
         """Best score should be the max silhouette in the results table."""
         result = auto_cluster(


### PR DESCRIPTION
## Summary

Rewrites the README to lead with **why** someone should use polars-ts, not just a feature list.

### README changes
- **TL;DR section** — 3-line code examples showing clustering, forecasting, and changepoint detection
- **"Why polars-ts?" table** — maps 5 common pain points to how the package solves them
- **Auto-cluster quick start** — new example for the `auto_cluster` pipeline
- **Reorganized features** — grouped by capability with concise tables instead of flat bullet lists
- **Tutorials section** — links to all 10 notebooks
- **Updated installation** — includes `clustering` extra for sklearn/scipy

### RELEASE_NOTES changes
- Add **v0.8.0** entry covering the clustering expansion (9 new methods, ROCKET/MiniRocket, Chronos/MOMENT, security patches)
- Add **v0.7.0** Rust performance section (exponential smoothing, k-medoids)

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All links resolve
- [ ] Code examples are syntactically correct