### PR TITLE
refactor: consolidate duplicated test fixtures into conftest files

### DIFF
--- a/tests/bayesian/conftest.py
+++ b/tests/bayesian/conftest.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def local_level_matrices(q: float = 1.0, r: float = 1.0):
+    """Return system matrices (F, H, Q, R) for a local-level model.
+
+    State: x_t (scalar level)
+    Observation: y_t = x_t + v_t
+    Transition: x_t = x_{t-1} + w_t
+    """
+    F = np.array([[1.0]])
+    H = np.array([[1.0]])
+    Q = np.array([[q]])
+    R = np.array([[r]])
+    return F, H, Q, R

--- a/tests/bayesian/test_kalman.py
+++ b/tests/bayesian/test_kalman.py
@@ -4,19 +4,7 @@ import pytest
 
 from polars_ts.bayesian.kalman import KalmanFilter, KalmanResult, kalman_filter
 
-# --- Local-level model helpers ---
-# State: x_t (scalar level)
-# Observation: y_t = x_t + v_t
-# Transition: x_t = x_{t-1} + w_t
-
-
-def _local_level_matrices(q: float = 1.0, r: float = 1.0):
-    """Return system matrices for a local-level (random walk + noise) model."""
-    F = np.array([[1.0]])
-    H = np.array([[1.0]])
-    Q = np.array([[q]])
-    R = np.array([[r]])
-    return F, H, Q, R
+from .conftest import local_level_matrices as _local_level_matrices
 
 
 @pytest.fixture

