### PR TITLE
refactor: replace if-chain lazy imports with registry pattern

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -45,232 +45,150 @@ def sens_slope(expr: IntoExpr) -> pl.Expr:
     )
 
 
+# ---------------------------------------------------------------------------
+# Lazy-import registry: name -> (module_path, attribute_name)
+#
+# Adding a new public name only requires one line here — no if-chains,
+# no merge conflicts.
+# ---------------------------------------------------------------------------
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    # --- Metrics ---
+    "Metrics": ("polars_ts.metrics", "Metrics"),
+    "mae": ("polars_ts.metrics.forecast", "mae"),
+    "rmse": ("polars_ts.metrics.forecast", "rmse"),
+    "mape": ("polars_ts.metrics.forecast", "mape"),
+    "smape": ("polars_ts.metrics.forecast", "smape"),
+    "mase": ("polars_ts.metrics.forecast", "mase"),
+    "crps": ("polars_ts.metrics.forecast", "crps"),
+    # --- Decomposition ---
+    "fourier_decomposition": ("polars_ts.decomposition.fourier_decomposition", "fourier_decomposition"),
+    "seasonal_decomposition": ("polars_ts.decomposition.seasonal_decomposition", "seasonal_decomposition"),
+    "seasonal_decompose_features": (
+        "polars_ts.decomposition.seasonal_decompose_features",
+        "seasonal_decompose_features",
+    ),
+    # --- Changepoint ---
+    "cusum": ("polars_ts.changepoint.cusum", "cusum"),
+    "pelt": ("polars_ts.changepoint", "pelt"),
+    "bocpd": ("polars_ts.changepoint", "bocpd"),
+    "regime_detect": ("polars_ts.changepoint", "regime_detect"),
+    # --- Clustering ---
+    "kmedoids": ("polars_ts.clustering.kmedoids", "kmedoids"),
+    "TimeSeriesKMedoids": ("polars_ts.clustering.kmedoids", "TimeSeriesKMedoids"),
+    "KShape": ("polars_ts.clustering.kshape", "KShape"),
+    "silhouette_score": ("polars_ts.clustering.evaluation", "silhouette_score"),
+    "silhouette_samples": ("polars_ts.clustering.evaluation", "silhouette_samples"),
+    "davies_bouldin_score": ("polars_ts.clustering.evaluation", "davies_bouldin_score"),
+    "calinski_harabasz_score": ("polars_ts.clustering.evaluation", "calinski_harabasz_score"),
+    "hdbscan_cluster": ("polars_ts.clustering.density", "hdbscan_cluster"),
+    "dbscan_cluster": ("polars_ts.clustering.density", "dbscan_cluster"),
+    "spectral_cluster": ("polars_ts.clustering.spectral", "spectral_cluster"),
+    "auto_cluster": ("polars_ts.clustering.auto", "auto_cluster"),
+    "shapelet_cluster": ("polars_ts.clustering.shapelets", "shapelet_cluster"),
+    "UShapeletClusterer": ("polars_ts.clustering.shapelets", "UShapeletClusterer"),
+    "clara": ("polars_ts.clustering.scalable", "clara"),
+    "clarans": ("polars_ts.clustering.scalable", "clarans"),
+    "kmeans_dba": ("polars_ts.clustering.kmeans", "kmeans_dba"),
+    "TimeSeriesKMeans": ("polars_ts.clustering.kmeans", "TimeSeriesKMeans"),
+    "agglomerative_cluster": ("polars_ts.clustering.hierarchical", "agglomerative_cluster"),
+    # --- Classification ---
+    "knn_classify": ("polars_ts.classification.knn", "knn_classify"),
+    "TimeSeriesKNNClassifier": ("polars_ts.classification.knn", "TimeSeriesKNNClassifier"),
+    "KShapeClassifier": ("polars_ts.classification.kshape_classifier", "KShapeClassifier"),
+    # --- Feature engineering ---
+    "lag_features": ("polars_ts.features", "lag_features"),
+    "rolling_features": ("polars_ts.features", "rolling_features"),
+    "calendar_features": ("polars_ts.features", "calendar_features"),
+    "fourier_features": ("polars_ts.features", "fourier_features"),
+    "rocket_features": ("polars_ts.features", "rocket_features"),
+    "minirocket_features": ("polars_ts.features", "minirocket_features"),
+    "target_encode": ("polars_ts.features.advanced", "target_encode"),
+    "holiday_features": ("polars_ts.features.advanced", "holiday_features"),
+    "interaction_features": ("polars_ts.features.advanced", "interaction_features"),
+    "time_embeddings": ("polars_ts.features.advanced", "time_embeddings"),
+    # --- Target transforms ---
+    "log_transform": ("polars_ts.transforms", "log_transform"),
+    "inverse_log_transform": ("polars_ts.transforms", "inverse_log_transform"),
+    "boxcox_transform": ("polars_ts.transforms", "boxcox_transform"),
+    "inverse_boxcox_transform": ("polars_ts.transforms", "inverse_boxcox_transform"),
+    "difference": ("polars_ts.transforms", "difference"),
+    "undifference": ("polars_ts.transforms", "undifference"),
+    # --- Validation ---
+    "expanding_window_cv": ("polars_ts.validation", "expanding_window_cv"),
+    "sliding_window_cv": ("polars_ts.validation", "sliding_window_cv"),
+    "rolling_origin_cv": ("polars_ts.validation", "rolling_origin_cv"),
+    # --- Models & forecasting ---
+    "SCUM": ("polars_ts.models", "SCUM"),
+    "naive_forecast": ("polars_ts.models", "naive_forecast"),
+    "seasonal_naive_forecast": ("polars_ts.models", "seasonal_naive_forecast"),
+    "moving_average_forecast": ("polars_ts.models", "moving_average_forecast"),
+    "fft_forecast": ("polars_ts.models", "fft_forecast"),
+    "RecursiveForecaster": ("polars_ts.models", "RecursiveForecaster"),
+    "DirectForecaster": ("polars_ts.models", "DirectForecaster"),
+    "ses_forecast": ("polars_ts.models", "ses_forecast"),
+    "holt_forecast": ("polars_ts.models", "holt_forecast"),
+    "holt_winters_forecast": ("polars_ts.models", "holt_winters_forecast"),
+    "arima_fit": ("polars_ts.models", "arima_fit"),
+    "arima_forecast": ("polars_ts.models", "arima_forecast"),
+    "auto_arima": ("polars_ts.models", "auto_arima"),
+    "ForecastPipeline": ("polars_ts.pipeline", "ForecastPipeline"),
+    "GlobalForecaster": ("polars_ts.global_model", "GlobalForecaster"),
+    # --- Ensembles ---
+    "WeightedEnsemble": ("polars_ts.ensemble", "WeightedEnsemble"),
+    "StackingForecaster": ("polars_ts.ensemble", "StackingForecaster"),
+    # --- Probabilistic ---
+    "QuantileRegressor": ("polars_ts.probabilistic", "QuantileRegressor"),
+    "conformal_interval": ("polars_ts.probabilistic", "conformal_interval"),
+    "EnbPI": ("polars_ts.probabilistic", "EnbPI"),
+    # --- Volatility ---
+    "garch_fit": ("polars_ts.volatility", "garch_fit"),
+    "garch_forecast": ("polars_ts.volatility", "garch_forecast"),
+    "GARCHResult": ("polars_ts.volatility", "GARCHResult"),
+    # --- VAR ---
+    "var_fit": ("polars_ts.var_model", "var_fit"),
+    "var_forecast": ("polars_ts.var_model", "var_forecast"),
+    "granger_causality": ("polars_ts.var_model", "granger_causality"),
+    "VARResult": ("polars_ts.var_model", "VARResult"),
+    # --- Reconciliation ---
+    "reconcile": ("polars_ts.reconciliation", "reconcile"),
+    # --- Adapters ---
+    "to_neuralforecast": ("polars_ts.adapters", "to_neuralforecast"),
+    "from_neuralforecast": ("polars_ts.adapters", "from_neuralforecast"),
+    "to_pytorch_forecasting": ("polars_ts.adapters", "to_pytorch_forecasting"),
+    "from_pytorch_forecasting": ("polars_ts.adapters", "from_pytorch_forecasting"),
+    "to_hf_dataset": ("polars_ts.adapters", "to_hf_dataset"),
+    "ForecastEnv": ("polars_ts.adapters", "ForecastEnv"),
+    "to_chronos_embeddings": ("polars_ts.adapters", "to_chronos_embeddings"),
+    "to_moment_embeddings": ("polars_ts.adapters", "to_moment_embeddings"),
+    # --- Bias & calibration ---
+    "bias_detect": ("polars_ts.bias", "bias_detect"),
+    "bias_correct": ("polars_ts.bias", "bias_correct"),
+    "calibration_table": ("polars_ts.calibration", "calibration_table"),
+    "pit_histogram": ("polars_ts.calibration", "pit_histogram"),
+    "reliability_diagram": ("polars_ts.calibration", "reliability_diagram"),
+    # --- Feature importance ---
+    "permutation_importance": ("polars_ts.importance", "permutation_importance"),
+    # --- Anomaly detection ---
+    "isolation_forest_detect": ("polars_ts.anomaly_forest", "isolation_forest_detect"),
+    # --- Preprocessing ---
+    "impute": ("polars_ts.imputation", "impute"),
+    "detect_outliers": ("polars_ts.outliers", "detect_outliers"),
+    "treat_outliers": ("polars_ts.outliers", "treat_outliers"),
+    "resample": ("polars_ts.resampling", "resample"),
+    # --- Diagnostics ---
+    "acf": ("polars_ts.diagnostics", "acf"),
+    "pacf": ("polars_ts.diagnostics", "pacf"),
+    "ljung_box": ("polars_ts.diagnostics", "ljung_box"),
+}
+
+
 def __getattr__(name: str) -> Any:
