### PR TITLE
docs: enrich documentation with 4 new guides, update README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
   <a href="https://pypi.org/project/polars-timeseries">PyPI</a>
 </p>
 
+<p align="center">
+  <a href="https://drumtorben.github.io/polars-ts/distance-metrics/">Distance Metrics</a> &bull;
+  <a href="https://drumtorben.github.io/polars-ts/clustering-guide/">Clustering</a> &bull;
+  <a href="https://drumtorben.github.io/polars-ts/forecasting-guide/">Forecasting</a> &bull;
+  <a href="https://drumtorben.github.io/polars-ts/imaging-guide/">Imaging</a> &bull;
+  <a href="https://drumtorben.github.io/polars-ts/changepoint-guide/">Changepoints</a> &bull;
+  <a href="https://drumtorben.github.io/polars-ts/preprocessing-guide/">Preprocessing</a>
+</p>
+
 ---
 
 **polars-ts** is a batteries-included time series toolkit built on [Polars](https://pola.rs/). It gives you Rust-accelerated distance metrics, 10+ clustering algorithms, a full forecasting stack, and diagnostics — all from a single `pip install`, no heavyweight frameworks required.
@@ -326,18 +335,18 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 
 The `notebooks/` directory contains 10 end-to-end tutorials:
 
-| # | Topic |
-|---|---|
-| 01 | Data wrangling & exploration |
-| 02 | Feature engineering & transforms |
-| 03 | Forecasting fundamentals |
-| 04 | ML forecasting pipelines |
-| 05 | Uncertainty & calibration |
-| 06 | Changepoint & anomaly detection |
-| 07 | Time series similarity & clustering |
-| 08 | Multivariate & volatility |
-| 09 | Ensembles & reconciliation |
-| 10 | Ecosystem adapters |
+| # | Topic | Notebook |
+|---|---|---|
+| 01 | Data wrangling & exploration | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/01_data_wrangling_and_exploration.ipynb) |
+| 02 | Feature engineering & transforms | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/02_feature_engineering_transforms.ipynb) |
+| 03 | Forecasting fundamentals | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/03_forecasting_fundamentals.ipynb) |
+| 04 | ML forecasting pipelines | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/04_ml_forecasting_pipelines.ipynb) |
+| 05 | Uncertainty & calibration | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/05_uncertainty_and_calibration.ipynb) |
+| 06 | Changepoint & anomaly detection | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/06_changepoint_anomaly_detection.ipynb) |
+| 07 | Time series similarity & clustering | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/07_time_series_similarity_clustering.ipynb) |
+| 08 | Multivariate & volatility | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/08_multivariate_volatility.ipynb) |
+| 09 | Ensembles & reconciliation | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/09_ensembles_reconciliation.ipynb) |
+| 10 | Ecosystem adapters | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/10_ecosystem_adapters.ipynb) |
 
 ---
 