--- a/tests/clustering/conftest.py
+++ b/tests/clustering/conftest.py
@@ -1,0 +1,22 @@
+import polars as pl
+import pytest
+
+
+@pytest.fixture
+def well_separated_data():
+    """Six series in two well-separated groups (ascending vs descending)."""
+    ascending = [1.0, 2.0, 3.0, 4.0]
+    descending = [4.0, 3.0, 2.0, 1.0]
+    return pl.DataFrame(
+        {
+            "unique_id": (["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4 + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4),
+            "y": (
+                ascending
+                + [1.0, 2.1, 3.0, 4.1]
+                + [1.0, 1.9, 3.1, 4.0]
+                + descending
+                + [4.1, 3.0, 2.0, 0.9]
+                + [3.9, 3.1, 1.9, 1.0]
+            ),
+        }
+    )

--- a/tests/clustering/test_auto.py
+++ b/tests/clustering/test_auto.py
@@ -9,26 +9,6 @@ _has_scipy = importlib.util.find_spec("scipy") is not None
 _has_sklearn = importlib.util.find_spec("sklearn") is not None
 
 
-@pytest.fixture
-def well_separated_data():
-    """Six series in two well-separated groups (ascending vs descending)."""
-    ascending = [1.0, 2.0, 3.0, 4.0]
-    descending = [4.0, 3.0, 2.0, 1.0]
-    return pl.DataFrame(
-        {
-            "unique_id": (["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4 + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4),
-            "y": (
-                ascending
-                + [1.0, 2.1, 3.0, 4.1]
-                + [1.0, 1.9, 3.1, 4.0]
-                + descending
-                + [4.1, 3.0, 2.0, 0.9]
-                + [3.9, 3.1, 1.9, 1.0]
-            ),
-        }
-    )
-
-
 class TestAutoClusterResult:
     def test_returns_auto_cluster_result(self, well_separated_data):
         result = auto_cluster(well_separated_data, methods=["kmedoids"], distances=["sbd"], k_range=range(2, 4))

--- a/tests/clustering/test_density.py
+++ b/tests/clustering/test_density.py
@@ -6,26 +6,6 @@ sklearn = pytest.importorskip("sklearn")
 from polars_ts.clustering.density import dbscan_cluster, hdbscan_cluster  # noqa: E402
 
 
-@pytest.fixture
-def well_separated_data():
-    """Six series in two well-separated groups (ascending vs descending)."""
-    ascending = [1.0, 2.0, 3.0, 4.0]
-    descending = [4.0, 3.0, 2.0, 1.0]
-    return pl.DataFrame(
-        {
-            "unique_id": (["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4 + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4),
-            "y": (
-                ascending
-                + [1.0, 2.1, 3.0, 4.1]
-                + [1.0, 1.9, 3.1, 4.0]
-                + descending
-                + [4.1, 3.0, 2.0, 0.9]
-                + [3.9, 3.1, 1.9, 1.0]
-            ),
-        }
-    )
-
-
 class TestHDBSCAN:
     def test_schema(self, well_separated_data):
         result = hdbscan_cluster(well_separated_data, method="dtw", min_cluster_size=2)

--- a/tests/clustering/test_spectral.py
+++ b/tests/clustering/test_spectral.py
@@ -7,26 +7,6 @@ sklearn = pytest.importorskip("sklearn")
 from polars_ts.clustering.spectral import spectral_cluster  # noqa: E402
 
 
-@pytest.fixture
-def well_separated_data():
-    """Six series in two well-separated groups (ascending vs descending)."""
-    ascending = [1.0, 2.0, 3.0, 4.0]
-    descending = [4.0, 3.0, 2.0, 1.0]
-    return pl.DataFrame(
-        {
-            "unique_id": (["A1"] * 4 + ["A2"] * 4 + ["A3"] * 4 + ["B1"] * 4 + ["B2"] * 4 + ["B3"] * 4),
-            "y": (
-                ascending
-                + [1.0, 2.1, 3.0, 4.1]
-                + [1.0, 1.9, 3.1, 4.0]
-                + descending
-                + [4.1, 3.0, 2.0, 0.9]
-                + [3.9, 3.1, 1.9, 1.0]
-            ),
-        }
-    )
-
-
 class TestSpectralCluster:
     def test_schema(self, well_separated_data):
         result = spectral_cluster(well_separated_data, k=2, method="sbd")

--- a/tests/imaging/conftest.py
+++ b/tests/imaging/conftest.py
@@ -1,0 +1,13 @@
+import polars as pl
+import pytest
+
+
+@pytest.fixture
+def sample_data():
+    """Two series: A ascending (10 points), B alternating (10 points)."""
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * 10 + ["B"] * 10,
+            "y": [float(i) for i in range(10)] + [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        }
+    )

--- a/tests/imaging/test_angular.py
+++ b/tests/imaging/test_angular.py
@@ -1,18 +1,7 @@
 import numpy as np
 import polars as pl
-import pytest
 
 from polars_ts.imaging.angular import to_gadf, to_gasf
-
-
-@pytest.fixture
-def sample_data():
-    return pl.DataFrame(
-        {
-            "unique_id": ["A"] * 10 + ["B"] * 10,
-            "y": [float(i) for i in range(10)] + [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-        }
-    )
 
 
 class TestGASF:

--- a/tests/imaging/test_recurrence.py
+++ b/tests/imaging/test_recurrence.py
@@ -7,16 +7,6 @@ scipy = pytest.importorskip("scipy")
 from polars_ts.imaging.recurrence import rqa_features, to_recurrence_plot  # noqa: E402
 
 
-@pytest.fixture
-def sample_data():
-    return pl.DataFrame(
-        {
-            "unique_id": ["A"] * 10 + ["B"] * 10,
-            "y": [float(i) for i in range(10)] + [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-        }
-    )
-
-
 class TestToRecurrencePlot:
     def test_output_shape(self, sample_data):
         images = to_recurrence_plot(sample_data, threshold=0.5)


### PR DESCRIPTION
## Summary

Closes #147

Consolidates duplicated test fixtures across 3 test directories into shared `conftest.py` files.

### Changes

| Conftest | Fixture | Previously duplicated in |
|---|---|---|
| `tests/clustering/conftest.py` | `well_separated_data` | `test_density.py`, `test_auto.py`, `test_spectral.py` |
| `tests/imaging/conftest.py` | `sample_data` | `test_angular.py`, `test_recurrence.py` |
| `tests/bayesian/conftest.py` | `local_level_matrices` | `test_kalman.py` (helper, will be reused by future Bayesian tests) |

**Net result:** 51 additions, 94 deletions — removed 43 lines of duplicated code.

Specialized fixtures that differ between files (e.g. `test_spectral.py` uses 200-point sine waves, `test_signature.py` uses ascending/descending patterns) were intentionally left in place.

## Test plan

- [x] All 94 affected tests pass
- [x] Ruff check + format clean