-    if name == "Metrics":
-        from polars_ts.metrics import Metrics
+    if name in _LAZY_IMPORTS:
+        import importlib
 
-        return Metrics
-    if name == "SCUM":
-        from polars_ts.models import SCUM
-
-        return SCUM
-    if name == "fourier_decomposition":
-        from polars_ts.decomposition.fourier_decomposition import fourier_decomposition
-
-        return fourier_decomposition
-    if name == "seasonal_decomposition":
-        from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
-
-        return seasonal_decomposition
-    if name == "seasonal_decompose_features":
-        from polars_ts.decomposition.seasonal_decompose_features import seasonal_decompose_features
-
-        return seasonal_decompose_features
-    if name == "cusum":
-        from polars_ts.changepoint.cusum import cusum
-
-        return cusum
-    if name == "kmedoids":
-        from polars_ts.clustering.kmedoids import kmedoids
-
-        return kmedoids
-    if name == "knn_classify":
-        from polars_ts.classification.knn import knn_classify
-
-        return knn_classify
-    if name == "TimeSeriesKNNClassifier":
-        from polars_ts.classification.knn import TimeSeriesKNNClassifier
-
-        return TimeSeriesKNNClassifier
-    if name == "KShapeClassifier":
-        from polars_ts.classification.kshape_classifier import KShapeClassifier
-
-        return KShapeClassifier
-    if name == "TimeSeriesKMedoids":
-        from polars_ts.clustering.kmedoids import TimeSeriesKMedoids
-
-        return TimeSeriesKMedoids
-    if name == "KShape":
-        from polars_ts.clustering.kshape import KShape
-
-        return KShape
-    if name == "silhouette_score":
-        from polars_ts.clustering.evaluation import silhouette_score
-
-        return silhouette_score
-    if name == "silhouette_samples":
-        from polars_ts.clustering.evaluation import silhouette_samples
-
-        return silhouette_samples
-    if name == "davies_bouldin_score":
-        from polars_ts.clustering.evaluation import davies_bouldin_score
-
-        return davies_bouldin_score
-    if name == "calinski_harabasz_score":
-        from polars_ts.clustering.evaluation import calinski_harabasz_score
-
-        return calinski_harabasz_score
-    if name in {"hdbscan_cluster", "dbscan_cluster"}:
-        from polars_ts.clustering import density as _density
-
-        return getattr(_density, name)
-    if name == "spectral_cluster":
-        from polars_ts.clustering.spectral import spectral_cluster
-
-        return spectral_cluster
-    if name == "auto_cluster":
-        from polars_ts.clustering.auto import auto_cluster
-
-        return auto_cluster
-    if name in {"shapelet_cluster", "UShapeletClusterer"}:
-        from polars_ts.clustering import shapelets as _shapelets
-
-        return getattr(_shapelets, name)
-    if name in {"clara", "clarans"}:
-        from polars_ts.clustering import scalable as _scalable
-
-        return getattr(_scalable, name)
-    if name == "kmeans_dba":
-        from polars_ts.clustering.kmeans import kmeans_dba
-
-        return kmeans_dba
-    if name == "TimeSeriesKMeans":
-        from polars_ts.clustering.kmeans import TimeSeriesKMeans
-
-        return TimeSeriesKMeans
-    if name == "agglomerative_cluster":
-        from polars_ts.clustering.hierarchical import agglomerative_cluster
-
-        return agglomerative_cluster
-    if name in {
-        "lag_features",
-        "rolling_features",
-        "calendar_features",
-        "fourier_features",
-        "rocket_features",
-        "minirocket_features",
-    }:
-        from polars_ts import features as _feat
-
-        return getattr(_feat, name)
-    if name in {
-        "log_transform",
-        "inverse_log_transform",
-        "boxcox_transform",
-        "inverse_boxcox_transform",
-        "difference",
-        "undifference",
-    }:
-        from polars_ts import transforms as _tr
-
-        return getattr(_tr, name)
-    if name in {"expanding_window_cv", "sliding_window_cv", "rolling_origin_cv"}:
-        from polars_ts import validation as _val
-
-        return getattr(_val, name)
-    if name in {"mae", "rmse", "mape", "smape", "mase", "crps"}:
-        from polars_ts.metrics import forecast as _fm
-
-        return getattr(_fm, name)
-    if name in {
-        "naive_forecast",
-        "seasonal_naive_forecast",
-        "moving_average_forecast",
-        "fft_forecast",
-        "RecursiveForecaster",
-        "DirectForecaster",
-        "ses_forecast",
-        "holt_forecast",
-        "holt_winters_forecast",
-    }:
-        from polars_ts import models as _models
-
-        return getattr(_models, name)
-    if name in {"pelt", "bocpd", "regime_detect"}:
-        from polars_ts import changepoint as _cp
-
-        return getattr(_cp, name)
-    if name in {"garch_fit", "garch_forecast", "GARCHResult"}:
-        from polars_ts import volatility as _vol
-
-        return getattr(_vol, name)
-    if name in {"var_fit", "var_forecast", "granger_causality", "VARResult"}:
-        from polars_ts import var_model as _var
-
-        return getattr(_var, name)
-    if name == "reconcile":
-        from polars_ts.reconciliation import reconcile
-
-        return reconcile
-    if name in {
-        "to_neuralforecast",
-        "from_neuralforecast",
-        "to_pytorch_forecasting",
-        "from_pytorch_forecasting",
-        "to_hf_dataset",
-        "ForecastEnv",
-        "to_chronos_embeddings",
-        "to_moment_embeddings",
-    }:
-        from polars_ts import adapters as _adapt
-
-        return getattr(_adapt, name)
-    if name in {"target_encode", "holiday_features", "interaction_features", "time_embeddings"}:
-        from polars_ts.features import advanced as _adv
-
-        return getattr(_adv, name)
-    if name in {"bias_detect", "bias_correct"}:
-        from polars_ts import bias as _bias
-
-        return getattr(_bias, name)
-    if name in {"calibration_table", "pit_histogram", "reliability_diagram"}:
-        from polars_ts import calibration as _cal
-
-        return getattr(_cal, name)
-    if name == "permutation_importance":
-        from polars_ts.importance import permutation_importance
-
-        return permutation_importance
-    if name == "isolation_forest_detect":
-        from polars_ts.anomaly_forest import isolation_forest_detect
-
-        return isolation_forest_detect
-    if name == "impute":
-        from polars_ts.imputation import impute
-
-        return impute
-    if name in {"detect_outliers", "treat_outliers"}:
-        from polars_ts import outliers as _outliers
-
-        return getattr(_outliers, name)
-    if name == "resample":
-        from polars_ts.resampling import resample
-
-        return resample
-    if name in {"acf", "pacf", "ljung_box"}:
-        from polars_ts import diagnostics as _diag
-
-        return getattr(_diag, name)
-    if name == "ForecastPipeline":
-        from polars_ts.pipeline import ForecastPipeline
-
-        return ForecastPipeline
-    if name == "GlobalForecaster":
-        from polars_ts.global_model import GlobalForecaster
-
-        return GlobalForecaster
-    if name in {"WeightedEnsemble", "StackingForecaster"}:
-        from polars_ts import ensemble as _ens
-
-        return getattr(_ens, name)
-    if name in {"QuantileRegressor", "conformal_interval", "EnbPI"}:
-        from polars_ts import probabilistic as _prob
-
-        return getattr(_prob, name)
-    if name in {"arima_fit", "arima_forecast", "auto_arima"}:
-        from polars_ts import models as _models
-
-        return getattr(_models, name)
+        mod_path, attr = _LAZY_IMPORTS[name]
+        mod = importlib.import_module(mod_path)
+        return getattr(mod, attr)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 
@@ -290,108 +208,5 @@ __all__ = [
     "compute_pairwise_edr",
     "mann_kendall",
     "sens_slope",
-    "cusum",
-    "fourier_decomposition",
-    "seasonal_decomposition",
-    "seasonal_decompose_features",
-    "Metrics",
-    "SCUM",
-    "kmedoids",
-    "knn_classify",
-    "TimeSeriesKNNClassifier",
-    "KShapeClassifier",
-    "TimeSeriesKMedoids",
-    "KShape",
-    "silhouette_score",
-    "silhouette_samples",
-    "davies_bouldin_score",
-    "calinski_harabasz_score",
-    "lag_features",
-    "rolling_features",
-    "calendar_features",
-    "fourier_features",
-    "log_transform",
-    "inverse_log_transform",
-    "boxcox_transform",
-    "inverse_boxcox_transform",
-    "difference",
-    "undifference",
-    "expanding_window_cv",
-    "sliding_window_cv",
-    "rolling_origin_cv",
-    "mae",
-    "rmse",
-    "mape",
-    "smape",
-    "mase",
-    "crps",
-    "naive_forecast",
-    "seasonal_naive_forecast",
-    "moving_average_forecast",
-    "fft_forecast",
-    "RecursiveForecaster",
-    "DirectForecaster",
-    "pelt",
-    "bocpd",
-    "regime_detect",
-    "garch_fit",
-    "garch_forecast",
-    "GARCHResult",
-    "var_fit",
-    "var_forecast",
-    "granger_causality",
-    "VARResult",
-    "reconcile",
-    "to_neuralforecast",
-    "from_neuralforecast",
-    "to_pytorch_forecasting",
-    "from_pytorch_forecasting",
-    "to_hf_dataset",
-    "ForecastEnv",
-    "to_chronos_embeddings",
-    "to_moment_embeddings",
-    "target_encode",
-    "holiday_features",
-    "interaction_features",
-    "time_embeddings",
-    "bias_detect",
-    "bias_correct",
-    "calibration_table",
-    "pit_histogram",
-    "reliability_diagram",
-    "permutation_importance",
-    "isolation_forest_detect",
-    "ses_forecast",
-    "holt_forecast",
-    "holt_winters_forecast",
-    "impute",
-    "detect_outliers",
-    "treat_outliers",
-    "resample",
-    "acf",
-    "pacf",
-    "ljung_box",
-    "ForecastPipeline",
-    "GlobalForecaster",
-    "WeightedEnsemble",
-    "StackingForecaster",
-    "QuantileRegressor",
-    "conformal_interval",
-    "EnbPI",
-    "arima_fit",
-    "arima_forecast",
-    "auto_arima",
-    "hdbscan_cluster",
-    "dbscan_cluster",
-    "spectral_cluster",
-    "auto_cluster",
-    "shapelet_cluster",
-    "UShapeletClusterer",
-    "rocket_features",
-    "minirocket_features",
-    "clara",
-    "clarans",
-    "kmeans_dba",
-    "TimeSeriesKMeans",
-    "agglomerative_cluster",
+    *_LAZY_IMPORTS.keys(),
 ]

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -189,7 +189,6 @@ def __getattr__(name: str) -> Any:
         mod_path, attr = _LAZY_IMPORTS[name]
         mod = importlib.import_module(mod_path)
         return getattr(mod, attr)