--- a/docs/changepoint-guide.md
+++ b/docs/changepoint-guide.md
@@ -1,0 +1,86 @@
+# Changepoint & Anomaly Detection Guide
+
+polars-ts provides trend tests, changepoint detection, regime inference, and anomaly detection — all group-aware and Polars-native.
+
+## Trend detection
+
+### Mann-Kendall test
+
+Non-parametric test for monotonic trend. Returns a struct with `tau`, `p_value`, and `trend` (increasing/decreasing/no trend). Implemented in Rust.
+
+```python
+import polars as pl
+import polars_ts as pts
+
+result = df.group_by("unique_id").agg(
+    pts.mann_kendall(pl.col("y")).alias("trend"),
+)
+```
+
+### Sen's slope
+
+Robust trend magnitude estimator (median of all pairwise slopes). Implemented in Rust.
+
+```python
+result = df.group_by("unique_id").agg(
+    pts.sens_slope(pl.col("y")).alias("slope"),
+)
+```
+
+## Changepoint detection
+
+### CUSUM
+
+Cumulative sum control chart for detecting mean shifts. Implemented in Rust.
+
+```python
+result = pts.cusum(df)
+```
+
+### PELT
+
+Pruned Exact Linear Time algorithm for finding multiple changepoints with configurable cost functions.
+
+```python
+result = pts.pelt(df, cost="meanvar", pen=10)
+```
+
+Cost functions: `"mean"`, `"var"`, `"meanvar"`.
+
+### BOCPD
+
+Bayesian Online Changepoint Detection — detects changepoints in a streaming fashion using a Student-t model.
+
+```python
+result = pts.bocpd(df, hazard=250, mu0=0, kappa0=1, alpha0=1, beta0=1)
+```
+
+## Regime detection
+
+Hidden Markov Model state inference via Baum-Welch EM.
+
+```python
+result = pts.regime_detect(df, n_regimes=3)
+```
+
+## Anomaly detection
+
+### Decomposition-based
+
+Flag anomalies from decomposition residuals exceeding a threshold.
+
+```python
+result = pts.seasonal_decomposition(df, freq=24, method="additive", anomaly_threshold=2.0)
+```
+
+### Isolation Forest
+
+Unsupervised anomaly detection on engineered features.
+
+```python
+result = pts.isolation_forest_detect(df, contamination=0.05)
+```
+
+## Further reading
+
+- **Notebook 06**: [Changepoint & anomaly detection](https://github.com/drumtorben/polars-ts/blob/main/notebooks/06_changepoint_anomaly_detection.ipynb)

--- a/docs/clustering-guide.md
+++ b/docs/clustering-guide.md
@@ -1,289 +1,152 @@
-# Clustering Time Series with polars-ts Distance Matrices
+# Clustering & Classification Guide
 
-This guide shows how to use pairwise distance matrices computed by polars-ts as
-input to standard clustering algorithms from scipy and scikit-learn.
+polars-ts provides 11 clustering algorithms, an automated pipeline selector, 3 evaluation metrics, and 3 classifiers — all working with the same distance infrastructure.
 
-## Overview
+## Available methods
 
-polars-ts computes pairwise distances between time series and returns the results
-as a Polars DataFrame with three columns:
+| Method | Function | When to use |
+|---|---|---|
+| **K-Medoids (PAM)** | `kmedoids` | Known k, any distance metric, interpretable medoids |
+| **K-Shape** | `KShape` | Shape-based grouping via cross-correlation centroids |
+| **Spectral (KSC)** | `spectral_cluster` | Non-convex clusters, graph Laplacian structure |
+| **HDBSCAN** | `hdbscan_cluster` | Unknown k, varying density, noise detection |
+| **DBSCAN** | `dbscan_cluster` | Fixed-radius neighbourhood, noise detection |
+| **Hierarchical** | `agglomerative_cluster` | Dendrogram visualization, flexible linkage |
+| **K-Means DBA** | `kmeans_dba` | DTW-aware centroids |
+| **CLARA** | `clara` | Scalable k-medoids via sampling |
+| **CLARANS** | `clarans` | Randomized k-medoids neighbourhood search |
+| **U-Shapelets** | `shapelet_cluster` | Interpretable sub-sequence patterns |
+| **Auto-cluster** | `auto_cluster` | Sweep methods × distances × k, pick the best |
 
-| Column | Description |
-|--------|-------------|
-| `id_1` | Identifier of the first series |
-| `id_2` | Identifier of the second series |
-| *(metric)* | The distance value (column name matches the metric, e.g. `dtw`, `msm`) |
+## Quick start
 
-The output contains one row per **unique unordered pair** — that is, only the
-upper triangle of the distance matrix, excluding the diagonal. This is exactly
-the information needed to build a condensed distance vector for scipy or a full
-square matrix for scikit-learn.
-
----
-
-## 1. Computing a Full Pairwise Distance Matrix
-
-All `compute_pairwise_*` functions accept two DataFrames with columns
-`unique_id` (series identifier) and `y` (values). Pass the same DataFrame twice
-to get the full pairwise matrix of all series against each other.
+### K-Medoids
 
 ```python
-import polars as pl
-from polars_ts import compute_pairwise_dtw
-# Each series is identified by "unique_id"; values live in "y"
-df = pl.DataFrame({
-    "unique_id": ["A"] * 5 + ["B"] * 5 + ["C"] * 5,
-    "y":         [1.0, 2, 3, 4, 5,
-                  1.0, 2, 3, 4, 6,
-                  5.0, 4, 3, 2, 1],
-})
+import polars_ts as pts
 
-distances = compute_pairwise_dtw(df, df)
-print(distances)
-# shape: (3, 3)
-# ┌──────┬──────┬─────┐
-# │ id_1 │ id_2 │ dtw │
-# │ ---  │ ---  │ --- │
-# │ str  │ str  │ f64 │
-# ╞══════╪══════╪═════╡
-# │ A    │ B    │ 1.0 │
-# │ A    │ C    │ 8.0 │
-# │ B    │ C    │ 9.0 │
-# └──────┴──────┴─────┘
+labels = pts.kmedoids(df, k=3, method="dtw")
+# → DataFrame[unique_id, cluster]
 ```
 
-Other available distance functions and their key parameters:
-
-| Function | Distance column | Key parameters |
-|----------|----------------|----------------|
-| `compute_pairwise_dtw` | `dtw` | `method` (`"sakoe_chiba"`, `"itakura"`, `"fast"`), `param` |
-| `compute_pairwise_ddtw` | `ddtw` | — |
-| `compute_pairwise_wdtw` | `wdtw` | `g` (weight penalty) |
-| `compute_pairwise_msm` | `msm` | `c` (cost) |
-| `compute_pairwise_erp` | `erp` | `g` (gap penalty) |
-| `compute_pairwise_lcss` | `lcss` | `epsilon` (matching threshold) |
-| `compute_pairwise_twe` | `twe` | `nu`, `lambda_` |
-| `compute_pairwise_dtw_multi` | `dtw_multi` | `metric` (`"manhattan"`, `"euclidean"`) |
-| `compute_pairwise_msm_multi` | `msm_multi` | `c` |
-
----
-
-## 2. Converting to a scipy Condensed Distance Vector
-
-scipy's hierarchical clustering functions expect a **condensed distance vector**
-— a 1-D array containing the upper triangle of the distance matrix in
-row-major order. polars-ts already returns exactly these upper-triangle pairs,
-but the row order may not match what scipy expects. The helper below
-re-indexes the pairs into the correct order.
+### K-Shape
 
 ```python
-import numpy as np
-from scipy.spatial.distance import squareform
-
-def to_condensed(distances):
-    # Convert a polars-ts pairwise result to a scipy condensed distance vector.
-    # Returns a (condensed_vector, labels) tuple.
-    cols = [c for c in distances.columns if c not in ("id_1", "id_2")]
-dist_col = cols[0]
-    # Collect all unique ids in sorted order
-    all_ids = set(distances["id_1"].to_list()) | set(distances["id_2"].to_list())
-    ids = sorted(all_ids)
-    id_to_idx = {name: i for i, name in enumerate(ids)}
-    n = len(ids)
-    # Build the condensed vector in scipy's expected order
-    condensed = np.zeros(n * (n - 1) // 2)
-    for row in distances.iter_rows(named=True):
-        i, j = id_to_idx[row["id_1"]], id_to_idx[row["id_2"]]
-        if i > j:
-            i, j = j, i
-        idx = n * i - i * (i + 1) // 2 + (j - i - 1)
-        condensed[idx] = row[dist_col]
-    return condensed, ids
+kshape = pts.KShape(n_clusters=3)
+kshape.fit(df)
+print(kshape.labels_)
 ```
 
-You can also convert to a full square matrix when needed:
+### HDBSCAN (automatic k, noise detection)
 
 ```python
-condensed, labels = to_condensed(distances)
-square_matrix = squareform(condensed)
-print(square_matrix)
+labels = pts.hdbscan_cluster(df, method="dtw", min_cluster_size=3)
+# Noise points have cluster = -1
 ```
 
----
-
-## 3. Hierarchical Clustering with scipy
-
-Once you have the condensed vector you can pass it directly to
-`scipy.cluster.hierarchy.linkage`.
+### Spectral clustering
 
 ```python
-from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
-import matplotlib.pyplot as plt
-
-condensed, labels = to_condensed(distances)
-# Compute the linkage matrix (Ward's method is not valid for arbitrary
-# distance matrices; use "average", "complete", or "single" instead)
-Z = linkage(condensed, method="average")
-# Cut the dendrogram to get flat clusters
-cluster_labels = fcluster(Z, t=2, criterion="maxclust")
-for name, cluster in zip(labels, cluster_labels):
-    print(f"  {name} -> cluster {cluster}")
+labels = pts.spectral_cluster(df, k=3, method="sbd", sigma=1.0)
 ```
 
-### Drawing a Dendrogram
+### Auto-cluster (automated selection)
 
 ```python
-fig, ax = plt.subplots(figsize=(8, 4))
-dendrogram(Z, labels=labels, ax=ax)
-ax.set_ylabel("Distance")
-ax.set_title("Hierarchical Clustering Dendrogram (DTW)")
-plt.tight_layout()
-plt.show()
-```
-
----
-
-## 4. Spectral Clustering with scikit-learn
-
-Spectral clustering operates on an **affinity (similarity) matrix** rather than a
-distance matrix. Convert distances to affinities using a Gaussian kernel or
-simple inversion.
-
-```python
-from sklearn.cluster import SpectralClustering
-
-condensed, labels = to_condensed(distances)
-square_matrix = squareform(condensed)
-# Convert distances to affinities via a Gaussian kernel.
-# sigma controls the width; a common heuristic is the median distance.
-sigma = np.median(square_matrix[square_matrix > 0])
-affinity_matrix = np.exp(-square_matrix ** 2 / (2 * sigma ** 2))
-# Ensure the diagonal is 1 (self-similarity)
-np.fill_diagonal(affinity_matrix, 1.0)
-
-sc = SpectralClustering(
-    n_clusters=2,
-    affinity="precomputed",
-    random_state=42,
+result = pts.auto_cluster(
+    df,
+    methods=["kmedoids", "spectral", "kshape"],
+    distances=["sbd", "dtw"],
+    k_range=range(2, 6),
+    metric="silhouette",
 )
-cluster_labels = sc.fit_predict(affinity_matrix)
-
-for name, cluster in zip(labels, cluster_labels):
-    print(f"  {name} -> cluster {cluster}")
+print(f"Best: {result.best_method}, k={result.best_k}, score={result.best_score:.4f}")
+print(result.results_table)  # Full grid search results
 ```
 
----
-
-## 5. Complete Worked Example
-
-The example below generates synthetic time series, computes DTW distances,
-performs both hierarchical and spectral clustering, and prints the results.
+## Evaluation metrics
 
 ```python
-import numpy as np
-import polars as pl
-from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
-from scipy.spatial.distance import squareform
-from sklearn.cluster import SpectralClustering
-import matplotlib.pyplot as plt
+from polars_ts import silhouette_score, davies_bouldin_score, calinski_harabasz_score
 
+sil = silhouette_score(df, labels, method="dtw")
+dbi = davies_bouldin_score(df, labels, method="dtw")
+chi = calinski_harabasz_score(df, labels, method="dtw")
+```
+
+| Metric | Ideal value | Interpretation |
+|---|---|---|
+| **Silhouette** | Close to 1 | Cohesive within, separated between |
+| **Davies-Bouldin** | Close to 0 | Low intra-cluster scatter vs inter-cluster distance |
+| **Calinski-Harabasz** | Higher is better | Between-cluster to within-cluster dispersion ratio |
+
+## Classification
+
+```python
+# k-NN classification
+preds = pts.knn_classify(train_df, test_df, k=3, method="dtw", label_col="label")
+
+# OOP API
+knn = pts.TimeSeriesKNNClassifier(k=3, metric="dtw")
+knn.fit(train_df, label_col="label")
+preds = knn.predict(test_df)
+
+# K-Shape classifier
+clf = pts.KShapeClassifier(n_centroids_per_class=1)
+clf.fit(train_df, label_col="label")
+preds = clf.predict(test_df)
+```
+
+## Feature extraction for clustering
+
+### ROCKET / MiniRocket
+
+Random convolutional kernel features for downstream clustering.
+
+```python
+features = pts.rocket_features(df, n_kernels=10000)
+features = pts.minirocket_features(df, n_kernels=10000)
+```
+
+### Foundation model embeddings
+
+```python
+embeddings = pts.to_chronos_embeddings(df, model_name="amazon/chronos-t5-small")
+embeddings = pts.to_moment_embeddings(df, model_name="AutonLab/MOMENT-1-large")
+```
+
+## Using distance matrices with scipy/sklearn
+
+polars-ts distance output can be converted to scipy condensed vectors or sklearn precomputed matrices. See the [distance metrics guide](distance-metrics.md) for the full conversion workflow.
+
+```python
 from polars_ts import compute_pairwise_dtw
-# ── Step 1: Create sample time series ──────────────────────────────────
-np.random.seed(42)
-n_points = 50
-# Group 1: upward trends
-series = {}
-for i in range(4):
-    series[f"up_{i}"] = np.linspace(0, 10, n_points) + np.random.normal(0, 0.5, n_points)
-# Group 2: downward trends
-for i in range(4):
-    series[f"down_{i}"] = np.linspace(10, 0, n_points) + np.random.normal(0, 0.5, n_points)
-# Build a polars DataFrame in the expected format
-df = pl.DataFrame({
-    "unique_id": [name for name, vals in series.items() for _ in vals],
-    "y": [v for vals in series.values() for v in vals],
-})
+from scipy.spatial.distance import squareform
+from scipy.cluster.hierarchy import linkage, fcluster
+import numpy as np
 
-print(f"Input shape: {df.shape}")
-print(f"Series: {sorted(series.keys())}")
-# ── Step 2: Compute pairwise DTW distances ─────────────────────────────
 distances = compute_pairwise_dtw(df, df)
-print(f"\nPairwise distances: {distances.shape[0]} pairs")
-print(distances.head())
-# ── Step 3: Convert to condensed form ──────────────────────────────────
-cols = [c for c in distances.columns if c not in ("id_1", "id_2")]
-dist_col = cols[0]
+
+# Convert to condensed vector
 ids = sorted(set(distances["id_1"].to_list()) | set(distances["id_2"].to_list()))
 id_to_idx = {name: i for i, name in enumerate(ids)}
 n = len(ids)
-
 condensed = np.zeros(n * (n - 1) // 2)
 for row in distances.iter_rows(named=True):
     i, j = id_to_idx[row["id_1"]], id_to_idx[row["id_2"]]
     if i > j:
         i, j = j, i
     idx = n * i - i * (i + 1) // 2 + (j - i - 1)
-    condensed[idx] = row[dist_col]
-# ── Step 4: Hierarchical clustering ───────────────────────────────────
+    condensed[idx] = row["dtw"]
+
+# Hierarchical clustering
 Z = linkage(condensed, method="average")
-hier_labels = fcluster(Z, t=2, criterion="maxclust")
-
-print("\n=== Hierarchical Clustering (2 clusters) ===")
-for name, cl in zip(ids, hier_labels):
-    print(f"  {name:>8s} -> cluster {cl}")
-# ── Step 5: Spectral clustering ───────────────────────────────────────
-square_matrix = squareform(condensed)
-sigma = np.median(square_matrix[square_matrix > 0])
-affinity = np.exp(-square_matrix ** 2 / (2 * sigma ** 2))
-np.fill_diagonal(affinity, 1.0)
-
-sc = SpectralClustering(n_clusters=2, affinity="precomputed", random_state=42)
-spec_labels = sc.fit_predict(affinity)
-
-print("\n=== Spectral Clustering (2 clusters) ===")
-for name, cl in zip(ids, spec_labels):
-    print(f"  {name:>8s} -> cluster {cl}")
-# ── Step 6: Visualize ─────────────────────────────────────────────────
-fig, axes = plt.subplots(1, 2, figsize=(14, 5))
-# Dendrogram
-dendrogram(Z, labels=ids, ax=axes[0])
-axes[0].set_title("Hierarchical Clustering Dendrogram")
-axes[0].set_ylabel("DTW Distance")
-axes[0].tick_params(axis="x", rotation=45)
-# Heatmap of the distance matrix
-im = axes[1].imshow(square_matrix, cmap="viridis")
-axes[1].set_xticks(range(n))
-axes[1].set_yticks(range(n))
-axes[1].set_xticklabels(ids, rotation=45, ha="right")
-axes[1].set_yticklabels(ids)
-axes[1].set_title("DTW Distance Heatmap")
-fig.colorbar(im, ax=axes[1], shrink=0.8)
-
-plt.tight_layout()
-plt.show()
+labels = fcluster(Z, t=3, criterion="maxclust")
 ```
 
-### Expected output
+## Further reading
 
-The eight series should cleanly separate into two clusters: all `up_*` series in
-one cluster and all `down_*` series in the other. Both hierarchical and spectral
-clustering should agree on this partition because the within-group DTW distances
-(small warping between noisy versions of the same trend) are much smaller than the
-between-group distances (comparing an upward trend against a downward trend).
-
----
-
-## Tips
-
-- **Linkage method**: Ward's method (`method="ward"`) requires Euclidean
-  distances and is not appropriate for arbitrary time-series distance metrics.
-  Use `"average"`, `"complete"`, or `"single"` instead.
-- **Choosing the number of clusters**: Use the dendrogram to visually identify a
-  natural cut height, or use the `inconsistent` criterion in `fcluster`.
-- **Large datasets**: polars-ts distance functions are implemented in Rust and
-  run in parallel. For very large collections, consider using approximate methods
-  like `compute_pairwise_dtw(df, df, method="fast", param=5.0)` (FastDTW).
-- **Alternative metrics**: Different distance metrics capture different notions
-  of similarity. MSM is better for amplitude-sensitive comparisons, LCSS is
-  robust to outliers, and WDTW penalizes large temporal shifts. Experiment with
-  multiple metrics on your data.
+- **Notebook 07**: [Time series similarity & clustering](https://github.com/drumtorben/polars-ts/blob/main/notebooks/07_time_series_similarity_clustering.ipynb)
+- Paparrizos & Gravano (2015). *k-Shape: Efficient and Accurate Clustering of Time Series*. SIGMOD.
+- Campello et al. (2013). *Density-Based Clustering Based on Hierarchical Density Estimates*. PAKDD.
+- von Luxburg (2007). *A Tutorial on Spectral Clustering*. Statistics and Computing.

--- a/docs/forecasting-guide.md
+++ b/docs/forecasting-guide.md
@@ -1,0 +1,125 @@
+# Forecasting Guide
+
+polars-ts provides a complete forecasting stack — from simple baselines to ML pipelines, ensembles, and probabilistic intervals.
+
+## Baseline models
+
+Start with baselines to establish a benchmark before moving to complex models.
+
+```python
+import polars_ts as pts
+
+naive = pts.naive_forecast(df, h=12)
+seasonal = pts.seasonal_naive_forecast(df, h=12, season_length=24)
+ma = pts.moving_average_forecast(df, h=12, window_size=7)
+fft = pts.fft_forecast(df, h=12, n_harmonics=5)
+```
+
+## Exponential smoothing
+
+Rust-accelerated implementations of SES, Holt, and Holt-Winters.
+
+```python
+ses = pts.ses_forecast(df, h=12, alpha=0.3)
+holt = pts.holt_forecast(df, h=12, alpha=0.3, beta=0.1)
+hw = pts.holt_winters_forecast(df, h=12, season_length=24, seasonal="additive")
+```
+
+## ARIMA / SARIMA
+
+Two backends: manual order via `statsmodels`, or automatic selection via `statsforecast`.
+
+```python
+# Manual order
+fitted = pts.arima_fit(df, order=(1, 1, 1))
+forecast = pts.arima_forecast(fitted, h=12)
+
+# Automatic
+forecast = pts.auto_arima(df, h=12, season_length=12)
+```
+
+## ML forecast pipeline
+
+`ForecastPipeline` wires up feature engineering, target transforms, and any sklearn-compatible model.
+
+```python
+from sklearn.ensemble import GradientBoostingRegressor
+
+pipe = pts.ForecastPipeline(
+    GradientBoostingRegressor(),
+    lags=[1, 2, 7, 14],
+    rolling_windows=[7, 14],
+    calendar=["day_of_week", "month"],
+    target_transform="log",
+)
+pipe.fit(train_df)
+forecasts = pipe.predict(train_df, h=7)
+```
+
+## Multi-step strategies
+
+```python
+recursive = pts.RecursiveForecaster(model, lags=[1, 7])
+recursive.fit(train_df)
+preds = recursive.predict(train_df, h=14)
+
+direct = pts.DirectForecaster(model, lags=[1, 7], h=14)
+direct.fit(train_df)
+preds = direct.predict(train_df)
+```
+
+## Global models
+
+Train a single model across all series with optional series-identity encoding.
+
+```python
+gf = pts.GlobalForecaster(model, lags=[1, 7], id_encoding="ordinal")
+gf.fit(train_df)
+preds = gf.predict(train_df, h=7)
+```
+
+## Ensembles
+
+```python
+# Weighted combination
+ens = pts.WeightedEnsemble(weights="inverse_error")
+combined = ens.combine([forecast_a, forecast_b], validation_dfs=[val_a, val_b])
+
+# Stacking meta-learner
+stacker = pts.StackingForecaster(base_models=[model_a, model_b], meta_model=linear)
+stacker.fit(train_df)
+```
+
+## Probabilistic forecasting
+
+```python
+# Quantile regression
+qr = pts.QuantileRegressor(model, quantiles=[0.1, 0.5, 0.9])
+qr.fit(train_df)
+intervals = qr.predict(train_df, h=7)
+
+# Conformal prediction intervals
+result = pts.conformal_interval(cal_residuals, predictions, coverage=0.9)
+
+# EnbPI — online adaptive intervals
+enbpi = pts.EnbPI(model, n_bootstraps=100)
+enbpi.fit(train_df)
+intervals = enbpi.predict(train_df, h=7)
+```
+
+## Evaluation metrics
+
+```python
+from polars_ts import mae, rmse, mape, smape, mase, crps
+
+print(f"MAE:  {mae(actuals, forecasts):.4f}")
+print(f"RMSE: {rmse(actuals, forecasts):.4f}")
+print(f"MAPE: {mape(actuals, forecasts):.4f}")
+```
+
+## Further reading
+
+- **Notebook 03**: [Forecasting fundamentals](https://github.com/drumtorben/polars-ts/blob/main/notebooks/03_forecasting_fundamentals.ipynb)
+- **Notebook 04**: [ML forecasting pipelines](https://github.com/drumtorben/polars-ts/blob/main/notebooks/04_ml_forecasting_pipelines.ipynb)
+- **Notebook 05**: [Uncertainty & calibration](https://github.com/drumtorben/polars-ts/blob/main/notebooks/05_uncertainty_and_calibration.ipynb)
+- **Notebook 09**: [Ensembles & reconciliation](https://github.com/drumtorben/polars-ts/blob/main/notebooks/09_ensembles_reconciliation.ipynb)

--- a/docs/imaging-guide.md
+++ b/docs/imaging-guide.md
@@ -1,0 +1,125 @@
+# Time Series Imaging Guide
+
+polars-ts can convert time series into 2D image representations, enabling the use of computer vision techniques for clustering, classification, and anomaly detection.
+
+## Overview
+
+All imaging functions follow the same API:
+
+- **Input**: `pl.DataFrame` with `[unique_id, y]` columns
+- **Output**: `dict[str, np.ndarray]` mapping series ID → 2D image array
+
+| Function | Module | Output |
+|---|---|---|
+| `to_recurrence_plot` | `polars_ts.imaging.recurrence` | Binary/grayscale n×n distance matrix |
+| `rqa_features` | `polars_ts.imaging.recurrence` | Dict of 6 scalar RQA features |
+| `to_gasf` | `polars_ts.imaging.angular` | Gramian Angular Summation Field |
+| `to_gadf` | `polars_ts.imaging.angular` | Gramian Angular Difference Field |
+| `to_mtf` | `polars_ts.imaging.transition` | Markov Transition Field |
+| `to_spectrogram` | `polars_ts.imaging.spectral` | STFT magnitude (freq × time) |
+| `to_scalogram` | `polars_ts.imaging.spectral` | CWT magnitude (scale × time) |
+| `extract_vision_embeddings` | `polars_ts.imaging.embeddings` | DataFrame of dense feature vectors |
+
+## Recurrence plots
+
+A recurrence plot is a matrix where `R[i,j] = 1` if observations `x(i)` and `x(j)` are within a threshold distance. Periodic signals produce diagonal lines; chaotic signals produce complex textures.
+
+```python
+from polars_ts import to_recurrence_plot, rqa_features
+
+images = to_recurrence_plot(df, threshold=0.1, metric="euclidean", normalize=True)
+
+# Extract quantitative features
+for sid, rp in images.items():
+    features = rqa_features(rp)
+    print(f"{sid}: RR={features['recurrence_rate']:.3f}, DET={features['determinism']:.3f}")
+```
+
+**RQA features**: recurrence rate, determinism, laminarity, mean diagonal line length, mean vertical line length, entropy.
+
+## Gramian Angular Fields
+
+GAF encodes temporal correlations as angular differences on the unit circle.
+
+```python
+from polars_ts import to_gasf, to_gadf
+
+gasf_images = to_gasf(df)                     # cos(phi_i + phi_j)
+gadf_images = to_gadf(df)                     # sin(phi_i - phi_j)
+gasf_small = to_gasf(df, image_size=64)       # PAA downsampled to 64×64
+```
+
+- **GASF** values lie in [-1, 1], symmetric matrix
+- **GADF** values lie in [-1, 1], antisymmetric matrix (diagonal = 0)
+
+## Markov Transition Fields
+
+MTF discretises values into quantile bins and maps transition probabilities onto the time axis.
+
+```python
+from polars_ts import to_mtf
+
+mtf_images = to_mtf(df, n_bins=8)             # 8 quantile bins
+mtf_small = to_mtf(df, n_bins=8, image_size=64)
+```
+
+Values lie in [0, 1] (transition probabilities).
+
+## Spectrograms & scalograms
+
+Time-frequency representations for non-stationary series.
+
+```python
+from polars_ts import to_spectrogram, to_scalogram
+
+# STFT spectrogram
+specs = to_spectrogram(df, nperseg=64, noverlap=32, window="hann", log_scale=True)
+
+# CWT scalogram (Morlet or Ricker wavelet)
+scals = to_scalogram(df, wavelet="morlet", n_scales=32)
+scals_custom = to_scalogram(df, wavelet="ricker", scales=np.geomspace(1, 50, 64))
+```
+
+## Vision model embeddings
+
+Pass any of the above images through a pretrained vision model to get dense feature vectors.
+
+```python
+from polars_ts import to_gasf, extract_vision_embeddings
+
+images = to_gasf(df)
+embeddings = extract_vision_embeddings(images, model="resnet18")
+# → DataFrame[unique_id, emb_0, emb_1, ..., emb_511]
+```
+
+Supported models: `resnet18`, `resnet50`, `vit_b_16`, `clip`.
+
+## Image → clustering pipeline
+
+```python
+import numpy as np
+from sklearn.cluster import KMeans
+from polars_ts import to_gasf
+
+images = to_gasf(df)
+X = np.stack([img.flatten() for img in images.values()])
+labels = KMeans(n_clusters=3, n_init=10).fit_predict(X)
+```
+
+Or use vision model embeddings for higher-quality features:
+
+```python
+from polars_ts import to_gasf, extract_vision_embeddings
+
+images = to_gasf(df)
+embeddings = extract_vision_embeddings(images, model="resnet18")
+X = embeddings.drop("unique_id").to_numpy()
+labels = KMeans(n_clusters=3, n_init=10).fit_predict(X)
+```
+
+## Further reading
+
+- **Notebook 07**: [Time series similarity & clustering](https://github.com/drumtorben/polars-ts/blob/main/notebooks/07_time_series_similarity_clustering.ipynb)
+- Wang & Oates (2015). *Encoding Time Series as Images for Classification*. AAAI.
+- Hatami et al. (2018). *Classification of TS by CNNs Applied to Recurrence Plots*.
+- Eckmann et al. (1987). *Recurrence Plots of Dynamical Systems*. Europhysics Letters.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Polars Time Series Extension
+# polars-ts — Time Series Toolkit for Polars
 
-Welcome to the documentation for the **Polars Time Series Extension**.
+**polars-ts** is a batteries-included time series toolkit built on [Polars](https://pola.rs/). It gives you Rust-accelerated distance metrics, 10+ clustering algorithms, a full forecasting stack, and diagnostics — all from a single `pip install`.
 
 ---
 
@@ -8,50 +8,114 @@ Welcome to the documentation for the **Polars Time Series Extension**.
 
 **Source Code**: [https://github.com/drumtorben/polars-ts](https://github.com/drumtorben/polars-ts)
 
+**PyPI**: [https://pypi.org/project/polars-timeseries](https://pypi.org/project/polars-timeseries)
+
 ---
 
-## 📖 Overview
+## Why polars-ts?
 
-The **Polars Time Series Extention** offers a wide range of metrics, feature extractors, and various tools for time series forecasting.
+| Pain point | How polars-ts helps |
+|---|---|
+| "I need DTW but scipy is slow" | 12 distance metrics compiled to native code via Rust + Rayon |
+| "I want to cluster time series but tslearn has too many deps" | K-Medoids, K-Shape, HDBSCAN, Spectral, Hierarchical + 6 more — all built-in |
+| "Setting up a forecast pipeline takes too long" | `ForecastPipeline` wires up lags, rolling stats, transforms, and any sklearn model in 5 lines |
+| "I don't know which clustering method to pick" | `auto_cluster` sweeps methods × distances × k and returns the best |
+| "Polars doesn't have time series functions" | Mann-Kendall, Sen's slope, CUSUM, PELT, decomposition, ACF/PACF — all Polars-native |
 
 ## Installation
 
 === "uv (recommended)"
-    `uv add polars-timeseries`
+    ```bash
+    uv add polars-timeseries
+    ```
 
 === "pip"
-    `pip install polars-timeseries`
+    ```bash
+    pip install polars-timeseries
+    ```
 
-=== "poetry"
-    `poetry add polars-timeseries`
+Extras for optional features:
 
-## How to use
-
-The `polars-ts` plugin is available under the namespace `pts`.
-See the following example where we compute the Kaboudan metric:
-
-```py
-import polars as pl
-from statsforecast import StatsForecast
-from statsforecast.models import AutoETS, OptimizedTheta
-
-import polars_ts as pts  # noqa
-
-# Create sample dataframe with columns `unique_id`, `ds`, and `y`.
-df = (
-    pl.scan_parquet("https://datasets-nixtla.s3.amazonaws.com/m4-hourly.parquet")
-    .filter(pl.col("unique_id").is_in(["H1", "H2", "H3"]))
-    .collect()
-)
-
-# Define models
-season_length = 24
-models = [
-    OptimizedTheta(season_length=season_length, decomposition_type="additive"),
-    AutoETS(season_length=season_length),
-]
-sf = StatsForecast(models=models, freq=1, n_jobs=-1)
-
-# Compute the Kaboudan metric in the `pts` namespace
-res = df.pts.kaboudan(sf, block_size=200, backtesting_start=0.5, n_folds=10)
+```bash
+pip install "polars-timeseries[clustering]"     # HDBSCAN, DBSCAN, spectral
+pip install "polars-timeseries[forecast]"       # SCUM, auto_arima
+pip install "polars-timeseries[all]"            # Everything
 ```
+
+Requires **Python 3.12+** and **Polars 1.30+**.
+
+## Quick start
+
+### Cluster time series automatically
+
+```python
+import polars_ts as pts
+
+result = pts.auto_cluster(
+    df,
+    methods=["kmedoids", "spectral", "kshape"],
+    distances=["sbd", "dtw"],
+    k_range=range(2, 6),
+)
+print(result.best_method, result.best_k, result.best_score)
+```
+
+### Build a forecast pipeline
+
+```python
+from sklearn.ensemble import GradientBoostingRegressor
+import polars_ts as pts
+
+pipe = pts.ForecastPipeline(
+    GradientBoostingRegressor(),
+    lags=[1, 2, 7],
+    rolling_windows=[7],
+    calendar=["day_of_week", "month"],
+    target_transform="log",
+)
+pipe.fit(train_df)
+forecasts = pipe.predict(train_df, h=7)
+```
+
+### Compute pairwise DTW distances
+
+```python
+import polars as pl
+import polars_ts as pts
+
+df = pl.DataFrame({
+    "unique_id": ["A"] * 5 + ["B"] * 5,
+    "y": [1.0, 2.0, 3.0, 2.0, 1.0,
+          1.0, 3.0, 5.0, 3.0, 1.0],
+})
+
+result = pts.compute_pairwise_dtw(df, df)
+```
+
+## What's included
+
+| Category | Highlights |
+|---|---|
+| [**Distance metrics**](distance-metrics.md) | 12 Rust-accelerated metrics (DTW, SBD, MSM, ERP, ...) |
+| [**Clustering**](clustering-guide.md) | K-Medoids, K-Shape, HDBSCAN, DBSCAN, Spectral, Hierarchical, K-Means DBA, CLARA, CLARANS, U-Shapelets, auto_cluster |
+| [**Forecasting**](forecasting-guide.md) | Baselines, ARIMA, exponential smoothing, ML pipelines, global models, ensembles |
+| [**Imaging**](imaging-guide.md) | Recurrence plots, GAF, MTF, spectrograms, scalograms, vision model embeddings |
+| [**Changepoint & anomaly**](changepoint-guide.md) | CUSUM, PELT, BOCPD, regime detection, Isolation Forest |
+| [**Preprocessing**](preprocessing-guide.md) | Imputation, outlier detection, resampling, feature engineering, target transforms |
+
+## Tutorials
+
+Interactive notebooks covering the full toolkit:
+
+| # | Topic | Notebook |
+|---|---|---|
+| 01 | Data wrangling & exploration | [01_data_wrangling_and_exploration.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/01_data_wrangling_and_exploration.ipynb) |
+| 02 | Feature engineering & transforms | [02_feature_engineering_transforms.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/02_feature_engineering_transforms.ipynb) |
+| 03 | Forecasting fundamentals | [03_forecasting_fundamentals.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/03_forecasting_fundamentals.ipynb) |
+| 04 | ML forecasting pipelines | [04_ml_forecasting_pipelines.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/04_ml_forecasting_pipelines.ipynb) |
+| 05 | Uncertainty & calibration | [05_uncertainty_and_calibration.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/05_uncertainty_and_calibration.ipynb) |
+| 06 | Changepoint & anomaly detection | [06_changepoint_anomaly_detection.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/06_changepoint_anomaly_detection.ipynb) |
+| 07 | Time series similarity & clustering | [07_time_series_similarity_clustering.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/07_time_series_similarity_clustering.ipynb) |
+| 08 | Multivariate & volatility | [08_multivariate_volatility.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/08_multivariate_volatility.ipynb) |
+| 09 | Ensembles & reconciliation | [09_ensembles_reconciliation.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/09_ensembles_reconciliation.ipynb) |
+| 10 | Ecosystem adapters | [10_ecosystem_adapters.ipynb](https://github.com/drumtorben/polars-ts/blob/main/notebooks/10_ecosystem_adapters.ipynb) |

--- a/docs/preprocessing-guide.md
+++ b/docs/preprocessing-guide.md
@@ -1,0 +1,101 @@
+# Preprocessing & Feature Engineering Guide
+
+polars-ts includes data preprocessing, feature engineering, target transforms, and validation strategies — all group-aware and designed for time series panels.
+
+## Missing value imputation
+
+```python
+import polars_ts as pts
+
+result = pts.impute(df, method="linear")           # linear interpolation
+result = pts.impute(df, method="forward_fill")     # forward fill
+result = pts.impute(df, method="seasonal", period=24)  # seasonal pattern
+```
+
+Methods: `forward_fill`, `backward_fill`, `linear`, `mean`, `median`, `seasonal`.
+
+## Outlier detection & treatment
+
+```python
+# Detect
+flags = pts.detect_outliers(df, method="zscore", threshold=3.0)
+flags = pts.detect_outliers(df, method="iqr", factor=1.5)
+flags = pts.detect_outliers(df, method="hampel", window=7)
+
+# Treat
+cleaned = pts.treat_outliers(df, method="clip")        # winsorize
+cleaned = pts.treat_outliers(df, method="median")      # replace with median
+cleaned = pts.treat_outliers(df, method="interpolate")  # linear interpolation
+```
+
+## Temporal resampling
+
+```python
+result = pts.resample(df, rule="1h", agg="mean")   # downsample to hourly
+```
+
+## Feature engineering
+
+```python
+# Lag features
+result = pts.lag_features(df, lags=[1, 7, 14])
+
+# Rolling features
+result = pts.rolling_features(df, windows=[7, 14], aggs=["mean", "std"])
+
+# Calendar features
+result = pts.calendar_features(df, features=["day_of_week", "month", "is_weekend"])
+
+# Fourier features for seasonality
+result = pts.fourier_features(df, period=24, order=3)
+
+# Advanced features
+result = pts.target_encode(df, col="category", target="y")
+result = pts.holiday_features(df, country="US")
+result = pts.interaction_features(df, columns=["feat_a", "feat_b"])
+result = pts.time_embeddings(df, components=["hour", "day_of_week"])
+```
+
+## Target transforms
+
+All transforms are group-aware and invertible.
+
+```python
+# Log transform
+transformed = pts.log_transform(df)
+original = pts.inverse_log_transform(transformed)
+
+# Box-Cox
+transformed = pts.boxcox_transform(df, lam=0.5)
+original = pts.inverse_boxcox_transform(transformed, lam=0.5)
+
+# Differencing
+diffed = pts.difference(df, order=1, period=24)
+original = pts.undifference(diffed)
+```
+
+## Validation strategies
+
+```python
+# Expanding window cross-validation
+splits = pts.expanding_window_cv(df, n_splits=5, horizon=12)
+
+# Sliding window cross-validation
+splits = pts.sliding_window_cv(df, train_size=100, horizon=12, step=12)
+
+# Rolling origin CV
+splits = pts.rolling_origin_cv(df, initial=100, horizon=12, fixed=False)
+```
+
+## Residual diagnostics
+
+```python
+acf_result = pts.acf(residuals, n_lags=40)
+pacf_result = pts.pacf(residuals, n_lags=20)
+lb_result = pts.ljung_box(residuals, lags=20)
+```
+
+## Further reading
+
+- **Notebook 01**: [Data wrangling & exploration](https://github.com/drumtorben/polars-ts/blob/main/notebooks/01_data_wrangling_and_exploration.ipynb)
+- **Notebook 02**: [Feature engineering & transforms](https://github.com/drumtorben/polars-ts/blob/main/notebooks/02_feature_engineering_transforms.ipynb)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -38,7 +38,11 @@ nav:
   - Home: index.md
   - Guides:
       - Distance Metrics: distance-metrics.md
-      - Clustering Guide: clustering-guide.md
+      - Clustering & Classification: clustering-guide.md
+      - Forecasting: forecasting-guide.md
+      - Time Series Imaging: imaging-guide.md
+      - Changepoint & Anomaly Detection: changepoint-guide.md
+      - Preprocessing & Features: preprocessing-guide.md
   - Reference:
       - Python API: reference/
       - Rust API: reference/rust/


### PR DESCRIPTION
## Summary

The docs were outdated — they only covered distance metrics and basic scipy clustering. The project now has forecasting, imaging, auto_cluster, 10+ clustering methods, etc. This PR brings the documentation in sync.

### 4 new guide pages

| Guide | Content |
|---|---|
| **[Forecasting](docs/forecasting-guide.md)** | Baselines, ARIMA, exponential smoothing, ML pipelines, global models, multi-step strategies, ensembles, probabilistic forecasting, evaluation |
| **[Imaging](docs/imaging-guide.md)** | Recurrence plots, RQA, GAF, MTF, spectrograms, scalograms, vision model embeddings, image→clustering pipeline |
| **[Changepoint & Anomaly](docs/changepoint-guide.md)** | Mann-Kendall, Sen's slope, CUSUM, PELT, BOCPD, regime detection, Isolation Forest |
| **[Preprocessing](docs/preprocessing-guide.md)** | Imputation, outliers, resampling, feature engineering, target transforms, validation strategies, diagnostics |

### Updated pages

- **index.md** — rewritten with value proposition, quick start examples, feature overview table linking to guides, tutorial list with clickable notebook links
- **clustering-guide.md** — expanded from scipy-only workflow to all 11 clustering methods, auto_cluster, evaluation metrics, classification, ROCKET, foundation model embeddings
- **mkdocs.yaml** — navigation updated with 4 new entries

### README enhancements

- **Navigation bar** — 6 guide links (Distance Metrics, Clustering, Forecasting, Imaging, Changepoints, Preprocessing) directly below the logo
- **Notebook links** — all 10 tutorials now have clickable "Open" links to the GitHub-hosted notebooks

## Test plan

- [ ] `mkdocs build -s` succeeds
- [ ] All internal links resolve
- [ ] Navigation renders correctly with 6 guide tabs