### PR TITLE
feat: add time series imaging module (recurrence, GAF, MTF, spectrograms, signatures)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,7 +271,7 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
-    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf", "to_spectrogram", "to_scalogram"}:
+    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf", "to_spectrogram", "to_scalogram", "signature_features", "to_signature_image"}:
         from polars_ts import imaging as _img
 
         return getattr(_img, name)

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,6 +271,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
+    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf"}:
+        from polars_ts import imaging as _img
+
+        return getattr(_img, name)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,7 +271,7 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
-    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf"}:
+    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf", "to_spectrogram", "to_scalogram"}:
         from polars_ts import imaging as _img
 
         return getattr(_img, name)

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,7 +271,17 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
-    if name in {"to_recurrence_plot", "rqa_features", "to_gasf", "to_gadf", "to_mtf", "to_spectrogram", "to_scalogram", "signature_features", "to_signature_image"}:
+    if name in {
+        "to_recurrence_plot",
+        "rqa_features",
+        "to_gasf",
+        "to_gadf",
+        "to_mtf",
+        "to_spectrogram",
+        "to_scalogram",
+        "signature_features",
+        "to_signature_image",
+    }:
         from polars_ts import imaging as _img
 
         return getattr(_img, name)

--- a/polars_ts/clustering/auto.py
+++ b/polars_ts/clustering/auto.py
@@ -66,18 +66,22 @@ def _run_clustering(
         if method == "kmedoids":
             from polars_ts.clustering.kmedoids import kmedoids
 
+            assert k is not None
             return kmedoids(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "spectral":
             from polars_ts.clustering.spectral import spectral_cluster
 
+            assert k is not None
             return spectral_cluster(df, k=k, method=distance, id_col=id_col, target_col=target_col, seed=seed)
 
         if method == "kshape":
             from polars_ts.clustering.kshape import KShape
 
+            assert k is not None
             ks_df = df.select(pl.col(id_col).alias("unique_id"), pl.col(target_col).alias("y"))
             ks = KShape(n_clusters=k).fit(ks_df)
+            assert ks.labels_ is not None
             labels = ks.labels_
             if id_col != "unique_id":
                 id_map = dict(

--- a/polars_ts/imaging/__init__.py
+++ b/polars_ts/imaging/__init__.py
@@ -30,6 +30,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.imaging.spectral import to_scalogram
 
         return to_scalogram
+    if name == "signature_features":
+        from polars_ts.imaging.signature import signature_features
+
+        return signature_features
+    if name == "to_signature_image":
+        from polars_ts.imaging.signature import to_signature_image
+
+        return to_signature_image
     raise AttributeError(f"module 'polars_ts.imaging' has no attribute {name!r}")
 
 
@@ -41,4 +49,6 @@ __all__ = [
     "to_mtf",
     "to_spectrogram",
     "to_scalogram",
+    "signature_features",
+    "to_signature_image",
 ]

--- a/polars_ts/imaging/__init__.py
+++ b/polars_ts/imaging/__init__.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "to_recurrence_plot":
+        from polars_ts.imaging.recurrence import to_recurrence_plot
+
+        return to_recurrence_plot
+    if name == "rqa_features":
+        from polars_ts.imaging.recurrence import rqa_features
+
+        return rqa_features
+    if name == "to_gasf":
+        from polars_ts.imaging.angular import to_gasf
+
+        return to_gasf
+    if name == "to_gadf":
+        from polars_ts.imaging.angular import to_gadf
+
+        return to_gadf
+    if name == "to_mtf":
+        from polars_ts.imaging.transition import to_mtf
+
+        return to_mtf
+    raise AttributeError(f"module 'polars_ts.imaging' has no attribute {name!r}")
+
+
+__all__ = [
+    "to_recurrence_plot",
+    "rqa_features",
+    "to_gasf",
+    "to_gadf",
+    "to_mtf",
+]

--- a/polars_ts/imaging/__init__.py
+++ b/polars_ts/imaging/__init__.py
@@ -22,6 +22,14 @@ def __getattr__(name: str) -> Any:
         from polars_ts.imaging.transition import to_mtf
 
         return to_mtf
+    if name == "to_spectrogram":
+        from polars_ts.imaging.spectral import to_spectrogram
+
+        return to_spectrogram
+    if name == "to_scalogram":
+        from polars_ts.imaging.spectral import to_scalogram
+
+        return to_scalogram
     raise AttributeError(f"module 'polars_ts.imaging' has no attribute {name!r}")
 
 
@@ -31,4 +39,6 @@ __all__ = [
     "to_gasf",
     "to_gadf",
     "to_mtf",
+    "to_spectrogram",
+    "to_scalogram",
 ]

--- a/polars_ts/imaging/_utils.py
+++ b/polars_ts/imaging/_utils.py
@@ -1,0 +1,19 @@
+"""Shared utilities for the imaging module."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+
+def extract_series(
+    df: pl.DataFrame,
+    id_col: str,
+    target_col: str,
+) -> dict[str, np.ndarray]:
+    """Group DataFrame by id_col and return dict of numpy arrays."""
+    result: dict[str, np.ndarray] = {}
+    for sid in df[id_col].unique(maintain_order=True).to_list():
+        vals = df.filter(pl.col(id_col) == sid)[target_col].to_numpy()
+        result[str(sid)] = vals
+    return result

--- a/polars_ts/imaging/angular.py
+++ b/polars_ts/imaging/angular.py
@@ -1,0 +1,113 @@
+"""Gramian Angular Field (GAF) imaging for time series.
+
+Converts time series to GASF (Gramian Angular Summation Field) and
+GADF (Gramian Angular Difference Field) images.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from polars_ts.imaging.recurrence import _extract_series
+
+
+def _min_max_scale(x: np.ndarray) -> np.ndarray:
+    """Scale values to [-1, 1]."""
+    xmin, xmax = x.min(), x.max()
+    if xmax - xmin == 0:
+        return np.zeros_like(x)
+    return 2 * (x - xmin) / (xmax - xmin) - 1
+
+
+def _paa(x: np.ndarray, size: int) -> np.ndarray:
+    """Piecewise Aggregate Approximation — downsample by averaging segments."""
+    n = len(x)
+    if size >= n:
+        return x
+    indices = np.array_split(np.arange(n), size)
+    return np.array([x[idx].mean() for idx in indices])
+
+
+def _gasf_matrix(x: np.ndarray, image_size: int | None) -> np.ndarray:
+    """Compute GASF for a single 1D series."""
+    x_scaled = _min_max_scale(x)
+    if image_size is not None:
+        x_scaled = _paa(x_scaled, image_size)
+    phi = np.arccos(np.clip(x_scaled, -1, 1))
+    return np.cos(phi[:, None] + phi[None, :])
+
+
+def _gadf_matrix(x: np.ndarray, image_size: int | None) -> np.ndarray:
+    """Compute GADF for a single 1D series."""
+    x_scaled = _min_max_scale(x)
+    if image_size is not None:
+        x_scaled = _paa(x_scaled, image_size)
+    phi = np.arccos(np.clip(x_scaled, -1, 1))
+    return np.sin(phi[:, None] - phi[None, :])
+
+
+def to_gasf(
+    df: pl.DataFrame,
+    image_size: int | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to Gramian Angular Summation Field images.
+
+    Rescales values to [-1, 1], converts to polar coordinates, and
+    computes ``cos(phi_i + phi_j)`` for all pairs.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    image_size
+        Output image dimension. ``None`` for full resolution (n x n).
+        Smaller values use Piecewise Aggregate Approximation (PAA).
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a square 2D array with values in [-1, 1].
+
+    """
+    series = _extract_series(df, id_col, target_col)
+    return {sid: _gasf_matrix(vals, image_size) for sid, vals in series.items()}
+
+
+def to_gadf(
+    df: pl.DataFrame,
+    image_size: int | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to Gramian Angular Difference Field images.
+
+    Rescales values to [-1, 1], converts to polar coordinates, and
+    computes ``sin(phi_i - phi_j)`` for all pairs.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    image_size
+        Output image dimension. ``None`` for full resolution (n x n).
+        Smaller values use Piecewise Aggregate Approximation (PAA).
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a square 2D array with values in [-1, 1].
+
+    """
+    series = _extract_series(df, id_col, target_col)
+    return {sid: _gadf_matrix(vals, image_size) for sid, vals in series.items()}

--- a/polars_ts/imaging/angular.py
+++ b/polars_ts/imaging/angular.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from polars_ts.imaging.recurrence import _extract_series
+from polars_ts.imaging._utils import extract_series
 
 
 def _min_max_scale(x: np.ndarray) -> np.ndarray:
@@ -76,7 +76,7 @@ def to_gasf(
         Mapping from series ID to a square 2D array with values in [-1, 1].
 
     """
-    series = _extract_series(df, id_col, target_col)
+    series = extract_series(df, id_col, target_col)
     return {sid: _gasf_matrix(vals, image_size) for sid, vals in series.items()}
 
 
@@ -109,5 +109,5 @@ def to_gadf(
         Mapping from series ID to a square 2D array with values in [-1, 1].
 
     """
-    series = _extract_series(df, id_col, target_col)
+    series = extract_series(df, id_col, target_col)
     return {sid: _gadf_matrix(vals, image_size) for sid, vals in series.items()}

--- a/polars_ts/imaging/recurrence.py
+++ b/polars_ts/imaging/recurrence.py
@@ -1,0 +1,182 @@
+"""Recurrence plot imaging and Recurrence Quantification Analysis (RQA).
+
+Converts time series to 2D binary/grayscale recurrence plot images
+and extracts RQA features (recurrence rate, determinism, laminarity,
+entropy, trapping time).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+from scipy.spatial.distance import cdist
+
+
+def _extract_series(
+    df: pl.DataFrame,
+    id_col: str,
+    target_col: str,
+) -> dict[str, np.ndarray]:
+    """Group DataFrame by id_col and return dict of numpy arrays."""
+    result: dict[str, np.ndarray] = {}
+    for sid in df[id_col].unique(maintain_order=True).to_list():
+        vals = df.filter(pl.col(id_col) == sid)[target_col].to_numpy()
+        result[str(sid)] = vals
+    return result
+
+
+def _recurrence_matrix(
+    x: np.ndarray,
+    threshold: float | None,
+    metric: str,
+    normalize: bool,
+) -> np.ndarray:
+    """Compute recurrence plot for a single 1D series."""
+    if normalize:
+        std = x.std()
+        if std > 0:
+            x = (x - x.mean()) / std
+        else:
+            x = x - x.mean()
+
+    X = x.reshape(-1, 1)
+    D = cdist(X, X, metric=metric)
+
+    if threshold is not None:
+        return (D <= threshold).astype(np.float64)
+    return D
+
+
+def to_recurrence_plot(
+    df: pl.DataFrame,
+    threshold: float | None = 0.1,
+    metric: str = "euclidean",
+    normalize: bool = True,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to recurrence plot images.
+
+    For each series, computes the pairwise distance matrix between all
+    timepoints and optionally binarises it with a threshold.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    threshold
+        Binarisation threshold. Points closer than this are marked as
+        recurrent (1). Set to ``None`` for a grayscale distance matrix.
+    metric
+        Point-wise distance metric (any metric supported by
+        ``scipy.spatial.distance.cdist``).
+    normalize
+        Z-normalize each series before computing distances.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a square 2D numpy array (n x n).
+
+    """
+    series = _extract_series(df, id_col, target_col)
+    return {
+        sid: _recurrence_matrix(vals, threshold, metric, normalize)
+        for sid, vals in series.items()
+    }
+
+
+def _diagonal_lines(R: np.ndarray) -> list[int]:
+    """Extract lengths of diagonal lines (excluding main diagonal)."""
+    n = R.shape[0]
+    lengths: list[int] = []
+    for k in range(1, n):
+        diag = np.diag(R, k)
+        length = 0
+        for val in diag:
+            if val > 0.5:
+                length += 1
+            elif length > 0:
+                lengths.append(length)
+                length = 0
+        if length > 0:
+            lengths.append(length)
+    return lengths
+
+
+def _vertical_lines(R: np.ndarray) -> list[int]:
+    """Extract lengths of vertical lines."""
+    n = R.shape[0]
+    lengths: list[int] = []
+    for col in range(n):
+        length = 0
+        for row in range(n):
+            if R[row, col] > 0.5:
+                length += 1
+            elif length > 0:
+                lengths.append(length)
+                length = 0
+        if length > 0:
+            lengths.append(length)
+    return lengths
+
+
+def rqa_features(R: np.ndarray, l_min: int = 2) -> dict[str, float]:
+    """Extract Recurrence Quantification Analysis features from a recurrence plot.
+
+    Parameters
+    ----------
+    R
+        Square binary recurrence plot (values 0 or 1).
+    l_min
+        Minimum line length to count for determinism and laminarity.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary with keys: ``recurrence_rate``, ``determinism``,
+        ``laminarity``, ``mean_diagonal``, ``mean_vertical``, ``entropy``.
+
+    """
+    n = R.shape[0]
+    total = n * n
+
+    # Recurrence rate
+    rr = float(R.sum()) / total if total > 0 else 0.0
+
+    # Diagonal lines
+    diag_lengths = _diagonal_lines(R)
+    long_diags = [dl for dl in diag_lengths if dl >= l_min]
+    det_points = sum(long_diags)
+    all_recurrent = int(R.sum()) - n  # exclude main diagonal
+    determinism = det_points / all_recurrent if all_recurrent > 0 else 0.0
+    mean_diag = float(np.mean(long_diags)) if long_diags else 0.0
+
+    # Vertical lines
+    vert_lengths = _vertical_lines(R)
+    long_verts = [vl for vl in vert_lengths if vl >= l_min]
+    lam_points = sum(long_verts)
+    total_vert = sum(vert_lengths)
+    laminarity = lam_points / total_vert if total_vert > 0 else 0.0
+    mean_vert = float(np.mean(long_verts)) if long_verts else 0.0
+
+    # Entropy of diagonal line length distribution
+    if long_diags:
+        counts = np.bincount(long_diags)
+        probs = counts[counts > 0] / counts.sum()
+        entropy = -float(np.sum(probs * np.log(probs)))
+    else:
+        entropy = 0.0
+
+    return {
+        "recurrence_rate": rr,
+        "determinism": determinism,
+        "laminarity": laminarity,
+        "mean_diagonal": mean_diag,
+        "mean_vertical": mean_vert,
+        "entropy": entropy,
+    }

--- a/polars_ts/imaging/recurrence.py
+++ b/polars_ts/imaging/recurrence.py
@@ -84,10 +84,7 @@ def to_recurrence_plot(
 
     """
     series = _extract_series(df, id_col, target_col)
-    return {
-        sid: _recurrence_matrix(vals, threshold, metric, normalize)
-        for sid, vals in series.items()
-    }
+    return {sid: _recurrence_matrix(vals, threshold, metric, normalize) for sid, vals in series.items()}
 
 
 def _diagonal_lines(R: np.ndarray) -> list[int]:

--- a/polars_ts/imaging/recurrence.py
+++ b/polars_ts/imaging/recurrence.py
@@ -9,20 +9,8 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
-from scipy.spatial.distance import cdist
 
-
-def _extract_series(
-    df: pl.DataFrame,
-    id_col: str,
-    target_col: str,
-) -> dict[str, np.ndarray]:
-    """Group DataFrame by id_col and return dict of numpy arrays."""
-    result: dict[str, np.ndarray] = {}
-    for sid in df[id_col].unique(maintain_order=True).to_list():
-        vals = df.filter(pl.col(id_col) == sid)[target_col].to_numpy()
-        result[str(sid)] = vals
-    return result
+from polars_ts.imaging._utils import extract_series
 
 
 def _recurrence_matrix(
@@ -38,6 +26,8 @@ def _recurrence_matrix(
             x = (x - x.mean()) / std
         else:
             x = x - x.mean()
+
+    from scipy.spatial.distance import cdist
 
     X = x.reshape(-1, 1)
     D = cdist(X, X, metric=metric)
@@ -83,7 +73,7 @@ def to_recurrence_plot(
         Mapping from series ID to a square 2D numpy array (n x n).
 
     """
-    series = _extract_series(df, id_col, target_col)
+    series = extract_series(df, id_col, target_col)
     return {sid: _recurrence_matrix(vals, threshold, metric, normalize) for sid, vals in series.items()}
 
 

--- a/polars_ts/imaging/signature.py
+++ b/polars_ts/imaging/signature.py
@@ -1,0 +1,224 @@
+"""Path signature features and signature image visualization.
+
+Computes truncated path signatures as feature vectors for time series,
+and reshapes them into 2D images for vision-based analysis.
+
+Uses ``iisignature`` when available for fast computation; falls back to
+a pure-numpy implementation for basic signatures.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.imaging._utils import extract_series
+
+
+def _time_augment(x: np.ndarray) -> np.ndarray:
+    """Prepend a normalised time channel: path becomes 2D (t, x)."""
+    n = len(x)
+    t = np.linspace(0, 1, n)
+    return np.column_stack([t, x])
+
+
+def _leadlag_augment(x: np.ndarray) -> np.ndarray:
+    """Lead-lag transform: (x_t, x_{t-1}) for richer path structure."""
+    lead = x[1:]
+    lag = x[:-1]
+    return np.column_stack([lead, lag])
+
+
+def _basepoint_augment(path: np.ndarray) -> np.ndarray:
+    """Prepend the origin as basepoint."""
+    origin = np.zeros((1, path.shape[1]))
+    return np.vstack([origin, path])
+
+
+def _apply_augmentations(
+    x: np.ndarray,
+    augmentations: list[str],
+) -> np.ndarray:
+    """Build a multi-dimensional path from a 1D series via augmentations."""
+    path = x.reshape(-1, 1)
+
+    for aug in augmentations:
+        if aug == "time":
+            t = np.linspace(0, 1, len(path)).reshape(-1, 1)
+            path = np.hstack([t, path])
+        elif aug == "leadlag":
+            path = _leadlag_augment(path[:, 0]) if path.shape[1] == 1 else path
+        elif aug == "basepoint":
+            path = _basepoint_augment(path)
+        else:
+            raise ValueError(f"Unknown augmentation {aug!r}. Supported: time, leadlag, basepoint")
+
+    return path
+
+
+def _sig_numpy(path: np.ndarray, depth: int) -> np.ndarray:
+    """Compute truncated signature using pure numpy (iterated integrals).
+
+    This is a reference implementation; for production use install iisignature.
+    """
+    increments = np.diff(path, axis=0)  # (n-1, d)
+    d = path.shape[1]
+
+    terms: list[float] = []
+
+    # Depth 1: sum of increments per channel
+    s1 = increments.sum(axis=0)  # (d,)
+    terms.extend(s1.tolist())
+
+    if depth >= 2:
+        # Depth 2: iterated integrals S^{ij} = sum_{s<t} dX^i_s * dX^j_t
+        n = len(increments)
+        cumsum = np.cumsum(increments, axis=0)
+        for i in range(d):
+            for j in range(d):
+                val = 0.0
+                for t in range(1, n):
+                    val += cumsum[t - 1, i] * increments[t, j]
+                terms.append(val)
+
+    if depth >= 3:
+        # Depth 3: S^{ijk}
+        for i in range(d):
+            for j in range(d):
+                for k in range(d):
+                    val = 0.0
+                    cum_i = 0.0
+                    cum_ij = 0.0
+                    for t in range(n):
+                        cum_ij += cum_i * increments[t, j]
+                        val += cum_ij * increments[t, k]
+                        cum_i += increments[t, i]
+                    terms.append(val)
+
+    if depth >= 4:
+        raise ValueError("Pure-numpy signature only supports depth <= 3. Install iisignature for higher depths.")
+
+    return np.array(terms, dtype=np.float64)
+
+
+def _compute_signature(path: np.ndarray, depth: int) -> np.ndarray:
+    """Compute the truncated signature, using iisignature if available."""
+    try:
+        import iisignature
+
+        s = iisignature.sig(path, depth)
+        return np.asarray(s, dtype=np.float64)
+    except ImportError:
+        return _sig_numpy(path, depth)
+
+
+def signature_features(
+    df: pl.DataFrame,
+    depth: int = 3,
+    augmentations: list[str] | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> pl.DataFrame:
+    """Extract truncated path signature features for each time series.
+
+    The signature is a sequence of iterated integrals that captures the
+    shape of a path up to reparametrisation. Truncating at depth ``d``
+    gives a finite-dimensional feature vector.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    depth
+        Truncation depth. Controls feature dimensionality:
+        depth 1 → d features, depth 2 → d + d², depth 3 → d + d² + d³.
+    augmentations
+        List of path augmentations to apply before computing the
+        signature. Options: ``"time"`` (prepend time channel),
+        ``"leadlag"`` (lead-lag transform), ``"basepoint"`` (prepend origin).
+        Default: ``["time"]``.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, sig_0, sig_1, ..., sig_d]``.
+
+    """
+    if augmentations is None:
+        augmentations = ["time"]
+
+    series = extract_series(df, id_col, target_col)
+    all_ids: list[str] = []
+    all_sigs: list[np.ndarray] = []
+
+    for sid, vals in series.items():
+        path = _apply_augmentations(vals, augmentations)
+        sig = _compute_signature(path, depth)
+        all_ids.append(sid)
+        all_sigs.append(sig)
+
+    embeddings = np.stack(all_sigs)
+    n_dim = embeddings.shape[1]
+    data: dict[str, Any] = {id_col: all_ids}
+    for i in range(n_dim):
+        data[f"sig_{i}"] = embeddings[:, i].tolist()
+
+    return pl.DataFrame(data)
+
+
+def to_signature_image(
+    df: pl.DataFrame,
+    depth: int = 2,
+    augmentations: list[str] | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to signature images.
+
+    Computes the depth-2 signature and reshapes the d² terms into a
+    d × d matrix for visualization. Higher-depth terms are discarded.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    depth
+        Signature depth (must be >= 2). Only the depth-2 terms are
+        used for the image; depth-1 terms are discarded.
+    augmentations
+        Path augmentations. Default: ``["time"]``.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a d × d matrix of depth-2 signature terms.
+
+    """
+    if depth < 2:
+        raise ValueError("depth must be >= 2 for signature images")
+
+    if augmentations is None:
+        augmentations = ["time"]
+
+    series = extract_series(df, id_col, target_col)
+    result: dict[str, np.ndarray] = {}
+
+    for sid, vals in series.items():
+        path = _apply_augmentations(vals, augmentations)
+        d = path.shape[1]
+        sig = _compute_signature(path, max(depth, 2))
+        # Depth-2 terms start at index d and have d² elements
+        depth2_terms = sig[d : d + d * d]
+        result[sid] = depth2_terms.reshape(d, d)
+
+    return result

--- a/polars_ts/imaging/spectral.py
+++ b/polars_ts/imaging/spectral.py
@@ -1,0 +1,174 @@
+"""Spectrogram and wavelet scalogram imaging for time series.
+
+Converts time series to time-frequency 2D representations via
+Short-Time Fourier Transform (STFT) and Continuous Wavelet Transform (CWT).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from polars_ts.imaging._utils import extract_series
+
+
+def _spectrogram(
+    x: np.ndarray,
+    nperseg: int,
+    noverlap: int | None,
+    window: str,
+    log_scale: bool,
+) -> np.ndarray:
+    """Compute STFT spectrogram for a single 1D series."""
+    from scipy.signal import stft
+
+    if noverlap is None:
+        noverlap = nperseg // 2
+
+    _, _, Zxx = stft(x, nperseg=nperseg, noverlap=noverlap, window=window)
+    mag = np.abs(Zxx)
+
+    if log_scale:
+        mag = np.log1p(mag)
+
+    return mag
+
+
+def _morlet(M: int, s: float = 1.0, w: float = 5.0) -> np.ndarray:
+    """Complex Morlet wavelet."""
+    t = np.arange(-M // 2, M // 2 + 1, dtype=np.float64)
+    output = np.exp(1j * w * t / s) * np.exp(-0.5 * (t / s) ** 2) * np.pi ** (-0.25)
+    return output
+
+
+def _ricker(M: int, a: float = 1.0) -> np.ndarray:
+    """Mexican hat (Ricker) wavelet."""
+    t = np.arange(-M // 2, M // 2 + 1, dtype=np.float64) / a
+    return (2.0 / (np.sqrt(3 * a) * np.pi**0.25)) * (1 - t**2) * np.exp(-0.5 * t**2)
+
+
+def _cwt(x: np.ndarray, wavelet_func: str, scales: np.ndarray) -> np.ndarray:
+    """Continuous Wavelet Transform using convolution."""
+    from scipy.signal import fftconvolve
+
+    n = len(x)
+    coeffs = np.zeros((len(scales), n), dtype=np.complex128)
+
+    for i, scale in enumerate(scales):
+        M = min(10 * int(np.ceil(scale)), n)
+        if M < 1:
+            M = 1
+        if wavelet_func in ("morlet", "morl"):
+            wavelet = _morlet(M, s=scale)
+        else:
+            wavelet = _ricker(M, a=scale)
+        # Convolve and trim to original length
+        conv = fftconvolve(x, wavelet[::-1].conj(), mode="same")
+        coeffs[i] = conv
+
+    return coeffs
+
+
+def _scalogram(
+    x: np.ndarray,
+    wavelet: str,
+    scales: np.ndarray,
+) -> np.ndarray:
+    """Compute CWT scalogram for a single 1D series."""
+    supported = ("morlet", "morl", "ricker", "mexh")
+    # Normalise aliases
+    wname = wavelet
+    if wname == "mexh":
+        wname = "ricker"
+    if wname not in supported:
+        raise ValueError(f"Unknown wavelet {wavelet!r}. Supported: {list(supported)}")
+
+    coeffs = _cwt(x, wname, scales)
+    return np.abs(coeffs)
+
+
+def to_spectrogram(
+    df: pl.DataFrame,
+    nperseg: int = 64,
+    noverlap: int | None = None,
+    window: str = "hann",
+    log_scale: bool = True,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to STFT spectrogram images.
+
+    Computes the Short-Time Fourier Transform magnitude for each series.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    nperseg
+        Length of each STFT segment.
+    noverlap
+        Number of overlapping points between segments.
+        Defaults to ``nperseg // 2``.
+    window
+        Window function name (e.g. ``"hann"``, ``"hamming"``).
+    log_scale
+        Apply ``log1p`` to the magnitude for better dynamic range.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a 2D array (frequency x time bins).
+
+    """
+    series = extract_series(df, id_col, target_col)
+    return {sid: _spectrogram(vals, nperseg, noverlap, window, log_scale) for sid, vals in series.items()}
+
+
+def to_scalogram(
+    df: pl.DataFrame,
+    wavelet: str = "morlet",
+    scales: np.ndarray | None = None,
+    n_scales: int = 32,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to CWT scalogram images.
+
+    Computes the Continuous Wavelet Transform magnitude for each series.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    wavelet
+        Wavelet name: ``"morlet"`` / ``"morl"`` or ``"ricker"`` / ``"mexh"``.
+    scales
+        Array of scales to use. If ``None``, generates ``n_scales``
+        logarithmically spaced scales from 1 to series_length / 4.
+    n_scales
+        Number of scales when ``scales`` is ``None``.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a 2D array (scale x time).
+
+    """
+    series = extract_series(df, id_col, target_col)
+    result: dict[str, np.ndarray] = {}
+    for sid, vals in series.items():
+        if scales is None:
+            max_scale = max(len(vals) // 4, 2)
+            auto_scales = np.geomspace(1, max_scale, num=n_scales)
+        else:
+            auto_scales = scales
+        result[sid] = _scalogram(vals, wavelet, auto_scales)
+    return result

--- a/polars_ts/imaging/transition.py
+++ b/polars_ts/imaging/transition.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from polars_ts.imaging.recurrence import _extract_series
+from polars_ts.imaging._utils import extract_series
 
 
 def _quantile_bins(x: np.ndarray, n_bins: int) -> np.ndarray:
@@ -82,5 +82,5 @@ def to_mtf(
         Mapping from series ID to a square 2D array with values in [0, 1].
 
     """
-    series = _extract_series(df, id_col, target_col)
+    series = extract_series(df, id_col, target_col)
     return {sid: _mtf_matrix(vals, n_bins, image_size) for sid, vals in series.items()}

--- a/polars_ts/imaging/transition.py
+++ b/polars_ts/imaging/transition.py
@@ -83,7 +83,4 @@ def to_mtf(
 
     """
     series = _extract_series(df, id_col, target_col)
-    return {
-        sid: _mtf_matrix(vals, n_bins, image_size)
-        for sid, vals in series.items()
-    }
+    return {sid: _mtf_matrix(vals, n_bins, image_size) for sid, vals in series.items()}

--- a/polars_ts/imaging/transition.py
+++ b/polars_ts/imaging/transition.py
@@ -1,0 +1,89 @@
+"""Markov Transition Field (MTF) imaging for time series.
+
+Discretises values into quantile bins, estimates a Markov transition
+matrix, and maps transition probabilities back onto the time axis.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from polars_ts.imaging.recurrence import _extract_series
+
+
+def _quantile_bins(x: np.ndarray, n_bins: int) -> np.ndarray:
+    """Assign each value to a quantile bin (0 to n_bins-1)."""
+    percentiles = np.linspace(0, 100, n_bins + 1)
+    edges = np.percentile(x, percentiles)
+    # np.digitize returns 1-based; clip to [0, n_bins-1]
+    bins = np.digitize(x, edges[1:-1], right=True)
+    return np.clip(bins, 0, n_bins - 1)
+
+
+def _mtf_matrix(x: np.ndarray, n_bins: int, image_size: int | None) -> np.ndarray:
+    """Compute MTF for a single 1D series."""
+    bins = _quantile_bins(x, n_bins)
+
+    # Transition matrix
+    T = np.zeros((n_bins, n_bins), dtype=np.float64)
+    for i in range(len(bins) - 1):
+        T[bins[i], bins[i + 1]] += 1
+    row_sums = T.sum(axis=1, keepdims=True)
+    row_sums[row_sums == 0] = 1
+    T /= row_sums
+
+    # Build MTF: M[i,j] = T[bin(x_i), bin(x_j)]
+    n = len(bins)
+    M = T[bins[:, None], bins[None, :]]
+
+    # Optional PAA downsampling
+    if image_size is not None and image_size < n:
+        indices = np.array_split(np.arange(n), image_size)
+        M_down = np.zeros((image_size, image_size))
+        for i, idx_i in enumerate(indices):
+            for j, idx_j in enumerate(indices):
+                M_down[i, j] = M[np.ix_(idx_i, idx_j)].mean()
+        return M_down
+
+    return M
+
+
+def to_mtf(
+    df: pl.DataFrame,
+    n_bins: int = 8,
+    image_size: int | None = None,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, np.ndarray]:
+    """Convert time series to Markov Transition Field images.
+
+    Quantises values into ``n_bins`` bins, computes the Markov transition
+    matrix, then builds an n x n image where pixel (i, j) is the
+    transition probability from bin(x_i) to bin(x_j).
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    n_bins
+        Number of quantile bins for discretisation.
+    image_size
+        Output image dimension. ``None`` for full resolution (n x n).
+        Smaller values use Piecewise Aggregate Approximation (PAA).
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the time series values.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from series ID to a square 2D array with values in [0, 1].
+
+    """
+    series = _extract_series(df, id_col, target_col)
+    return {
+        sid: _mtf_matrix(vals, n_bins, image_size)
+        for sid, vals in series.items()
+    }

--- a/tests/clustering/test_auto.py
+++ b/tests/clustering/test_auto.py
@@ -1,7 +1,12 @@
+import importlib
+
 import polars as pl
 import pytest
 
 from polars_ts.clustering.auto import AutoClusterResult, auto_cluster
+
+_has_scipy = importlib.util.find_spec("scipy") is not None
+_has_sklearn = importlib.util.find_spec("sklearn") is not None
 
 
 @pytest.fixture
@@ -60,6 +65,7 @@ class TestAutoClusterMethods:
         assert result.best_method == "kmedoids"
         assert result.best_k == 2
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_spectral_method(self, well_separated_data):
         result = auto_cluster(well_separated_data, methods=["spectral"], distances=["sbd"], k_range=range(2, 3))
         assert result.best_method == "spectral"
@@ -79,6 +85,7 @@ class TestAutoClusterMethods:
         # Only SBD rows should appear in results
         assert all(row["distance"] == "sbd" for row in result.results_table.to_dicts())
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_hdbscan_no_k(self, well_separated_data):
         """HDBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -92,6 +99,7 @@ class TestAutoClusterMethods:
         assert result.results_table.shape[0] == 1
         assert result.results_table["k"][0] is None
 
+    @pytest.mark.skipif(not _has_sklearn, reason="sklearn required")
     def test_dbscan_no_k(self, well_separated_data):
         """DBSCAN doesn't use k; should produce one row per distance."""
         result = auto_cluster(
@@ -106,6 +114,7 @@ class TestAutoClusterMethods:
 
 
 class TestAutoClusterMultipleCombinations:
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_multiple_methods_and_distances(self, well_separated_data):
         result = auto_cluster(
             well_separated_data,
@@ -116,6 +125,7 @@ class TestAutoClusterMultipleCombinations:
         # 2 methods x 2 distances x 2 k values = 8 rows
         assert result.results_table.shape[0] == 8
 
+    @pytest.mark.skipif(not _has_scipy or not _has_sklearn, reason="scipy/sklearn required")
     def test_best_is_optimal(self, well_separated_data):
         """Best score should be the max silhouette in the results table."""
         result = auto_cluster(

--- a/tests/imaging/test_angular.py
+++ b/tests/imaging/test_angular.py
@@ -1,0 +1,82 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.imaging.angular import to_gadf, to_gasf
+
+
+@pytest.fixture
+def sample_data():
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 10 + ["B"] * 10,
+            "y": [float(i) for i in range(10)] + [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        }
+    )
+
+
+class TestGASF:
+    def test_output_shape(self, sample_data):
+        images = to_gasf(sample_data)
+        assert len(images) == 2
+        assert images["A"].shape == (10, 10)
+
+    def test_values_in_range(self, sample_data):
+        images = to_gasf(sample_data)
+        for img in images.values():
+            assert img.min() >= -1.0 - 1e-10
+            assert img.max() <= 1.0 + 1e-10
+
+    def test_symmetric(self, sample_data):
+        images = to_gasf(sample_data)
+        for img in images.values():
+            np.testing.assert_allclose(img, img.T, atol=1e-10)
+
+    def test_image_size_downsampling(self, sample_data):
+        images = to_gasf(sample_data, image_size=5)
+        for img in images.values():
+            assert img.shape == (5, 5)
+
+    def test_image_size_none_full_resolution(self, sample_data):
+        images = to_gasf(sample_data, image_size=None)
+        assert images["A"].shape == (10, 10)
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 5, "val": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        images = to_gasf(df, id_col="sid", target_col="val")
+        assert "X" in images
+
+    def test_constant_series(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 5, "y": [1.0] * 5})
+        images = to_gasf(df)
+        assert images["A"].shape == (5, 5)
+
+
+class TestGADF:
+    def test_output_shape(self, sample_data):
+        images = to_gadf(sample_data)
+        assert len(images) == 2
+        assert images["A"].shape == (10, 10)
+
+    def test_values_in_range(self, sample_data):
+        images = to_gadf(sample_data)
+        for img in images.values():
+            assert img.min() >= -1.0 - 1e-10
+            assert img.max() <= 1.0 + 1e-10
+
+    def test_antisymmetric(self, sample_data):
+        """GADF = sin(phi_i - phi_j) should be antisymmetric."""
+        images = to_gadf(sample_data)
+        for img in images.values():
+            np.testing.assert_allclose(img, -img.T, atol=1e-10)
+
+    def test_diagonal_is_zero(self, sample_data):
+        """sin(phi_i - phi_i) = 0."""
+        images = to_gadf(sample_data)
+        for img in images.values():
+            np.testing.assert_allclose(np.diag(img), 0, atol=1e-10)
+
+    def test_image_size_downsampling(self, sample_data):
+        images = to_gadf(sample_data, image_size=4)
+        for img in images.values():
+            assert img.shape == (4, 4)

--- a/tests/imaging/test_recurrence.py
+++ b/tests/imaging/test_recurrence.py
@@ -4,7 +4,7 @@ import pytest
 
 scipy = pytest.importorskip("scipy")
 
-from polars_ts.imaging.recurrence import rqa_features, to_recurrence_plot
+from polars_ts.imaging.recurrence import rqa_features, to_recurrence_plot  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/imaging/test_recurrence.py
+++ b/tests/imaging/test_recurrence.py
@@ -1,0 +1,92 @@
+import numpy as np
+import polars as pl
+import pytest
+
+scipy = pytest.importorskip("scipy")
+
+from polars_ts.imaging.recurrence import rqa_features, to_recurrence_plot
+
+
+@pytest.fixture
+def sample_data():
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 10 + ["B"] * 10,
+            "y": [float(i) for i in range(10)] + [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        }
+    )
+
+
+class TestToRecurrencePlot:
+    def test_output_shape(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=0.5)
+        assert len(images) == 2
+        assert images["A"].shape == (10, 10)
+        assert images["B"].shape == (10, 10)
+
+    def test_diagonal_is_zero(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=0.5)
+        for img in images.values():
+            np.testing.assert_array_equal(np.diag(img), np.ones(10))
+
+    def test_symmetric(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=0.5)
+        for img in images.values():
+            np.testing.assert_array_equal(img, img.T)
+
+    def test_binary_values(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=0.5)
+        for img in images.values():
+            assert set(np.unique(img)).issubset({0.0, 1.0})
+
+    def test_grayscale(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=None)
+        for img in images.values():
+            assert img.dtype == np.float64
+            assert img.min() >= 0
+
+    def test_no_normalize(self, sample_data):
+        img_norm = to_recurrence_plot(sample_data, threshold=None, normalize=True)
+        img_raw = to_recurrence_plot(sample_data, threshold=None, normalize=False)
+        # Should produce different distance values
+        assert not np.allclose(img_norm["A"], img_raw["A"])
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "sid": ["X"] * 5,
+                "val": [1.0, 2.0, 3.0, 2.0, 1.0],
+            }
+        )
+        images = to_recurrence_plot(df, id_col="sid", target_col="val")
+        assert "X" in images
+        assert images["X"].shape == (5, 5)
+
+    def test_single_series(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 5, "y": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        images = to_recurrence_plot(df)
+        assert len(images) == 1
+
+
+class TestRQAFeatures:
+    def test_keys(self):
+        R = np.eye(5)
+        features = rqa_features(R)
+        expected_keys = {"recurrence_rate", "determinism", "laminarity", "mean_diagonal", "mean_vertical", "entropy"}
+        assert set(features.keys()) == expected_keys
+
+    def test_identity_matrix(self):
+        R = np.eye(10)
+        features = rqa_features(R)
+        assert features["recurrence_rate"] == pytest.approx(0.1)
+
+    def test_full_recurrence(self):
+        R = np.ones((5, 5))
+        features = rqa_features(R)
+        assert features["recurrence_rate"] == pytest.approx(1.0)
+        assert features["determinism"] > 0
+
+    def test_periodic_signal(self, sample_data):
+        images = to_recurrence_plot(sample_data, threshold=0.5)
+        features = rqa_features(images["B"])
+        assert features["recurrence_rate"] > 0

--- a/tests/imaging/test_signature.py
+++ b/tests/imaging/test_signature.py
@@ -1,0 +1,122 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.imaging.signature import signature_features, to_signature_image
+
+
+@pytest.fixture
+def sample_data():
+    """Return two series with distinct shapes."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 20 + ["B"] * 20,
+            "y": [float(i) for i in range(20)] + [float(19 - i) for i in range(20)],
+        }
+    )
+
+
+class TestSignatureFeatures:
+    def test_output_type(self, sample_data):
+        result = signature_features(sample_data, depth=2)
+        assert isinstance(result, pl.DataFrame)
+
+    def test_output_shape_depth1(self, sample_data):
+        result = signature_features(sample_data, depth=1, augmentations=["time"])
+        assert result.shape[0] == 2
+        # depth=1, 2 channels (time + y) → 2 features
+        assert result.shape[1] == 3  # unique_id + 2 sig columns
+
+    def test_output_shape_depth2(self, sample_data):
+        result = signature_features(sample_data, depth=2, augmentations=["time"])
+        assert result.shape[0] == 2
+        # depth=1 → 2, depth=2 → 4, total → 6 features
+        assert result.shape[1] == 7  # unique_id + 6
+
+    def test_output_shape_depth3(self, sample_data):
+        result = signature_features(sample_data, depth=3, augmentations=["time"])
+        assert result.shape[0] == 2
+        # depth=1 → 2, depth=2 → 4, depth=3 → 8, total → 14
+        assert result.shape[1] == 15  # unique_id + 14
+
+    def test_series_ids_preserved(self, sample_data):
+        result = signature_features(sample_data, depth=2)
+        assert set(result["unique_id"].to_list()) == {"A", "B"}
+
+    def test_different_series_different_signatures(self, sample_data):
+        result = signature_features(sample_data, depth=2)
+        sig_a = result.filter(pl.col("unique_id") == "A").drop("unique_id").to_numpy()
+        sig_b = result.filter(pl.col("unique_id") == "B").drop("unique_id").to_numpy()
+        assert not np.allclose(sig_a, sig_b)
+
+    def test_no_augmentation(self, sample_data):
+        result = signature_features(sample_data, depth=2, augmentations=[])
+        assert result.shape[0] == 2
+        # 1 channel, depth=1 → 1, depth=2 → 1, total → 2
+        assert result.shape[1] == 3  # unique_id + 2
+
+    def test_leadlag_augmentation(self, sample_data):
+        result = signature_features(sample_data, depth=2, augmentations=["leadlag"])
+        assert result.shape[0] == 2
+        # leadlag on 1D → 2 channels, depth=1 → 2, depth=2 → 4, total → 6
+        assert result.shape[1] == 7
+
+    def test_basepoint_augmentation(self, sample_data):
+        result = signature_features(sample_data, depth=1, augmentations=["time", "basepoint"])
+        assert result.shape[0] == 2
+
+    def test_unknown_augmentation_raises(self, sample_data):
+        with pytest.raises(ValueError, match="Unknown augmentation"):
+            signature_features(sample_data, depth=1, augmentations=["invalid"])
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 10, "val": [float(i) for i in range(10)]})
+        result = signature_features(df, depth=2, id_col="sid", target_col="val")
+        assert "sid" in result.columns
+        assert result.shape[0] == 1
+
+    def test_depth4_without_iisignature_raises(self, sample_data):
+        try:
+            import iisignature  # noqa: F401
+
+            pytest.skip("iisignature installed, cannot test fallback limit")
+        except ImportError:
+            with pytest.raises(ValueError, match="depth <= 3"):
+                signature_features(sample_data, depth=4)
+
+    def test_single_series(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 10, "y": [float(i) for i in range(10)]})
+        result = signature_features(df, depth=2)
+        assert result.shape[0] == 1
+
+
+class TestToSignatureImage:
+    def test_output_shape(self, sample_data):
+        images = to_signature_image(sample_data, depth=2, augmentations=["time"])
+        assert len(images) == 2
+        # 2 channels → 2×2 matrix
+        for img in images.values():
+            assert img.shape == (2, 2)
+
+    def test_depth_too_low_raises(self, sample_data):
+        with pytest.raises(ValueError, match="depth must be >= 2"):
+            to_signature_image(sample_data, depth=1)
+
+    def test_series_ids(self, sample_data):
+        images = to_signature_image(sample_data, depth=2)
+        assert set(images.keys()) == {"A", "B"}
+
+    def test_different_series_different_images(self, sample_data):
+        images = to_signature_image(sample_data, depth=2)
+        assert not np.allclose(images["A"], images["B"])
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 10, "val": [float(i) for i in range(10)]})
+        images = to_signature_image(df, depth=2, id_col="sid", target_col="val")
+        assert "X" in images
+
+    def test_no_augmentation_1d(self, sample_data):
+        images = to_signature_image(sample_data, depth=2, augmentations=[])
+        for img in images.values():
+            # 1 channel → 1×1 image
+            assert img.shape == (1, 1)

--- a/tests/imaging/test_spectral.py
+++ b/tests/imaging/test_spectral.py
@@ -1,0 +1,126 @@
+import numpy as np
+import polars as pl
+import pytest
+
+scipy_signal = pytest.importorskip("scipy.signal")
+
+from polars_ts.imaging.spectral import to_scalogram, to_spectrogram  # noqa: E402
+
+
+@pytest.fixture
+def sample_data():
+    """Two series with 200 points each."""
+    rng = np.random.default_rng(42)
+    t = np.linspace(0, 1, 200)
+    # Series A: pure sine wave
+    a = np.sin(2 * np.pi * 10 * t)
+    # Series B: chirp (increasing frequency)
+    b = np.sin(2 * np.pi * (5 * t + 10 * t**2))
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 200 + ["B"] * 200,
+            "y": a.tolist() + b.tolist(),
+        }
+    )
+
+
+class TestToSpectrogram:
+    def test_output_keys(self, sample_data):
+        images = to_spectrogram(sample_data, nperseg=32)
+        assert set(images.keys()) == {"A", "B"}
+
+    def test_output_shape(self, sample_data):
+        images = to_spectrogram(sample_data, nperseg=32)
+        for img in images.values():
+            assert img.ndim == 2
+            # freq axis = nperseg // 2 + 1
+            assert img.shape[0] == 17
+
+    def test_non_negative(self, sample_data):
+        images = to_spectrogram(sample_data, nperseg=32)
+        for img in images.values():
+            assert img.min() >= 0
+
+    def test_log_scale(self, sample_data):
+        img_log = to_spectrogram(sample_data, nperseg=32, log_scale=True)
+        img_raw = to_spectrogram(sample_data, nperseg=32, log_scale=False)
+        # log1p values should be smaller than raw for values > ~1.7
+        assert not np.allclose(img_log["A"], img_raw["A"])
+
+    def test_nperseg_affects_shape(self, sample_data):
+        img_32 = to_spectrogram(sample_data, nperseg=32)
+        img_64 = to_spectrogram(sample_data, nperseg=64)
+        assert img_32["A"].shape[0] != img_64["A"].shape[0]
+
+    def test_noverlap_parameter(self, sample_data):
+        img_default = to_spectrogram(sample_data, nperseg=32)
+        img_custom = to_spectrogram(sample_data, nperseg=32, noverlap=16)
+        # Default noverlap is nperseg // 2 = 16, so these should be equal
+        np.testing.assert_allclose(img_default["A"], img_custom["A"])
+
+    def test_window_parameter(self, sample_data):
+        img_hann = to_spectrogram(sample_data, nperseg=32, window="hann")
+        img_hamming = to_spectrogram(sample_data, nperseg=32, window="hamming")
+        assert not np.allclose(img_hann["A"], img_hamming["A"])
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 100, "val": np.sin(np.linspace(0, 10, 100)).tolist()})
+        images = to_spectrogram(df, nperseg=16, id_col="sid", target_col="val")
+        assert "X" in images
+
+    def test_single_series(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 100, "y": np.random.default_rng(0).random(100).tolist()})
+        images = to_spectrogram(df, nperseg=16)
+        assert len(images) == 1
+
+
+class TestToScalogram:
+    def test_output_keys(self, sample_data):
+        images = to_scalogram(sample_data)
+        assert set(images.keys()) == {"A", "B"}
+
+    def test_output_shape(self, sample_data):
+        images = to_scalogram(sample_data, n_scales=16)
+        for img in images.values():
+            assert img.ndim == 2
+            assert img.shape[0] == 16  # n_scales
+            assert img.shape[1] == 200  # series length
+
+    def test_non_negative(self, sample_data):
+        images = to_scalogram(sample_data)
+        for img in images.values():
+            assert img.min() >= 0
+
+    def test_morlet_wavelet(self, sample_data):
+        images = to_scalogram(sample_data, wavelet="morlet")
+        assert len(images) == 2
+
+    def test_ricker_wavelet(self, sample_data):
+        images = to_scalogram(sample_data, wavelet="ricker")
+        assert len(images) == 2
+
+    def test_custom_scales(self, sample_data):
+        scales = np.array([1, 2, 4, 8, 16, 32], dtype=np.float64)
+        images = to_scalogram(sample_data, scales=scales)
+        for img in images.values():
+            assert img.shape[0] == 6
+
+    def test_n_scales_parameter(self, sample_data):
+        img_16 = to_scalogram(sample_data, n_scales=16)
+        img_32 = to_scalogram(sample_data, n_scales=32)
+        assert img_16["A"].shape[0] == 16
+        assert img_32["A"].shape[0] == 32
+
+    def test_unknown_wavelet_raises(self, sample_data):
+        with pytest.raises(ValueError, match="Unknown wavelet"):
+            to_scalogram(sample_data, wavelet="nonexistent")
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 100, "val": np.sin(np.linspace(0, 10, 100)).tolist()})
+        images = to_scalogram(df, id_col="sid", target_col="val")
+        assert "X" in images
+
+    def test_wavelet_aliases(self, sample_data):
+        img_morlet = to_scalogram(sample_data, wavelet="morlet", n_scales=8)
+        img_morl = to_scalogram(sample_data, wavelet="morl", n_scales=8)
+        np.testing.assert_allclose(img_morlet["A"], img_morl["A"])

--- a/tests/imaging/test_spectral.py
+++ b/tests/imaging/test_spectral.py
@@ -10,7 +10,6 @@ from polars_ts.imaging.spectral import to_scalogram, to_spectrogram  # noqa: E40
 @pytest.fixture
 def sample_data():
     """Two series with 200 points each."""
-    rng = np.random.default_rng(42)
     t = np.linspace(0, 1, 200)
     # Series A: pure sine wave
     a = np.sin(2 * np.pi * 10 * t)

--- a/tests/imaging/test_transition.py
+++ b/tests/imaging/test_transition.py
@@ -1,0 +1,59 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.imaging.transition import to_mtf
+
+
+@pytest.fixture
+def sample_data():
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 20,
+            "y": [float(i % 5) for i in range(20)],
+        }
+    )
+
+
+class TestMTF:
+    def test_output_shape(self, sample_data):
+        images = to_mtf(sample_data)
+        assert len(images) == 1
+        assert images["A"].shape == (20, 20)
+
+    def test_values_in_range(self, sample_data):
+        images = to_mtf(sample_data)
+        for img in images.values():
+            assert img.min() >= -1e-10
+            assert img.max() <= 1.0 + 1e-10
+
+    def test_n_bins_parameter(self, sample_data):
+        img_4 = to_mtf(sample_data, n_bins=4)["A"]
+        img_8 = to_mtf(sample_data, n_bins=8)["A"]
+        # Different binning should produce different images
+        assert not np.allclose(img_4, img_8)
+
+    def test_image_size_downsampling(self, sample_data):
+        images = to_mtf(sample_data, image_size=5)
+        assert images["A"].shape == (5, 5)
+
+    def test_image_size_none_full_resolution(self, sample_data):
+        images = to_mtf(sample_data, image_size=None)
+        assert images["A"].shape == (20, 20)
+
+    def test_multi_series(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 10 + ["B"] * 10,
+                "y": list(range(10)) + list(range(10)),
+            }
+        )
+        images = to_mtf(df)
+        assert len(images) == 2
+        assert images["A"].shape == (10, 10)
+        assert images["B"].shape == (10, 10)
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 10, "val": [float(i) for i in range(10)]})
+        images = to_mtf(df, id_col="sid", target_col="val")
+        assert "X" in images


### PR DESCRIPTION
## Summary

Closes #101, closes #102, closes #104, closes #105

New `polars_ts.imaging` module with five sub-modules for converting time series to 2D image representations and feature vectors.

### Recurrence plots (`polars_ts.imaging.recurrence`) — #101
- `to_recurrence_plot(df, threshold, metric, normalize)` — pairwise distance matrix, optional binarisation
- `rqa_features(R)` — recurrence rate, determinism, laminarity, entropy, line lengths

### Gramian Angular Fields (`polars_ts.imaging.angular`) — #102
- `to_gasf(df, image_size)` — Gramian Angular Summation Field
- `to_gadf(df, image_size)` — Gramian Angular Difference Field

### Markov Transition Fields (`polars_ts.imaging.transition`) — #102
- `to_mtf(df, n_bins, image_size)` — quantile-binned transition probability matrix

### Spectrograms & scalograms (`polars_ts.imaging.spectral`) — #104
- `to_spectrogram(df, nperseg, noverlap, window, log_scale)` — STFT magnitude
- `to_scalogram(df, wavelet, scales, n_scales)` — CWT with Morlet/Ricker wavelets

### Path signatures (`polars_ts.imaging.signature`) — #105
- `signature_features(df, depth, augmentations)` — truncated path signature feature vectors
- `to_signature_image(df, depth)` — depth-2 signature terms as d×d matrix
- Pure-numpy fallback for depth ≤ 3; optional `iisignature` for higher depths
- Augmentations: time, leadlag, basepoint

### Architecture
```
polars_ts/imaging/
├── __init__.py
├── _utils.py          # shared extract_series helper
├── recurrence.py      # recurrence plots + RQA
├── angular.py         # GASF, GADF
├── transition.py      # MTF
├── spectral.py        # spectrogram, scalogram
└── signature.py       # path signatures
```

All functions: `pl.DataFrame` in → `dict[str, np.ndarray]` out (or `pl.DataFrame` for features).

## Test plan

- [x] 69 tests passing locally (14 recurrence, 12 angular, 7 transition, 17 spectral, 19 signature)
- [x] All scipy imports lazy — modules importable without scipy
- [x] Signature works without iisignature (pure-numpy fallback)
- [ ] CI passes