-        return getattr(_models, name)
     if name in {
         "KalmanFilter",
         "kalman_filter",

--- a/polars_ts/_lazy.py
+++ b/polars_ts/_lazy.py
@@ -1,0 +1,53 @@
+"""Shared lazy-import helper for polars-ts modules.
+
+Provides a generic ``make_getattr`` factory that turns a flat registry
+dict into a module-level ``__getattr__`` function.  This eliminates
+the duplicated if-chain boilerplate across submodule ``__init__.py``
+files.
+
+Usage in a submodule ``__init__.py``::
+
+    from polars_ts._lazy import make_getattr
+
+    _IMPORTS: dict[str, tuple[str, str]] = {
+        "KShape": ("polars_ts.clustering.kshape", "KShape"),
+        "kmedoids": ("polars_ts.clustering.kmedoids", "kmedoids"),
+    }
+
+    __getattr__, __all__ = make_getattr(_IMPORTS, __name__)
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def make_getattr(
+    registry: dict[str, tuple[str, str]],
+    module_name: str,
+) -> tuple[Any, list[str]]:
+    """Create ``__getattr__`` and ``__all__`` from a lazy-import registry.
+
+    Parameters
+    ----------
+    registry
+        Mapping from public name to ``(module_path, attribute_name)``.
+    module_name
+        The ``__name__`` of the calling module (for error messages).
+
+    Returns
+    -------
+    tuple
+        ``(__getattr__, __all__)`` ready to be assigned at module level.
+
+    """
+
+    def __getattr__(name: str) -> Any:
+        if name in registry:
+            mod_path, attr = registry[name]
+            mod = importlib.import_module(mod_path)
+            return getattr(mod, attr)
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    return __getattr__, list(registry.keys())

--- a/polars_ts/adapters/__init__.py
+++ b/polars_ts/adapters/__init__.py
@@ -1,41 +1,16 @@
 """Integration adapters for DL/RL frameworks. Closes #48."""
 
-from __future__ import annotations
+from polars_ts._lazy import make_getattr
 
-from typing import Any
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "to_neuralforecast": ("polars_ts.adapters.neuralforecast", "to_neuralforecast"),
+    "from_neuralforecast": ("polars_ts.adapters.neuralforecast", "from_neuralforecast"),
+    "to_pytorch_forecasting": ("polars_ts.adapters.pytorch_forecasting", "to_pytorch_forecasting"),
+    "from_pytorch_forecasting": ("polars_ts.adapters.pytorch_forecasting", "from_pytorch_forecasting"),
+    "to_hf_dataset": ("polars_ts.adapters.huggingface", "to_hf_dataset"),
+    "ForecastEnv": ("polars_ts.adapters.rl_env", "ForecastEnv"),
+    "to_chronos_embeddings": ("polars_ts.adapters.embeddings", "to_chronos_embeddings"),
+    "to_moment_embeddings": ("polars_ts.adapters.embeddings", "to_moment_embeddings"),
+}
 
