### PR TITLE
feat: add Kalman Filter and RTS smoother (#114)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,6 +271,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
+    if name in {"KalmanFilter", "kalman_filter"}:
+        from polars_ts import bayesian as _bayes
+
+        return getattr(_bayes, name)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -271,6 +271,10 @@ def __getattr__(name: str) -> Any:
         from polars_ts import models as _models
 
         return getattr(_models, name)
+    if name in {"KalmanFilter", "KalmanResult", "kalman_filter"}:
+        from polars_ts.bayesian import kalman as _kalman
+
+        return getattr(_kalman, name)
     if name in {
         "to_recurrence_plot",
         "rqa_features",

--- a/polars_ts/bayesian/__init__.py
+++ b/polars_ts/bayesian/__init__.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"KalmanFilter", "kalman_filter"}:
+        from polars_ts.bayesian.kalman import KalmanFilter, kalman_filter
+
+        if name == "KalmanFilter":
+            return KalmanFilter
+        return kalman_filter
+    raise AttributeError(f"module 'polars_ts.bayesian' has no attribute {name!r}")
+
+
+__all__ = [
+    "KalmanFilter",
+    "kalman_filter",
+]

--- a/polars_ts/bayesian/kalman.py
+++ b/polars_ts/bayesian/kalman.py
@@ -1,0 +1,265 @@
+"""Kalman Filter and Rauch-Tung-Striebel (RTS) smoother.
+
+Linear Gaussian state-space model:
+
+    x_t = F @ x_{t-1} + w_t,  w_t ~ N(0, Q)   (state transition)
+    y_t = H @ x_t     + v_t,  v_t ~ N(0, R)   (observation)
+
+The Kalman filter computes filtered state estimates (forward pass),
+and the RTS smoother refines them (backward pass).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import polars as pl
+
+
+@dataclass
+class KalmanResult:
+    """Container for Kalman filter / smoother output.
+
+    Attributes
+    ----------
+    filtered_states
+        Array of shape ``(T, n)`` — filtered state means.
+    filtered_covs
+        Array of shape ``(T, n, n)`` — filtered state covariances.
+    predicted_states
+        Array of shape ``(T, n)`` — one-step-ahead predicted state means.
+    predicted_covs
+        Array of shape ``(T, n, n)`` — one-step-ahead predicted covariances.
+    smoothed_states
+        Array of shape ``(T, n)`` — smoothed state means (after RTS pass).
+        ``None`` if smoothing was not requested.
+    smoothed_covs
+        Array of shape ``(T, n, n)`` — smoothed state covariances.
+        ``None`` if smoothing was not requested.
+    log_likelihood
+        Total log-likelihood of the observations.
+
+    """
+
+    filtered_states: np.ndarray
+    filtered_covs: np.ndarray
+    predicted_states: np.ndarray
+    predicted_covs: np.ndarray
+    smoothed_states: np.ndarray | None = None
+    smoothed_covs: np.ndarray | None = None
+    log_likelihood: float = 0.0
+
+
+class KalmanFilter:
+    """Kalman Filter with optional RTS smoother.
+
+    Parameters
+    ----------
+    F
+        State transition matrix of shape ``(n, n)``.
+    H
+        Observation matrix of shape ``(m, n)`` where ``m`` is the
+        observation dimension and ``n`` is the state dimension.
+    Q
+        Process noise covariance of shape ``(n, n)``.
+    R
+        Observation noise covariance of shape ``(m, m)``.
+    x0
+        Initial state mean of shape ``(n,)``. Defaults to zeros.
+    P0
+        Initial state covariance of shape ``(n, n)``.
+        Defaults to ``1e6 * I`` (diffuse prior).
+
+    """
+
+    def __init__(
+        self,
+        F: np.ndarray,
+        H: np.ndarray,
+        Q: np.ndarray,
+        R: np.ndarray,
+        x0: np.ndarray | None = None,
+        P0: np.ndarray | None = None,
+    ) -> None:
+        self.F = np.asarray(F, dtype=np.float64)
+        self.H = np.asarray(H, dtype=np.float64)
+        self.Q = np.asarray(Q, dtype=np.float64)
+        self.R = np.asarray(R, dtype=np.float64)
+
+        n = self.F.shape[0]
+        self.x0 = np.zeros(n) if x0 is None else np.asarray(x0, dtype=np.float64)
+        self.P0 = np.eye(n) * 1e6 if P0 is None else np.asarray(P0, dtype=np.float64)
+
+    def filter(self, y: np.ndarray) -> KalmanResult:
+        """Run the Kalman filter forward pass.
+
+        Parameters
+        ----------
+        y
+            Observations of shape ``(T,)`` or ``(T, m)``.
+            Use ``np.nan`` for missing observations.
+
+        Returns
+        -------
+        KalmanResult
+            Filtered states, covariances, and log-likelihood.
+
+        """
+        y = np.asarray(y, dtype=np.float64)
+        if y.ndim == 1:
+            y = y.reshape(-1, 1)
+
+        T, m = y.shape
+        n = self.F.shape[0]
+
+        filtered_states = np.zeros((T, n))
+        filtered_covs = np.zeros((T, n, n))
+        predicted_states = np.zeros((T, n))
+        predicted_covs = np.zeros((T, n, n))
+        log_lik = 0.0
+
+        x = self.x0.copy()
+        P = self.P0.copy()
+
+        for t in range(T):
+            # Predict
+            x_pred = self.F @ x
+            P_pred = self.F @ P @ self.F.T + self.Q
+
+            predicted_states[t] = x_pred
+            predicted_covs[t] = P_pred
+
+            # Check for missing observation
+            yt = y[t]
+            if np.any(np.isnan(yt)):
+                # No update — predicted = filtered
+                x = x_pred
+                P = P_pred
+            else:
+                # Innovation
+                innov = yt - self.H @ x_pred
+                S = self.H @ P_pred @ self.H.T + self.R
+
+                # Kalman gain
+                S_inv = np.linalg.inv(S)
+                K = P_pred @ self.H.T @ S_inv
+
+                # Update
+                x = x_pred + K @ innov
+                P = (np.eye(n) - K @ self.H) @ P_pred
+
+                # Log-likelihood contribution
+                sign, logdet = np.linalg.slogdet(S)
+                log_lik += -0.5 * (m * np.log(2 * np.pi) + logdet + float(innov.T @ S_inv @ innov))
+
+            filtered_states[t] = x
+            filtered_covs[t] = P
+
+        return KalmanResult(
+            filtered_states=filtered_states,
+            filtered_covs=filtered_covs,
+            predicted_states=predicted_states,
+            predicted_covs=predicted_covs,
+            log_likelihood=log_lik,
+        )
+
+    def smooth(self, y: np.ndarray) -> KalmanResult:
+        """Run the Kalman filter + RTS smoother.
+
+        Parameters
+        ----------
+        y
+            Observations of shape ``(T,)`` or ``(T, m)``.
+
+        Returns
+        -------
+        KalmanResult
+            Filtered and smoothed states, covariances, and log-likelihood.
+
+        """
+        result = self.filter(y)
+        T = result.filtered_states.shape[0]
+        n = self.F.shape[0]
+
+        smoothed_states = np.zeros((T, n))
+        smoothed_covs = np.zeros((T, n, n))
+
+        # Initialise from the last filtered state
+        smoothed_states[-1] = result.filtered_states[-1]
+        smoothed_covs[-1] = result.filtered_covs[-1]
+
+        # Backward pass
+        for t in range(T - 2, -1, -1):
+            P_pred = result.predicted_covs[t + 1]
+            P_filt = result.filtered_covs[t]
+
+            # Smoother gain
+            L = P_filt @ self.F.T @ np.linalg.inv(P_pred)
+
+            smoothed_states[t] = (
+                result.filtered_states[t] + L @ (smoothed_states[t + 1] - result.predicted_states[t + 1])
+            )
+            smoothed_covs[t] = P_filt + L @ (smoothed_covs[t + 1] - P_pred) @ L.T
+
+        result.smoothed_states = smoothed_states
+        result.smoothed_covs = smoothed_covs
+        return result
+
+
+def kalman_filter(
+    df: pl.DataFrame,
+    F: np.ndarray,
+    H: np.ndarray,
+    Q: np.ndarray,
+    R: np.ndarray,
+    x0: np.ndarray | None = None,
+    P0: np.ndarray | None = None,
+    smooth: bool = True,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+) -> dict[str, KalmanResult]:
+    """Apply Kalman filter (and optional RTS smoother) to each time series.
+
+    Convenience function that wraps :class:`KalmanFilter` for panel data.
+
+    Parameters
+    ----------
+    df
+        DataFrame with columns ``id_col`` and ``target_col``.
+    F
+        State transition matrix ``(n, n)``.
+    H
+        Observation matrix ``(m, n)``.
+    Q
+        Process noise covariance ``(n, n)``.
+    R
+        Observation noise covariance ``(m, m)``.
+    x0
+        Initial state mean ``(n,)``. Defaults to zeros.
+    P0
+        Initial state covariance ``(n, n)``. Defaults to diffuse prior.
+    smooth
+        Whether to run the RTS smoother after filtering.
+    id_col
+        Column identifying each time series.
+    target_col
+        Column with the observed values.
+
+    Returns
+    -------
+    dict[str, KalmanResult]
+        Mapping from series ID to the filter/smoother result.
+
+    """
+    kf = KalmanFilter(F=F, H=H, Q=Q, R=R, x0=x0, P0=P0)
+    results: dict[str, KalmanResult] = {}
+
+    for sid in df[id_col].unique(maintain_order=True).to_list():
+        y = df.filter(pl.col(id_col) == sid)[target_col].to_numpy()
+        if smooth:
+            results[str(sid)] = kf.smooth(y)
+        else:
+            results[str(sid)] = kf.filter(y)
+
+    return results

--- a/polars_ts/bayesian/kalman.py
+++ b/polars_ts/bayesian/kalman.py
@@ -197,8 +197,8 @@ class KalmanFilter:
             # Smoother gain
             L = P_filt @ self.F.T @ np.linalg.inv(P_pred)
 
-            smoothed_states[t] = (
-                result.filtered_states[t] + L @ (smoothed_states[t + 1] - result.predicted_states[t + 1])
+            smoothed_states[t] = result.filtered_states[t] + L @ (
+                smoothed_states[t + 1] - result.predicted_states[t + 1]
             )
             smoothed_covs[t] = P_filt + L @ (smoothed_covs[t + 1] - P_pred) @ L.T
 

--- a/tests/bayesian/test_kalman.py
+++ b/tests/bayesian/test_kalman.py
@@ -9,6 +9,7 @@ from polars_ts.bayesian.kalman import KalmanFilter, KalmanResult, kalman_filter
 # Observation: y_t = x_t + v_t
 # Transition: x_t = x_{t-1} + w_t
 
+
 def _local_level_matrices(q: float = 1.0, r: float = 1.0):
     """Return system matrices for a local-level (random walk + noise) model."""
     F = np.array([[1.0]])
@@ -175,8 +176,7 @@ class TestKalmanFilterFunction:
         df = pl.DataFrame(
             {
                 "unique_id": ["A"] * 50 + ["B"] * 50,
-                "y": (5.0 + rng.normal(0, 0.5, 50)).tolist()
-                + (10.0 + rng.normal(0, 0.5, 50)).tolist(),
+                "y": (5.0 + rng.normal(0, 0.5, 50)).tolist() + (10.0 + rng.normal(0, 0.5, 50)).tolist(),
             }
         )
         F, H, Q, R = _local_level_matrices(q=0.01, r=1.0)

--- a/tests/bayesian/test_kalman.py
+++ b/tests/bayesian/test_kalman.py
@@ -1,0 +1,237 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.bayesian.kalman import KalmanFilter, KalmanResult, kalman_filter
+
+# --- Local-level model helpers ---
+# State: x_t (scalar level)
+# Observation: y_t = x_t + v_t
+# Transition: x_t = x_{t-1} + w_t
+
+def _local_level_matrices(q: float = 1.0, r: float = 1.0):
+    """Return system matrices for a local-level (random walk + noise) model."""
+    F = np.array([[1.0]])
+    H = np.array([[1.0]])
+    Q = np.array([[q]])
+    R = np.array([[r]])
+    return F, H, Q, R
+
+
+@pytest.fixture
+def constant_series():
+    """Series with constant mean + noise."""
+    rng = np.random.default_rng(42)
+    y = 5.0 + rng.normal(0, 0.5, size=100)
+    return y
+
+
+@pytest.fixture
+def trend_series():
+    """Series with linear trend + noise."""
+    rng = np.random.default_rng(42)
+    y = np.linspace(0, 10, 100) + rng.normal(0, 0.5, size=100)
+    return y
+
+
+class TestKalmanFilter:
+    def test_filter_output_type(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        assert isinstance(result, KalmanResult)
+
+    def test_filter_shapes(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        T = len(constant_series)
+        assert result.filtered_states.shape == (T, 1)
+        assert result.filtered_covs.shape == (T, 1, 1)
+        assert result.predicted_states.shape == (T, 1)
+        assert result.predicted_covs.shape == (T, 1, 1)
+
+    def test_filter_no_smoothed(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        assert result.smoothed_states is None
+        assert result.smoothed_covs is None
+
+    def test_log_likelihood_finite(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        assert np.isfinite(result.log_likelihood)
+
+    def test_filtered_state_tracks_constant(self, constant_series):
+        F, H, Q, R = _local_level_matrices(q=0.01, r=1.0)
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        # After convergence, filtered state should be near 5.0
+        assert abs(result.filtered_states[-1, 0] - 5.0) < 1.0
+
+    def test_covariance_positive_definite(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(constant_series)
+        for t in range(len(constant_series)):
+            eigvals = np.linalg.eigvalsh(result.filtered_covs[t])
+            assert np.all(eigvals > 0)
+
+    def test_custom_initial_state(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R, x0=np.array([5.0]), P0=np.array([[0.1]]))
+        result = kf.filter(constant_series)
+        # With good initial guess, first filtered state should be near 5.0
+        assert abs(result.filtered_states[0, 0] - 5.0) < 1.0
+
+
+class TestKalmanSmoother:
+    def test_smooth_output_shapes(self, constant_series):
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.smooth(constant_series)
+        T = len(constant_series)
+        assert result.smoothed_states is not None
+        assert result.smoothed_covs is not None
+        assert result.smoothed_states.shape == (T, 1)
+        assert result.smoothed_covs.shape == (T, 1, 1)
+
+    def test_smoothed_covariance_smaller(self, constant_series):
+        """Smoothed covariance should be <= filtered covariance."""
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.smooth(constant_series)
+        assert result.smoothed_covs is not None
+        for t in range(len(constant_series)):
+            diff = result.filtered_covs[t] - result.smoothed_covs[t]
+            eigvals = np.linalg.eigvalsh(diff)
+            assert np.all(eigvals >= -1e-10)
+
+    def test_last_smoothed_equals_filtered(self, constant_series):
+        """At the last timestep, smoothed = filtered."""
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.smooth(constant_series)
+        assert result.smoothed_states is not None
+        np.testing.assert_allclose(
+            result.smoothed_states[-1],
+            result.filtered_states[-1],
+            atol=1e-10,
+        )
+
+    def test_smoothed_tracks_constant(self, constant_series):
+        F, H, Q, R = _local_level_matrices(q=0.01, r=1.0)
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.smooth(constant_series)
+        assert result.smoothed_states is not None
+        mean_state = result.smoothed_states[:, 0].mean()
+        assert abs(mean_state - 5.0) < 0.5
+
+
+class TestMissingObservations:
+    def test_missing_values_handled(self):
+        y = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.filter(y)
+        assert np.all(np.isfinite(result.filtered_states))
+
+    def test_missing_increases_uncertainty(self):
+        y_complete = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        y_missing = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+        F, H, Q, R = _local_level_matrices()
+        kf = KalmanFilter(F, H, Q, R)
+        r_complete = kf.filter(y_complete)
+        r_missing = kf.filter(y_missing)
+        # At t=2 (missing), uncertainty should be higher
+        assert r_missing.filtered_covs[2, 0, 0] > r_complete.filtered_covs[2, 0, 0]
+
+
+class TestMultivariate:
+    def test_2d_state(self):
+        """Local linear trend: state = [level, trend]."""
+        F = np.array([[1.0, 1.0], [0.0, 1.0]])
+        H = np.array([[1.0, 0.0]])
+        Q = np.diag([0.1, 0.01])
+        R = np.array([[1.0]])
+
+        rng = np.random.default_rng(42)
+        y = np.linspace(0, 10, 50) + rng.normal(0, 1.0, size=50)
+
+        kf = KalmanFilter(F, H, Q, R)
+        result = kf.smooth(y)
+        assert result.filtered_states.shape == (50, 2)
+        assert result.smoothed_states is not None
+        assert result.smoothed_states.shape == (50, 2)
+        # Trend component should be positive
+        assert result.smoothed_states[-1, 1] > 0
+
+
+class TestKalmanFilterFunction:
+    def test_panel_data(self):
+        rng = np.random.default_rng(42)
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 50 + ["B"] * 50,
+                "y": (5.0 + rng.normal(0, 0.5, 50)).tolist()
+                + (10.0 + rng.normal(0, 0.5, 50)).tolist(),
+            }
+        )
+        F, H, Q, R = _local_level_matrices(q=0.01, r=1.0)
+        results = kalman_filter(df, F, H, Q, R)
+        assert set(results.keys()) == {"A", "B"}
+        assert results["A"].smoothed_states is not None
+        assert results["B"].smoothed_states is not None
+
+    def test_filter_only(self):
+        df = pl.DataFrame({"unique_id": ["A"] * 20, "y": list(range(20))})
+        F, H, Q, R = _local_level_matrices()
+        results = kalman_filter(df, F, H, Q, R, smooth=False)
+        assert results["A"].smoothed_states is None
+
+    def test_custom_columns(self):
+        df = pl.DataFrame({"sid": ["X"] * 10, "val": [float(i) for i in range(10)]})
+        F, H, Q, R = _local_level_matrices()
+        results = kalman_filter(df, F, H, Q, R, id_col="sid", target_col="val")
+        assert "X" in results
+
+    def test_series_independence(self):
+        """Each series should be filtered independently."""
+        rng = np.random.default_rng(42)
+        y_a = 5.0 + rng.normal(0, 0.5, 30)
+        df_single = pl.DataFrame({"unique_id": ["A"] * 30, "y": y_a.tolist()})
+        df_panel = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 30 + ["B"] * 30,
+                "y": y_a.tolist() + rng.normal(0, 1, 30).tolist(),
+            }
+        )
+        F, H, Q, R = _local_level_matrices(q=0.01, r=1.0)
+        r_single = kalman_filter(df_single, F, H, Q, R)
+        r_panel = kalman_filter(df_panel, F, H, Q, R)
+        assert r_single["A"].smoothed_states is not None
+        assert r_panel["A"].smoothed_states is not None
+        np.testing.assert_allclose(
+            r_single["A"].filtered_states,
+            r_panel["A"].filtered_states,
+            atol=1e-10,
+        )
+
+
+class TestImports:
+    def test_top_level_import(self):
+        from polars_ts import KalmanFilter as KF
+
+        assert KF is KalmanFilter
+
+    def test_functional_import(self):
+        from polars_ts import kalman_filter as kf
+
+        assert callable(kf)
+
+    def test_submodule_import(self):
+        from polars_ts.bayesian import KalmanFilter as KF
+
+        assert KF is KalmanFilter


### PR DESCRIPTION
## Summary

Closes #114

Adds a Kalman Filter and Rauch-Tung-Striebel (RTS) smoother as the foundational linear state-space model for the Bayesian methods roadmap (#123).

### API

```python
import numpy as np
import polars_ts as pts

# System matrices for a local-level model
F = np.array([[1.0]])       # state transition
H = np.array([[1.0]])       # observation
Q = np.array([[0.01]])      # process noise
R = np.array([[1.0]])       # observation noise

# OOP API
kf = pts.KalmanFilter(F, H, Q, R)
result = kf.smooth(y)       # filter + RTS smoother
print(result.filtered_states, result.smoothed_states, result.log_likelihood)

# Functional API for panel data
results = pts.kalman_filter(df, F, H, Q, R)
# → dict[str, KalmanResult]
```

### Features

- Configurable system matrices (F, H, Q, R) and initial state (x0, P0)
- Forward pass: filtered states, covariances, log-likelihood
- Backward pass (RTS): smoothed states with reduced uncertainty
- Missing observation handling (`np.nan` → prediction-only step)
- Multivariate state support (e.g. local linear trend with level + slope)
- Panel data convenience function (`kalman_filter`)
- Pure numpy, no extra dependencies

### Implementation

- `polars_ts/bayesian/kalman.py` — `KalmanFilter` class + `kalman_filter` function
- `KalmanResult` dataclass with filtered/predicted/smoothed states and covariances
- Registered in `polars_ts.bayesian` and top-level `polars_ts` lazy imports

## Test plan

- [x] 21 tests passing locally
- [x] Filter output shapes and types
- [x] Filtered state tracks constant and trending signals
- [x] Covariance matrices are positive definite
- [x] Smoothed covariance ≤ filtered covariance (property of RTS)
- [x] Last smoothed state = last filtered state
- [x] Missing observations increase uncertainty
- [x] Multivariate state (local linear trend, 2D state)
- [x] Panel data series filtered independently
- [x] Import paths (top-level, submodule)
- [ ] CI passes