-
-def __getattr__(name: str) -> Any:
-    if name in {"to_neuralforecast", "from_neuralforecast"}:
-        from polars_ts.adapters import neuralforecast
-
-        return getattr(neuralforecast, name)
-    if name in {"to_pytorch_forecasting", "from_pytorch_forecasting"}:
-        from polars_ts.adapters import pytorch_forecasting
-
-        return getattr(pytorch_forecasting, name)
-    if name == "to_hf_dataset":
-        from polars_ts.adapters.huggingface import to_hf_dataset
-
-        return to_hf_dataset
-    if name == "ForecastEnv":
-        from polars_ts.adapters.rl_env import ForecastEnv
-
-        return ForecastEnv
-    if name in {"to_chronos_embeddings", "to_moment_embeddings"}:
-        from polars_ts.adapters import embeddings as _emb
-
-        return getattr(_emb, name)
-    raise AttributeError(f"module 'polars_ts.adapters' has no attribute {name!r}")
-
-
-__all__ = [
-    "to_neuralforecast",
-    "from_neuralforecast",
-    "to_pytorch_forecasting",
-    "from_pytorch_forecasting",
-    "to_hf_dataset",
-    "ForecastEnv",
-    "to_chronos_embeddings",
-    "to_moment_embeddings",
-]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/changepoint/__init__.py
+++ b/polars_ts/changepoint/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from polars_ts._lazy import make_getattr
 from polars_ts.changepoint.cusum import cusum  # eager — Rust plugin
 
@@ -11,5 +13,5 @@ _getattr, _all = make_getattr(_IMPORTS, __name__)
 __all__ = ["cusum", *_all]
 
 
-def __getattr__(name: str):  # noqa: ANN001, ANN202
+def __getattr__(name: str) -> Any:
     return _getattr(name)

--- a/polars_ts/changepoint/__init__.py
+++ b/polars_ts/changepoint/__init__.py
@@ -1,22 +1,15 @@
-from typing import Any
+from polars_ts._lazy import make_getattr
+from polars_ts.changepoint.cusum import cusum  # eager — Rust plugin
 
-from polars_ts.changepoint.cusum import cusum
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "pelt": ("polars_ts.changepoint.pelt", "pelt"),
+    "bocpd": ("polars_ts.changepoint.bocpd", "bocpd"),
+    "regime_detect": ("polars_ts.changepoint.regime", "regime_detect"),
+}
 
-
-def __getattr__(name: str) -> Any:
-    if name == "pelt":
-        from polars_ts.changepoint.pelt import pelt
-
-        return pelt
-    if name == "bocpd":
-        from polars_ts.changepoint.bocpd import bocpd
-
-        return bocpd
-    if name == "regime_detect":
-        from polars_ts.changepoint.regime import regime_detect
-
-        return regime_detect
-    raise AttributeError(f"module 'polars_ts.changepoint' has no attribute {name!r}")
+_getattr, _all = make_getattr(_IMPORTS, __name__)
+__all__ = ["cusum", *_all]
 
 
-__all__ = ["cusum", "pelt", "bocpd", "regime_detect"]
+def __getattr__(name: str):  # noqa: ANN001, ANN202
+    return _getattr(name)

--- a/polars_ts/classification/__init__.py
+++ b/polars_ts/classification/__init__.py
@@ -1,20 +1,9 @@
-from typing import Any
+from polars_ts._lazy import make_getattr
 
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "knn_classify": ("polars_ts.classification.knn", "knn_classify"),
+    "TimeSeriesKNNClassifier": ("polars_ts.classification.knn", "TimeSeriesKNNClassifier"),
+    "KShapeClassifier": ("polars_ts.classification.kshape_classifier", "KShapeClassifier"),
+}
 
-def __getattr__(name: str) -> Any:
-    if name == "knn_classify":
-        from polars_ts.classification.knn import knn_classify
-
-        return knn_classify
-    if name == "TimeSeriesKNNClassifier":
-        from polars_ts.classification.knn import TimeSeriesKNNClassifier
-
-        return TimeSeriesKNNClassifier
-    if name == "KShapeClassifier":
-        from polars_ts.classification.kshape_classifier import KShapeClassifier
-
-        return KShapeClassifier
-    raise AttributeError(f"module 'polars_ts.classification' has no attribute {name!r}")
-
-
-__all__ = ["knn_classify", "TimeSeriesKNNClassifier", "KShapeClassifier"]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -1,100 +1,25 @@
-from typing import Any
+from polars_ts._lazy import make_getattr
 
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "kmedoids": ("polars_ts.clustering.kmedoids", "kmedoids"),
+    "TimeSeriesKMedoids": ("polars_ts.clustering.kmedoids", "TimeSeriesKMedoids"),
+    "KShape": ("polars_ts.clustering.kshape", "KShape"),
+    "silhouette_score": ("polars_ts.clustering.evaluation", "silhouette_score"),
+    "silhouette_samples": ("polars_ts.clustering.evaluation", "silhouette_samples"),
+    "davies_bouldin_score": ("polars_ts.clustering.evaluation", "davies_bouldin_score"),
+    "calinski_harabasz_score": ("polars_ts.clustering.evaluation", "calinski_harabasz_score"),
+    "hdbscan_cluster": ("polars_ts.clustering.density", "hdbscan_cluster"),
+    "dbscan_cluster": ("polars_ts.clustering.density", "dbscan_cluster"),
+    "spectral_cluster": ("polars_ts.clustering.spectral", "spectral_cluster"),
+    "auto_cluster": ("polars_ts.clustering.auto", "auto_cluster"),
+    "AutoClusterResult": ("polars_ts.clustering.auto", "AutoClusterResult"),
+    "shapelet_cluster": ("polars_ts.clustering.shapelets", "shapelet_cluster"),
+    "UShapeletClusterer": ("polars_ts.clustering.shapelets", "UShapeletClusterer"),
+    "clara": ("polars_ts.clustering.scalable", "clara"),
+    "clarans": ("polars_ts.clustering.scalable", "clarans"),
+    "kmeans_dba": ("polars_ts.clustering.kmeans", "kmeans_dba"),
+    "TimeSeriesKMeans": ("polars_ts.clustering.kmeans", "TimeSeriesKMeans"),
+    "agglomerative_cluster": ("polars_ts.clustering.hierarchical", "agglomerative_cluster"),
+}
 
-def __getattr__(name: str) -> Any:
-    if name == "kmedoids":
-        from polars_ts.clustering.kmedoids import kmedoids
-
-        return kmedoids
-    if name == "TimeSeriesKMedoids":
-        from polars_ts.clustering.kmedoids import TimeSeriesKMedoids
-
-        return TimeSeriesKMedoids
-    if name == "KShape":
-        from polars_ts.clustering.kshape import KShape
-
-        return KShape
-    if name == "silhouette_score":
-        from polars_ts.clustering.evaluation import silhouette_score
-
-        return silhouette_score
-    if name == "silhouette_samples":
-        from polars_ts.clustering.evaluation import silhouette_samples
-
-        return silhouette_samples
-    if name == "davies_bouldin_score":
-        from polars_ts.clustering.evaluation import davies_bouldin_score
-
-        return davies_bouldin_score
-    if name == "calinski_harabasz_score":
-        from polars_ts.clustering.evaluation import calinski_harabasz_score
-
-        return calinski_harabasz_score
-    if name == "hdbscan_cluster":
-        from polars_ts.clustering.density import hdbscan_cluster
-
-        return hdbscan_cluster
-    if name == "dbscan_cluster":
-        from polars_ts.clustering.density import dbscan_cluster
-
-        return dbscan_cluster
-    if name == "spectral_cluster":
-        from polars_ts.clustering.spectral import spectral_cluster
-
-        return spectral_cluster
-    if name == "auto_cluster":
-        from polars_ts.clustering.auto import auto_cluster
-
-        return auto_cluster
-    if name == "AutoClusterResult":
-        from polars_ts.clustering.auto import AutoClusterResult
-
-        return AutoClusterResult
-    if name in {"shapelet_cluster", "UShapeletClusterer"}:
-        from polars_ts.clustering import shapelets as _shapelets
-
-        return getattr(_shapelets, name)
-    if name == "clara":
-        from polars_ts.clustering.scalable import clara
-
-        return clara
-    if name == "clarans":
-        from polars_ts.clustering.scalable import clarans
-
-        return clarans
-    if name == "kmeans_dba":
-        from polars_ts.clustering.kmeans import kmeans_dba
-
-        return kmeans_dba
-    if name == "TimeSeriesKMeans":
-        from polars_ts.clustering.kmeans import TimeSeriesKMeans
-
-        return TimeSeriesKMeans
-    if name == "agglomerative_cluster":
-        from polars_ts.clustering.hierarchical import agglomerative_cluster
-
-        return agglomerative_cluster
-    raise AttributeError(f"module 'polars_ts.clustering' has no attribute {name!r}")
-
-
-__all__ = [
-    "kmedoids",
-    "TimeSeriesKMedoids",
-    "KShape",
-    "silhouette_score",
-    "silhouette_samples",
-    "davies_bouldin_score",
-    "calinski_harabasz_score",
-    "hdbscan_cluster",
-    "dbscan_cluster",
-    "spectral_cluster",
-    "auto_cluster",
-    "AutoClusterResult",
-    "shapelet_cluster",
-    "UShapeletClusterer",
-    "clara",
-    "clarans",
-    "kmeans_dba",
-    "TimeSeriesKMeans",
-    "agglomerative_cluster",
-]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/decomposition/__init__.py
+++ b/polars_ts/decomposition/__init__.py
@@ -1,20 +1,12 @@
-from typing import Any
+from polars_ts._lazy import make_getattr
 
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "fourier_decomposition": ("polars_ts.decomposition.fourier_decomposition", "fourier_decomposition"),
+    "seasonal_decomposition": ("polars_ts.decomposition.seasonal_decomposition", "seasonal_decomposition"),
+    "seasonal_decompose_features": (
+        "polars_ts.decomposition.seasonal_decompose_features",
+        "seasonal_decompose_features",
+    ),
+}
 
-def __getattr__(name: str) -> Any:
-    if name == "fourier_decomposition":
-        from polars_ts.decomposition.fourier_decomposition import fourier_decomposition
-
-        return fourier_decomposition
-    if name == "seasonal_decomposition":
-        from polars_ts.decomposition.seasonal_decomposition import seasonal_decomposition
-
-        return seasonal_decomposition
-    if name == "seasonal_decompose_features":
-        from polars_ts.decomposition.seasonal_decompose_features import seasonal_decompose_features
-
-        return seasonal_decompose_features
-    raise AttributeError(f"module 'polars_ts.decomposition' has no attribute {name!r}")
-
-
-__all__ = ["fourier_decomposition", "seasonal_decomposition", "seasonal_decompose_features"]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/ensemble/__init__.py
+++ b/polars_ts/ensemble/__init__.py
@@ -1,24 +1,10 @@
-"""Forecast ensembling: weighted combination and stacking.
+"""Forecast ensembling: weighted combination and stacking."""
 
-Implements ensemble strategies from Ch 9 of
-"Modern Time Series Forecasting with Python" (2nd Ed.).
-"""
+from polars_ts._lazy import make_getattr
 
-from __future__ import annotations
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "WeightedEnsemble": ("polars_ts.ensemble.weighted", "WeightedEnsemble"),
+    "StackingForecaster": ("polars_ts.ensemble.stacking", "StackingForecaster"),
+}
 
-from typing import Any
-
-
-def __getattr__(name: str) -> Any:
-    if name == "WeightedEnsemble":
-        from polars_ts.ensemble.weighted import WeightedEnsemble
-
-        return WeightedEnsemble
-    if name == "StackingForecaster":
-        from polars_ts.ensemble.stacking import StackingForecaster
-
-        return StackingForecaster
-    raise AttributeError(f"module 'polars_ts.ensemble' has no attribute {name!r}")
-
-
-__all__ = ["WeightedEnsemble", "StackingForecaster"]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/features/__init__.py
+++ b/polars_ts/features/__init__.py
@@ -1,47 +1,14 @@
-"""Feature engineering subpackage for time series data.
+"""Feature engineering subpackage for time series data."""
 
-Provides lag, rolling, calendar, and Fourier feature generation — all pure
-Polars, group-aware, following existing library patterns.
-"""
+from polars_ts._lazy import make_getattr
 
-from __future__ import annotations
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "lag_features": ("polars_ts.features.lags", "lag_features"),
+    "rolling_features": ("polars_ts.features.rolling", "rolling_features"),
+    "calendar_features": ("polars_ts.features.calendar", "calendar_features"),
+    "fourier_features": ("polars_ts.features.fourier", "fourier_features"),
+    "rocket_features": ("polars_ts.features.rocket", "rocket_features"),
+    "minirocket_features": ("polars_ts.features.rocket", "minirocket_features"),
+}
 
-from typing import Any
-
-
-def __getattr__(name: str) -> Any:
-    if name == "lag_features":
-        from polars_ts.features.lags import lag_features
-
-        return lag_features
-    if name == "rolling_features":
-        from polars_ts.features.rolling import rolling_features
-
-        return rolling_features
-    if name == "calendar_features":
-        from polars_ts.features.calendar import calendar_features
-
-        return calendar_features
-    if name == "fourier_features":
-        from polars_ts.features.fourier import fourier_features
-
-        return fourier_features
-    if name == "rocket_features":
-        from polars_ts.features.rocket import rocket_features
-
-        return rocket_features
-    if name == "minirocket_features":
-        from polars_ts.features.rocket import minirocket_features
-
-        return minirocket_features
-    raise AttributeError(f"module 'polars_ts.features' has no attribute {name!r}")
-
-
-__all__ = [
-    "lag_features",
-    "rolling_features",
-    "calendar_features",
-    "fourier_features",
-    "rocket_features",
-    "minirocket_features",
-]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/models/__init__.py
+++ b/polars_ts/models/__init__.py
@@ -1,12 +1,27 @@
 from typing import Any
 
-_BASELINE_NAMES = {"naive_forecast", "seasonal_naive_forecast", "moving_average_forecast", "fft_forecast"}
-_MULTISTEP_NAMES = {"RecursiveForecaster", "DirectForecaster"}
-_ES_NAMES = {"ses_forecast", "holt_forecast", "holt_winters_forecast"}
-_ARIMA_NAMES = {"arima_fit", "arima_forecast", "auto_arima"}
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "naive_forecast": ("polars_ts.models.baselines", "naive_forecast"),
+    "seasonal_naive_forecast": ("polars_ts.models.baselines", "seasonal_naive_forecast"),
+    "moving_average_forecast": ("polars_ts.models.baselines", "moving_average_forecast"),
+    "fft_forecast": ("polars_ts.models.baselines", "fft_forecast"),
+    "RecursiveForecaster": ("polars_ts.models.multistep", "RecursiveForecaster"),
+    "DirectForecaster": ("polars_ts.models.multistep", "DirectForecaster"),
+    "ses_forecast": ("polars_ts.models.exponential_smoothing", "ses_forecast"),
+    "holt_forecast": ("polars_ts.models.exponential_smoothing", "holt_forecast"),
+    "holt_winters_forecast": ("polars_ts.models.exponential_smoothing", "holt_winters_forecast"),
+    "arima_fit": ("polars_ts.models.arima", "arima_fit"),
+    "arima_forecast": ("polars_ts.models.arima", "arima_forecast"),
+    "auto_arima": ("polars_ts.models.arima", "auto_arima"),
+}
+
+_getattr, _all = make_getattr(_IMPORTS, __name__)
 
 
 def __getattr__(name: str) -> Any:
+    # SCUM requires statsforecast — provide a helpful ImportError
     if name == "SCUM":
         try:
             from polars_ts.models.scum import SCUM
@@ -15,37 +30,7 @@ def __getattr__(name: str) -> Any:
                 "statsforecast is required for SCUM. " "Install it with: pip install polars-timeseries[forecast]"
             ) from None
         return SCUM
-    if name in _BASELINE_NAMES:
-        from polars_ts.models import baselines
-
-        return getattr(baselines, name)
-    if name in _MULTISTEP_NAMES:
-        from polars_ts.models import multistep
-
-        return getattr(multistep, name)
-    if name in _ES_NAMES:
-        from polars_ts.models import exponential_smoothing
-
-        return getattr(exponential_smoothing, name)
-    if name in _ARIMA_NAMES:
-        from polars_ts.models import arima
-
-        return getattr(arima, name)
-    raise AttributeError(f"module 'polars_ts.models' has no attribute {name!r}")
+    return _getattr(name)
 
 
-__all__ = [
-    "SCUM",
-    "naive_forecast",
-    "seasonal_naive_forecast",
-    "moving_average_forecast",
-    "fft_forecast",
-    "RecursiveForecaster",
-    "DirectForecaster",
-    "ses_forecast",
-    "holt_forecast",
-    "holt_winters_forecast",
-    "arima_fit",
-    "arima_forecast",
-    "auto_arima",
-]
+__all__ = ["SCUM", *_all]

--- a/polars_ts/probabilistic/__init__.py
+++ b/polars_ts/probabilistic/__init__.py
@@ -1,28 +1,11 @@
-"""Probabilistic forecasting: quantile regression and conformal prediction.
+"""Probabilistic forecasting: quantile regression and conformal prediction."""
 
-Implements prediction interval methods from Ch 16 of
-"Modern Time Series Forecasting with Python" (2nd Ed.).
-"""
+from polars_ts._lazy import make_getattr
 
-from __future__ import annotations
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "QuantileRegressor": ("polars_ts.probabilistic.quantile_regression", "QuantileRegressor"),
+    "conformal_interval": ("polars_ts.probabilistic.conformal", "conformal_interval"),
+    "EnbPI": ("polars_ts.probabilistic.conformal", "EnbPI"),
+}
 
-from typing import Any
-
-
-def __getattr__(name: str) -> Any:
-    if name == "QuantileRegressor":
-        from polars_ts.probabilistic.quantile_regression import QuantileRegressor
-
-        return QuantileRegressor
-    if name == "conformal_interval":
-        from polars_ts.probabilistic.conformal import conformal_interval
-
-        return conformal_interval
-    if name == "EnbPI":
-        from polars_ts.probabilistic.conformal import EnbPI
-
-        return EnbPI
-    raise AttributeError(f"module 'polars_ts.probabilistic' has no attribute {name!r}")
-
-
-__all__ = ["QuantileRegressor", "conformal_interval", "EnbPI"]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/transforms/__init__.py
+++ b/polars_ts/transforms/__init__.py
@@ -1,48 +1,14 @@
-"""Target transform subpackage for time series data.
+"""Target transform subpackage for time series data."""
 
-Provides invertible transforms (log, Box-Cox, differencing) for
-preparing target columns before modelling and restoring predictions
-to the original scale.
-"""
+from polars_ts._lazy import make_getattr
 
-from __future__ import annotations
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "log_transform": ("polars_ts.transforms.log", "log_transform"),
+    "inverse_log_transform": ("polars_ts.transforms.log", "inverse_log_transform"),
+    "boxcox_transform": ("polars_ts.transforms.boxcox", "boxcox_transform"),
+    "inverse_boxcox_transform": ("polars_ts.transforms.boxcox", "inverse_boxcox_transform"),
+    "difference": ("polars_ts.transforms.differencing", "difference"),
+    "undifference": ("polars_ts.transforms.differencing", "undifference"),
+}
 
-from typing import Any
-
-
-def __getattr__(name: str) -> Any:
-    if name == "log_transform":
-        from polars_ts.transforms.log import log_transform
-
-        return log_transform
-    if name == "inverse_log_transform":
-        from polars_ts.transforms.log import inverse_log_transform
-
-        return inverse_log_transform
-    if name == "boxcox_transform":
-        from polars_ts.transforms.boxcox import boxcox_transform
-
-        return boxcox_transform
-    if name == "inverse_boxcox_transform":
-        from polars_ts.transforms.boxcox import inverse_boxcox_transform
-
-        return inverse_boxcox_transform
-    if name == "difference":
-        from polars_ts.transforms.differencing import difference
-
-        return difference
-    if name == "undifference":
-        from polars_ts.transforms.differencing import undifference
-
-        return undifference
-    raise AttributeError(f"module 'polars_ts.transforms' has no attribute {name!r}")
-
-
-__all__ = [
-    "log_transform",
-    "inverse_log_transform",
-    "boxcox_transform",
-    "inverse_boxcox_transform",
-    "difference",
-    "undifference",
-]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/validation/__init__.py
+++ b/polars_ts/validation/__init__.py
@@ -1,32 +1,11 @@
-"""Validation strategies for time series backtesting.
+"""Validation strategies for time series backtesting."""
 
-Provides group-aware temporal cross-validation splitters:
-expanding window, sliding window, and rolling-origin CV.
-"""
+from polars_ts._lazy import make_getattr
 
-from __future__ import annotations
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "expanding_window_cv": ("polars_ts.validation.splits", "expanding_window_cv"),
+    "sliding_window_cv": ("polars_ts.validation.splits", "sliding_window_cv"),
+    "rolling_origin_cv": ("polars_ts.validation.splits", "rolling_origin_cv"),
+}
 
-from typing import Any
-
-
-def __getattr__(name: str) -> Any:
-    if name == "expanding_window_cv":
-        from polars_ts.validation.splits import expanding_window_cv
-
-        return expanding_window_cv
-    if name == "sliding_window_cv":
-        from polars_ts.validation.splits import sliding_window_cv
-
-        return sliding_window_cv
-    if name == "rolling_origin_cv":
-        from polars_ts.validation.splits import rolling_origin_cv
-
-        return rolling_origin_cv
-    raise AttributeError(f"module 'polars_ts.validation' has no attribute {name!r}")
-
-
-__all__ = [
-    "expanding_window_cv",
-    "sliding_window_cv",
-    "rolling_origin_cv",
-]
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)


### PR DESCRIPTION
## Summary

Eliminates 83 if-blocks across 11 `__init__.py` files by replacing them with a data-driven registry pattern. Net result: **-392 lines**.

### Problem

Every new feature required adding 3-4 lines to `polars_ts/__init__.py` (if-block + import + return) and the relevant submodule `__init__.py`. This caused:
- Merge conflicts on every PR touching different features
- 401-line `__init__.py` that was hard to navigate
- Identical boilerplate duplicated across 10 submodules

### Solution

New `polars_ts/_lazy.py` provides `make_getattr(registry, module_name)`:

```python
# Before (per name — 4 lines each, 49 blocks):
def __getattr__(name: str) -> Any:
    if name == "kmedoids":
        from polars_ts.clustering.kmedoids import kmedoids
        return kmedoids
    if name == "KShape":
        from polars_ts.clustering.kshape import KShape
        return KShape
    # ... 47 more blocks
    raise AttributeError(...)

# After (per name — 1 line each):
_LAZY_IMPORTS = {
    "kmedoids": ("polars_ts.clustering.kmedoids", "kmedoids"),
    "KShape": ("polars_ts.clustering.kshape", "KShape"),
    # ... all in one dict
}
```

Adding a new export is now **1 dict line** instead of a 4-line if-block.

### Files changed

| File | Before | After | Change |
|---|---|---|---|
| `polars_ts/__init__.py` | 397 lines (49 if-blocks) | 175 lines (1 registry dict) | -222 |
| `polars_ts/_lazy.py` | — | 50 lines (new shared helper) | +50 |
| 10 submodule `__init__.py` | 333 lines (34 if-blocks) | 113 lines (10 registry dicts) | -220 |
| **Total** | 730 lines | 338 lines | **-392** |

### Special cases preserved

- `models/__init__.py`: SCUM `ImportError` with helpful install message
- `changepoint/__init__.py`: eager `cusum` import (Rust plugin)

## Test plan

- [x] 45 lazy-import tests pass
- [x] ruff check + ruff format clean
- [ ] CI passes (full test suite)