### PR TITLE
feat: add causal inference (CausalImpact + Synthetic Control) (#153)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -190,6 +190,13 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "bayesian_ets": ("polars_ts.models.bayesian_ets", "bayesian_ets"),
     "BayesianETS": ("polars_ts.models.bayesian_ets", "BayesianETS"),
     "ETSPriors": ("polars_ts.models.bayesian_ets", "ETSPriors"),
+    # --- Causal Inference ---
+    "CausalImpact": ("polars_ts.causal.causal_impact", "CausalImpact"),
+    "causal_impact": ("polars_ts.causal.causal_impact", "causal_impact"),
+    "CausalImpactResult": ("polars_ts.causal.causal_impact", "CausalImpactResult"),
+    "SyntheticControl": ("polars_ts.causal.synthetic_control", "SyntheticControl"),
+    "synthetic_control": ("polars_ts.causal.synthetic_control", "synthetic_control"),
+    "SyntheticControlResult": ("polars_ts.causal.synthetic_control", "SyntheticControlResult"),
 }
 
 

--- a/polars_ts/causal/__init__.py
+++ b/polars_ts/causal/__init__.py
@@ -1,0 +1,12 @@
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "CausalImpact": ("polars_ts.causal.causal_impact", "CausalImpact"),
+    "causal_impact": ("polars_ts.causal.causal_impact", "causal_impact"),
+    "CausalImpactResult": ("polars_ts.causal.causal_impact", "CausalImpactResult"),
+    "SyntheticControl": ("polars_ts.causal.synthetic_control", "SyntheticControl"),
+    "synthetic_control": ("polars_ts.causal.synthetic_control", "synthetic_control"),
+    "SyntheticControlResult": ("polars_ts.causal.synthetic_control", "SyntheticControlResult"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/causal/causal_impact.py
+++ b/polars_ts/causal/causal_impact.py
@@ -48,9 +48,12 @@ class CausalImpactResult:
     cumulative_effect
         Cumulative sum of pointwise effects.
     cumulative_effect_lower
-        Lower credible bound of cumulative effect.
+        Conservative lower bound of cumulative effect (sum of
+        pointwise lower bounds). This is wider than a proper
+        posterior-based interval because it does not account for
+        cross-timestep correlation.
     cumulative_effect_upper
-        Upper credible bound of cumulative effect.
+        Conservative upper bound of cumulative effect.
     total_effect
         Sum of pointwise effects over the post period.
     total_effect_lower
@@ -173,6 +176,7 @@ class CausalImpact:
         self.time_col = time_col
         self.target_col = target_col
         self._states: dict[Any, _FitState] = {}
+        self._intervention_date: date | datetime | None = None
         self.is_fitted_: bool = False
 
     def fit(
@@ -202,6 +206,7 @@ class CausalImpact:
 
         z = norm.ppf(1 - (1 - self.coverage) / 2)
 
+        self._intervention_date = intervention_date
         sorted_df = df.sort(self.id_col, self.time_col)
 
         for group_id, group_df in sorted_df.group_by(self.id_col, maintain_order=True):
@@ -262,21 +267,24 @@ class CausalImpact:
             cf_sum = float(np.sum(counterfactual))
             if abs(cf_sum) > 1e-10:
                 rel = total / cf_sum
-                rel_lower = total_lower / cf_sum
-                rel_upper = total_upper / cf_sum
+                rel_lo = total_lower / cf_sum
+                rel_hi = total_upper / cf_sum
+                # Division by negative cf_sum flips ordering
+                rel_lower = min(rel_lo, rel_hi)
+                rel_upper = max(rel_lo, rel_hi)
             else:
                 rel = rel_lower = rel_upper = 0.0
 
-            # Pre-period diagnostics
-            pre_fitted = _bsts_in_sample(model, pre_y)
+            # Pre-period diagnostics (reuse smoothed states from forecast)
+            kr = bsts_result.kalman_result
+            assert kr.smoothed_states is not None
+            assert kr.smoothed_covs is not None
+            _, H_mat, _, R_mat = model._build_system()
+            pre_fitted = np.array([float((H_mat @ kr.smoothed_states[t]).item()) for t in range(len(pre_y))])
             pre_residuals = pre_y - pre_fitted
             pre_mape = float(np.mean(np.abs(pre_residuals / np.where(np.abs(pre_y) > 1e-10, pre_y, 1.0))))
 
             # Pre-period coverage: fraction of obs inside credible interval
-            kr = bsts_result.kalman_result
-            assert kr.smoothed_states is not None
-            assert kr.smoothed_covs is not None
-            F_mat, H_mat, _, R_mat = model._build_system()
             pre_fitted_var = np.array(
                 [float((H_mat @ kr.smoothed_covs[t] @ H_mat.T + R_mat).item()) for t in range(len(pre_y))]
             )
@@ -405,8 +413,10 @@ class CausalImpact:
         """Run a placebo test at a date before the actual intervention.
 
         Fits the model pretending ``placebo_date`` is the intervention,
-        using only pre-intervention data. If the model is well-specified,
-        the estimated effect should be near zero.
+        using only data from the pre-intervention period (data after
+        the real intervention is excluded to avoid contamination).
+        If the model is well-specified, the estimated effect should
+        be near zero.
 
         Parameters
         ----------
@@ -422,6 +432,12 @@ class CausalImpact:
             total_effect_upper, relative_effect.
 
         """
+        if not self.is_fitted_ or self._intervention_date is None:
+            raise RuntimeError("Call fit() before placebo_test().")
+
+        # Filter out post-intervention data to avoid contamination
+        pre_only = df.filter(pl.col(self.time_col) < self._intervention_date)
+
         placebo = CausalImpact(
             trend=self.trend,
             seasonal=self.seasonal,
@@ -434,18 +450,8 @@ class CausalImpact:
             time_col=self.time_col,
             target_col=self.target_col,
         )
-        placebo.fit(df, intervention_date=placebo_date)
+        placebo.fit(pre_only, intervention_date=placebo_date)
         return placebo.summary()
-
-
-def _bsts_in_sample(model: BSTS, y: np.ndarray) -> np.ndarray:
-    """Compute BSTS in-sample fitted values from smoothed states."""
-    result = model.fit(y)
-    kr = result.kalman_result
-    assert kr.smoothed_states is not None
-    _, H, _, _ = model._build_system()
-    fitted = np.array([float((H @ kr.smoothed_states[t]).item()) for t in range(len(y))])
-    return fitted
 
 
 def causal_impact(

--- a/polars_ts/causal/causal_impact.py
+++ b/polars_ts/causal/causal_impact.py
@@ -1,0 +1,501 @@
+"""CausalImpact: Bayesian causal inference for intervention analysis.
+
+Estimates the causal effect of an intervention on a time series using
+a Bayesian structural time series (BSTS) counterfactual model. The
+pre-intervention period trains the model; the post-intervention
+counterfactual projection is subtracted from the observed series to
+yield the estimated treatment effect with credible intervals.
+
+Design notes (from issue #148 feedback):
+- Returns (point, lower, upper) from day one — no bolt-on bootstrap.
+- Exposes full BSTS spec so priors are never hidden.
+- Pre-period diagnostics run by default.
+- Built-in placebo tests via ``placebo_test``.
+
+References
+----------
+Brodersen et al. (2015). *Inferring causal impact using Bayesian
+structural time series models.* Annals of Applied Statistics.
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.bayesian.bsts import BSTS, BSTSResult
+
+
+@dataclass
+class CausalImpactResult:
+    """Result container for a CausalImpact analysis.
+
+    All effect arrays have length equal to the post-intervention period.
+
+    Attributes
+    ----------
+    point_effect
+        Pointwise causal effect (observed - counterfactual).
+    point_effect_lower
+        Lower credible bound of the pointwise effect.
+    point_effect_upper
+        Upper credible bound of the pointwise effect.
+    cumulative_effect
+        Cumulative sum of pointwise effects.
+    cumulative_effect_lower
+        Lower credible bound of cumulative effect.
+    cumulative_effect_upper
+        Upper credible bound of cumulative effect.
+    total_effect
+        Sum of pointwise effects over the post period.
+    total_effect_lower
+        Lower credible bound of total effect.
+    total_effect_upper
+        Upper credible bound of total effect.
+    relative_effect
+        Total effect divided by sum of counterfactual.
+    relative_effect_lower
+        Lower credible bound of relative effect.
+    relative_effect_upper
+        Upper credible bound of relative effect.
+    counterfactual
+        Predicted counterfactual series for the post period.
+    counterfactual_lower
+        Lower credible bound of counterfactual.
+    counterfactual_upper
+        Upper credible bound of counterfactual.
+    observed_post
+        Observed values in the post period.
+    bsts_result
+        Underlying BSTS model result.
+    pre_mape
+        Mean absolute percentage error on the pre-period (diagnostic).
+    pre_coverage
+        Fraction of pre-period observations inside the credible interval.
+
+    """
+
+    point_effect: np.ndarray
+    point_effect_lower: np.ndarray
+    point_effect_upper: np.ndarray
+    cumulative_effect: np.ndarray
+    cumulative_effect_lower: np.ndarray
+    cumulative_effect_upper: np.ndarray
+    total_effect: float
+    total_effect_lower: float
+    total_effect_upper: float
+    relative_effect: float
+    relative_effect_lower: float
+    relative_effect_upper: float
+    counterfactual: np.ndarray
+    counterfactual_lower: np.ndarray
+    counterfactual_upper: np.ndarray
+    observed_post: np.ndarray
+    bsts_result: BSTSResult
+    pre_mape: float
+    pre_coverage: float
+
+
+@dataclass
+class _FitState:
+    """Internal per-series fit state."""
+
+    bsts_model: BSTS
+    pre_y: np.ndarray
+    post_y: np.ndarray
+    pre_len: int
+    post_len: int
+    result: CausalImpactResult | None = None
+
+
+class CausalImpact:
+    """Bayesian CausalImpact estimator.
+
+    Parameters
+    ----------
+    trend
+        BSTS trend type: ``"level"`` or ``"local_linear"``.
+    seasonal
+        Number of seasons for the BSTS seasonal component.
+        ``None`` disables seasonality.
+    sigma_obs
+        Observation noise standard deviation.
+    sigma_level
+        Level component noise standard deviation.
+    sigma_trend
+        Trend component noise standard deviation.
+    sigma_seasonal
+        Seasonal component noise standard deviation.
+    coverage
+        Credible interval coverage (e.g. 0.9 for 90%).
+    id_col
+        Column identifying each time series.
+    time_col
+        Column with timestamps.
+    target_col
+        Column with observed values.
+
+    Notes
+    -----
+    The BSTS prior hyperparameters (``sigma_*``) are exposed explicitly
+    because the posterior interval is dominated by the prior when the
+    pre-period is short (<60 observations). Always inspect ``pre_mape``
+    and ``pre_coverage`` diagnostics before trusting effect estimates.
+
+    """
+
+    def __init__(
+        self,
+        trend: str = "local_linear",
+        seasonal: int | None = None,
+        sigma_obs: float = 1.0,
+        sigma_level: float = 0.1,
+        sigma_trend: float = 0.01,
+        sigma_seasonal: float = 0.01,
+        coverage: float = 0.9,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> None:
+        self.trend = trend
+        self.seasonal = seasonal
+        self.sigma_obs = sigma_obs
+        self.sigma_level = sigma_level
+        self.sigma_trend = sigma_trend
+        self.sigma_seasonal = sigma_seasonal
+        self.coverage = coverage
+        self.id_col = id_col
+        self.time_col = time_col
+        self.target_col = target_col
+        self._states: dict[Any, _FitState] = {}
+        self.is_fitted_: bool = False
+
+    def fit(
+        self,
+        df: pl.DataFrame,
+        intervention_date: date | datetime,
+    ) -> CausalImpact:
+        """Fit the causal impact model.
+
+        Parameters
+        ----------
+        df
+            Panel DataFrame with ``id_col``, ``time_col``, and ``target_col``.
+            Must contain both pre- and post-intervention observations.
+        intervention_date
+            The first date/time of the post-intervention period. All
+            observations with ``time_col >= intervention_date`` are
+            treated as post-intervention.
+
+        Returns
+        -------
+        CausalImpact
+            Self, for chaining.
+
+        """
+        from scipy.stats import norm
+
+        z = norm.ppf(1 - (1 - self.coverage) / 2)
+
+        sorted_df = df.sort(self.id_col, self.time_col)
+
+        for group_id, group_df in sorted_df.group_by(self.id_col, maintain_order=True):
+            gid = group_id[0]
+
+            pre_df = group_df.filter(pl.col(self.time_col) < intervention_date)
+            post_df = group_df.filter(pl.col(self.time_col) >= intervention_date)
+
+            if len(pre_df) < 3:
+                raise ValueError(
+                    f"Series {gid!r}: pre-intervention period has {len(pre_df)} " f"observations, need at least 3."
+                )
+            if len(post_df) == 0:
+                raise ValueError(
+                    f"Series {gid!r}: no post-intervention observations found. "
+                    f"Check that intervention_date={intervention_date} is within "
+                    f"the data range."
+                )
+
+            pre_y = pre_df[self.target_col].to_numpy().astype(np.float64)
+            post_y = post_df[self.target_col].to_numpy().astype(np.float64)
+
+            model = BSTS(
+                trend=self.trend,
+                seasonal=self.seasonal,
+                sigma_obs=self.sigma_obs,
+                sigma_level=self.sigma_level,
+                sigma_trend=self.sigma_trend,
+                sigma_seasonal=self.sigma_seasonal,
+            )
+
+            bsts_result = model.forecast(pre_y, h=len(post_y))
+
+            assert bsts_result.forecast is not None
+            assert bsts_result.forecast_var is not None
+
+            counterfactual = bsts_result.forecast
+            cf_std = np.sqrt(np.maximum(bsts_result.forecast_var, 0.0))
+            cf_lower = counterfactual - z * cf_std
+            cf_upper = counterfactual + z * cf_std
+
+            # Pointwise effect
+            point_effect = post_y - counterfactual
+            effect_lower = post_y - cf_upper  # lower effect when cf is high
+            effect_upper = post_y - cf_lower  # upper effect when cf is low
+
+            # Cumulative effect
+            cum_effect = np.cumsum(point_effect)
+            cum_lower = np.cumsum(effect_lower)
+            cum_upper = np.cumsum(effect_upper)
+
+            # Total effect
+            total = float(np.sum(point_effect))
+            total_lower = float(np.sum(effect_lower))
+            total_upper = float(np.sum(effect_upper))
+
+            # Relative effect
+            cf_sum = float(np.sum(counterfactual))
+            if abs(cf_sum) > 1e-10:
+                rel = total / cf_sum
+                rel_lower = total_lower / cf_sum
+                rel_upper = total_upper / cf_sum
+            else:
+                rel = rel_lower = rel_upper = 0.0
+
+            # Pre-period diagnostics
+            pre_fitted = _bsts_in_sample(model, pre_y)
+            pre_residuals = pre_y - pre_fitted
+            pre_mape = float(np.mean(np.abs(pre_residuals / np.where(np.abs(pre_y) > 1e-10, pre_y, 1.0))))
+
+            # Pre-period coverage: fraction of obs inside credible interval
+            kr = bsts_result.kalman_result
+            assert kr.smoothed_states is not None
+            assert kr.smoothed_covs is not None
+            F_mat, H_mat, _, R_mat = model._build_system()
+            pre_fitted_var = np.array(
+                [float((H_mat @ kr.smoothed_covs[t] @ H_mat.T + R_mat).item()) for t in range(len(pre_y))]
+            )
+            pre_std = np.sqrt(np.maximum(pre_fitted_var, 0.0))
+            in_interval = np.abs(pre_residuals) <= z * pre_std
+            pre_coverage = float(np.mean(in_interval))
+
+            result = CausalImpactResult(
+                point_effect=point_effect,
+                point_effect_lower=effect_lower,
+                point_effect_upper=effect_upper,
+                cumulative_effect=cum_effect,
+                cumulative_effect_lower=cum_lower,
+                cumulative_effect_upper=cum_upper,
+                total_effect=total,
+                total_effect_lower=total_lower,
+                total_effect_upper=total_upper,
+                relative_effect=rel,
+                relative_effect_lower=rel_lower,
+                relative_effect_upper=rel_upper,
+                counterfactual=counterfactual,
+                counterfactual_lower=cf_lower,
+                counterfactual_upper=cf_upper,
+                observed_post=post_y,
+                bsts_result=bsts_result,
+                pre_mape=pre_mape,
+                pre_coverage=pre_coverage,
+            )
+
+            state = _FitState(
+                bsts_model=model,
+                pre_y=pre_y,
+                post_y=post_y,
+                pre_len=len(pre_y),
+                post_len=len(post_y),
+                result=result,
+            )
+            self._states[gid] = state
+
+        self.is_fitted_ = True
+        return self
+
+    def results(self) -> dict[Any, CausalImpactResult]:
+        """Return per-series CausalImpactResult objects.
+
+        Returns
+        -------
+        dict[Any, CausalImpactResult]
+            Mapping from series ID to result.
+
+        """
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before results().")
+        return {gid: s.result for gid, s in self._states.items() if s.result is not None}
+
+    def summary(self) -> pl.DataFrame:
+        """Return a summary DataFrame with one row per series.
+
+        Columns: id_col, total_effect, total_effect_lower, total_effect_upper,
+        relative_effect, relative_effect_lower, relative_effect_upper,
+        pre_mape, pre_coverage.
+
+        """
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before summary().")
+
+        rows: list[dict[str, Any]] = []
+        for gid, state in self._states.items():
+            r = state.result
+            assert r is not None
+            rows.append(
+                {
+                    self.id_col: gid,
+                    "total_effect": r.total_effect,
+                    "total_effect_lower": r.total_effect_lower,
+                    "total_effect_upper": r.total_effect_upper,
+                    "relative_effect": r.relative_effect,
+                    "relative_effect_lower": r.relative_effect_lower,
+                    "relative_effect_upper": r.relative_effect_upper,
+                    "pre_mape": r.pre_mape,
+                    "pre_coverage": r.pre_coverage,
+                }
+            )
+        return pl.DataFrame(rows)
+
+    def to_frame(self) -> pl.DataFrame:
+        """Return pointwise results as a DataFrame.
+
+        Columns: id_col, step, observed, counterfactual, counterfactual_lower,
+        counterfactual_upper, point_effect, point_effect_lower,
+        point_effect_upper, cumulative_effect, cumulative_effect_lower,
+        cumulative_effect_upper.
+
+        """
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before to_frame().")
+
+        all_rows: list[dict[str, Any]] = []
+        for gid, state in self._states.items():
+            r = state.result
+            assert r is not None
+            for t in range(state.post_len):
+                all_rows.append(
+                    {
+                        self.id_col: gid,
+                        "step": t + 1,
+                        "observed": float(r.observed_post[t]),
+                        "counterfactual": float(r.counterfactual[t]),
+                        "counterfactual_lower": float(r.counterfactual_lower[t]),
+                        "counterfactual_upper": float(r.counterfactual_upper[t]),
+                        "point_effect": float(r.point_effect[t]),
+                        "point_effect_lower": float(r.point_effect_lower[t]),
+                        "point_effect_upper": float(r.point_effect_upper[t]),
+                        "cumulative_effect": float(r.cumulative_effect[t]),
+                        "cumulative_effect_lower": float(r.cumulative_effect_lower[t]),
+                        "cumulative_effect_upper": float(r.cumulative_effect_upper[t]),
+                    }
+                )
+        return pl.DataFrame(all_rows)
+
+    def placebo_test(
+        self,
+        df: pl.DataFrame,
+        placebo_date: date | datetime,
+    ) -> pl.DataFrame:
+        """Run a placebo test at a date before the actual intervention.
+
+        Fits the model pretending ``placebo_date`` is the intervention,
+        using only pre-intervention data. If the model is well-specified,
+        the estimated effect should be near zero.
+
+        Parameters
+        ----------
+        df
+            Same panel DataFrame used in ``fit()``.
+        placebo_date
+            A date strictly before the actual intervention.
+
+        Returns
+        -------
+        pl.DataFrame
+            Summary with columns: id_col, total_effect, total_effect_lower,
+            total_effect_upper, relative_effect.
+
+        """
+        placebo = CausalImpact(
+            trend=self.trend,
+            seasonal=self.seasonal,
+            sigma_obs=self.sigma_obs,
+            sigma_level=self.sigma_level,
+            sigma_trend=self.sigma_trend,
+            sigma_seasonal=self.sigma_seasonal,
+            coverage=self.coverage,
+            id_col=self.id_col,
+            time_col=self.time_col,
+            target_col=self.target_col,
+        )
+        placebo.fit(df, intervention_date=placebo_date)
+        return placebo.summary()
+
+
+def _bsts_in_sample(model: BSTS, y: np.ndarray) -> np.ndarray:
+    """Compute BSTS in-sample fitted values from smoothed states."""
+    result = model.fit(y)
+    kr = result.kalman_result
+    assert kr.smoothed_states is not None
+    _, H, _, _ = model._build_system()
+    fitted = np.array([float((H @ kr.smoothed_states[t]).item()) for t in range(len(y))])
+    return fitted
+
+
+def causal_impact(
+    df: pl.DataFrame,
+    intervention_date: date | datetime,
+    trend: str = "local_linear",
+    seasonal: int | None = None,
+    sigma_obs: float = 1.0,
+    sigma_level: float = 0.1,
+    sigma_trend: float = 0.01,
+    sigma_seasonal: float = 0.01,
+    coverage: float = 0.9,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+) -> dict[Any, CausalImpactResult]:
+    """Estimate the causal effect of an intervention on time series.
+
+    Convenience function wrapping :class:`CausalImpact`.
+
+    Parameters
+    ----------
+    df
+        Panel DataFrame.
+    intervention_date
+        First date of the post-intervention period.
+    trend, seasonal, sigma_obs, sigma_level, sigma_trend, sigma_seasonal
+        BSTS model configuration (see :class:`CausalImpact`).
+    coverage
+        Credible interval coverage.
+    id_col, time_col, target_col
+        Column names.
+
+    Returns
+    -------
+    dict[Any, CausalImpactResult]
+        Mapping from series ID to result.
+
+    """
+    ci = CausalImpact(
+        trend=trend,
+        seasonal=seasonal,
+        sigma_obs=sigma_obs,
+        sigma_level=sigma_level,
+        sigma_trend=sigma_trend,
+        sigma_seasonal=sigma_seasonal,
+        coverage=coverage,
+        id_col=id_col,
+        time_col=time_col,
+        target_col=target_col,
+    )
+    ci.fit(df, intervention_date=intervention_date)
+    return ci.results()

--- a/polars_ts/causal/synthetic_control.py
+++ b/polars_ts/causal/synthetic_control.py
@@ -1,0 +1,431 @@
+"""Synthetic Control Method for causal inference.
+
+Constructs a counterfactual for a treated unit by finding an optimal
+weighted combination of donor (control) units. The treatment effect is
+the gap between the observed treated series and the synthetic control.
+
+Supports:
+- Classic synthetic control (Abadie et al., 2010)
+- Prediction intervals via scpi-style uncertainty quantification
+  (Cattaneo et al., 2025)
+- Built-in placebo tests across all donor units
+
+References
+----------
+Abadie, Diamond & Hainmueller (2010). *Synthetic Control Methods
+for Comparative Case Studies.*
+
+Xu (2017). *Generalized Synthetic Control Method: Causal Inference
+with Interactive Fixed Effects Models.*
+
+Cattaneo, Feng, Palomba & Titiunik (2025). *scpi: Uncertainty
+Quantification for Synthetic Control Methods.* J. Stat. Soft.
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+
+@dataclass
+class SyntheticControlResult:
+    """Result container for a synthetic control analysis.
+
+    Attributes
+    ----------
+    treated_id
+        Identifier of the treated unit.
+    weights
+        Donor weights, shape ``(n_donors,)``.
+    donor_ids
+        List of donor unit identifiers, aligned with ``weights``.
+    counterfactual
+        Synthetic control series for the full time range.
+    counterfactual_lower
+        Lower prediction interval for the counterfactual.
+    counterfactual_upper
+        Upper prediction interval for the counterfactual.
+    point_effect
+        Pointwise treatment effect (observed - synthetic) for the
+        post-intervention period.
+    point_effect_lower
+        Lower bound of pointwise effect.
+    point_effect_upper
+        Upper bound of pointwise effect.
+    total_effect
+        Sum of pointwise effects.
+    total_effect_lower
+        Lower bound of total effect.
+    total_effect_upper
+        Upper bound of total effect.
+    pre_rmse
+        Root mean squared error in the pre-intervention period.
+
+    """
+
+    treated_id: Any
+    weights: np.ndarray
+    donor_ids: list[Any]
+    counterfactual: np.ndarray
+    counterfactual_lower: np.ndarray
+    counterfactual_upper: np.ndarray
+    point_effect: np.ndarray
+    point_effect_lower: np.ndarray
+    point_effect_upper: np.ndarray
+    total_effect: float
+    total_effect_lower: float
+    total_effect_upper: float
+    pre_rmse: float
+
+
+class SyntheticControl:
+    """Synthetic Control Method estimator.
+
+    Parameters
+    ----------
+    coverage
+        Prediction interval coverage (e.g. 0.9 for 90%).
+    id_col
+        Column identifying each unit.
+    time_col
+        Column with timestamps.
+    target_col
+        Column with observed values.
+
+    """
+
+    def __init__(
+        self,
+        coverage: float = 0.9,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> None:
+        self.coverage = coverage
+        self.id_col = id_col
+        self.time_col = time_col
+        self.target_col = target_col
+        self._result: SyntheticControlResult | None = None
+        self.is_fitted_: bool = False
+
+    def fit(
+        self,
+        df: pl.DataFrame,
+        treated_id: Any,
+        intervention_date: date | datetime,
+        donor_ids: list[Any] | None = None,
+    ) -> SyntheticControl:
+        """Fit the synthetic control model.
+
+        Parameters
+        ----------
+        df
+            Panel DataFrame with all units (treated + donors).
+        treated_id
+            Identifier of the treated unit.
+        intervention_date
+            First date of the post-intervention period.
+        donor_ids
+            Specific donor unit IDs. If ``None``, all units except
+            ``treated_id`` are used as donors.
+
+        Returns
+        -------
+        SyntheticControl
+            Self, for chaining.
+
+        """
+        sorted_df = df.sort(self.id_col, self.time_col)
+        all_ids = sorted_df[self.id_col].unique(maintain_order=True).to_list()
+
+        if treated_id not in all_ids:
+            raise ValueError(f"treated_id={treated_id!r} not found in data.")
+
+        if donor_ids is None:
+            donor_ids = [uid for uid in all_ids if uid != treated_id]
+
+        if len(donor_ids) == 0:
+            raise ValueError("No donor units available.")
+
+        # Extract treated series
+        treated_df = sorted_df.filter(pl.col(self.id_col) == treated_id)
+        times = treated_df[self.time_col].to_list()
+        treated_y = treated_df[self.target_col].to_numpy().astype(np.float64)
+
+        pre_mask = np.array([t < intervention_date for t in times])
+        post_mask = ~pre_mask
+
+        if pre_mask.sum() < 2:
+            raise ValueError(f"Pre-intervention period has {pre_mask.sum()} observations, " f"need at least 2.")
+        if post_mask.sum() == 0:
+            raise ValueError("No post-intervention observations found.")
+
+        # Build donor matrix (T x n_donors)
+        donor_matrix = np.zeros((len(times), len(donor_ids)))
+        valid_donors: list[Any] = []
+        col_idx = 0
+        for did in donor_ids:
+            d_df = sorted_df.filter(pl.col(self.id_col) == did)
+            d_times = d_df[self.time_col].to_list()
+            if d_times != times:
+                continue  # skip donors with mismatched time index
+            donor_matrix[:, col_idx] = d_df[self.target_col].to_numpy().astype(np.float64)
+            valid_donors.append(did)
+            col_idx += 1
+
+        donor_matrix = donor_matrix[:, :col_idx]
+        if col_idx == 0:
+            raise ValueError("No donors with matching time index found.")
+
+        # Solve for weights: minimize ||y_pre - D_pre @ w||^2
+        # subject to w >= 0, sum(w) = 1
+        pre_treated = treated_y[pre_mask]
+        pre_donors = donor_matrix[pre_mask]
+        weights = _solve_sc_weights(pre_treated, pre_donors)
+
+        # Construct counterfactual
+        counterfactual = donor_matrix @ weights
+
+        # Pre-period fit quality
+        pre_residuals = pre_treated - counterfactual[pre_mask]
+        pre_rmse = float(np.sqrt(np.mean(pre_residuals**2)))
+
+        # Prediction intervals (scpi-style)
+        # Use pre-period residual distribution for uncertainty
+        residual_std = float(np.std(pre_residuals, ddof=1)) if len(pre_residuals) > 1 else 0.0
+
+        from scipy.stats import norm
+
+        z = norm.ppf(1 - (1 - self.coverage) / 2)
+
+        # Uncertainty grows with forecast horizon (random-walk diffusion)
+        post_len = int(post_mask.sum())
+        horizon = np.arange(1, post_len + 1, dtype=np.float64)
+        post_std = residual_std * np.sqrt(horizon)
+
+        full_std = np.zeros(len(times))
+        full_std[pre_mask] = residual_std
+        full_std[post_mask] = post_std
+
+        cf_lower = counterfactual - z * full_std
+        cf_upper = counterfactual + z * full_std
+
+        # Effects (post-period only)
+        post_treated = treated_y[post_mask]
+        post_cf = counterfactual[post_mask]
+        point_effect = post_treated - post_cf
+        effect_lower = post_treated - (post_cf + z * post_std)
+        effect_upper = post_treated - (post_cf - z * post_std)
+
+        total = float(np.sum(point_effect))
+        total_lower = float(np.sum(effect_lower))
+        total_upper = float(np.sum(effect_upper))
+
+        self._result = SyntheticControlResult(
+            treated_id=treated_id,
+            weights=weights,
+            donor_ids=valid_donors,
+            counterfactual=counterfactual,
+            counterfactual_lower=cf_lower,
+            counterfactual_upper=cf_upper,
+            point_effect=point_effect,
+            point_effect_lower=effect_lower,
+            point_effect_upper=effect_upper,
+            total_effect=total,
+            total_effect_lower=total_lower,
+            total_effect_upper=total_upper,
+            pre_rmse=pre_rmse,
+        )
+        self.is_fitted_ = True
+        return self
+
+    @property
+    def result(self) -> SyntheticControlResult:
+        """Access the fit result."""
+        if not self.is_fitted_ or self._result is None:
+            raise RuntimeError("Call fit() before accessing result.")
+        return self._result
+
+    def to_frame(self) -> pl.DataFrame:
+        """Return pointwise post-period results as a DataFrame.
+
+        Columns: step, observed, counterfactual, counterfactual_lower,
+        counterfactual_upper, point_effect, point_effect_lower,
+        point_effect_upper.
+
+        """
+        r = self.result
+        rows: list[dict[str, Any]] = []
+        for t in range(len(r.point_effect)):
+            rows.append(
+                {
+                    "step": t + 1,
+                    "observed": float(r.point_effect[t] + r.counterfactual[-len(r.point_effect) + t]),
+                    "counterfactual": float(r.counterfactual[-len(r.point_effect) + t]),
+                    "counterfactual_lower": float(r.counterfactual_lower[-len(r.point_effect) + t]),
+                    "counterfactual_upper": float(r.counterfactual_upper[-len(r.point_effect) + t]),
+                    "point_effect": float(r.point_effect[t]),
+                    "point_effect_lower": float(r.point_effect_lower[t]),
+                    "point_effect_upper": float(r.point_effect_upper[t]),
+                }
+            )
+        return pl.DataFrame(rows)
+
+    def placebo_test(
+        self,
+        df: pl.DataFrame,
+        intervention_date: date | datetime,
+    ) -> pl.DataFrame:
+        """Run placebo tests treating each donor as the treated unit.
+
+        Fits the synthetic control for every donor unit (using remaining
+        donors as the pool) and reports the empirical distribution of
+        placebo effects. A credible treatment effect should be larger
+        than the placebo distribution.
+
+        Parameters
+        ----------
+        df
+            Same panel DataFrame used in ``fit()``.
+        intervention_date
+            Same intervention date.
+
+        Returns
+        -------
+        pl.DataFrame
+            Columns: unit_id, is_treated, total_effect, pre_rmse.
+
+        """
+        r = self.result
+        all_donor_ids = list(r.donor_ids)
+        treated_id = r.treated_id
+
+        rows: list[dict[str, Any]] = []
+        # Include the actual treated unit
+        rows.append(
+            {
+                "unit_id": treated_id,
+                "is_treated": True,
+                "total_effect": r.total_effect,
+                "pre_rmse": r.pre_rmse,
+            }
+        )
+
+        # Run placebo for each donor
+        for donor in all_donor_ids:
+            placebo_donors = [d for d in all_donor_ids if d != donor]
+            placebo_donors.append(treated_id)
+            try:
+                sc = SyntheticControl(
+                    coverage=self.coverage,
+                    id_col=self.id_col,
+                    time_col=self.time_col,
+                    target_col=self.target_col,
+                )
+                sc.fit(df, treated_id=donor, intervention_date=intervention_date, donor_ids=placebo_donors)
+                pr = sc.result
+                rows.append(
+                    {
+                        "unit_id": donor,
+                        "is_treated": False,
+                        "total_effect": pr.total_effect,
+                        "pre_rmse": pr.pre_rmse,
+                    }
+                )
+            except (ValueError, np.linalg.LinAlgError):
+                continue
+
+        return pl.DataFrame(rows)
+
+
+def _solve_sc_weights(y: np.ndarray, D: np.ndarray) -> np.ndarray:
+    """Solve for synthetic control weights using constrained least squares.
+
+    Minimizes ||y - D @ w||^2 subject to w >= 0, sum(w) = 1.
+    Falls back to unconstrained + normalization if scipy.optimize
+    is not available.
+    """
+    from scipy.optimize import minimize
+
+    n_donors = D.shape[1]
+    if n_donors == 1:
+        return np.array([1.0])
+
+    def objective(w: np.ndarray) -> float:
+        return float(np.sum((y - D @ w) ** 2))
+
+    def jac(w: np.ndarray) -> np.ndarray:
+        return -2.0 * D.T @ (y - D @ w)
+
+    constraints = {"type": "eq", "fun": lambda w: np.sum(w) - 1.0}
+    bounds = [(0.0, 1.0)] * n_donors
+    x0 = np.ones(n_donors) / n_donors
+
+    result = minimize(
+        objective,
+        x0,
+        jac=jac,
+        method="SLSQP",
+        bounds=bounds,
+        constraints=constraints,
+        options={"maxiter": 1000, "ftol": 1e-12},
+    )
+
+    w = result.x
+    w = np.maximum(w, 0.0)
+    w_sum = w.sum()
+    if w_sum > 0:
+        w /= w_sum
+    else:
+        w = np.ones(n_donors) / n_donors
+    return w
+
+
+def synthetic_control(
+    df: pl.DataFrame,
+    treated_id: Any,
+    intervention_date: date | datetime,
+    donor_ids: list[Any] | None = None,
+    coverage: float = 0.9,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+) -> SyntheticControlResult:
+    """Estimate the causal effect using the synthetic control method.
+
+    Convenience function wrapping :class:`SyntheticControl`.
+
+    Parameters
+    ----------
+    df
+        Panel DataFrame with all units.
+    treated_id
+        Identifier of the treated unit.
+    intervention_date
+        First date of the post-intervention period.
+    donor_ids
+        Specific donor IDs. ``None`` uses all non-treated units.
+    coverage
+        Prediction interval coverage.
+    id_col, time_col, target_col
+        Column names.
+
+    Returns
+    -------
+    SyntheticControlResult
+
+    """
+    sc = SyntheticControl(
+        coverage=coverage,
+        id_col=id_col,
+        time_col=time_col,
+        target_col=target_col,
+    )
+    sc.fit(df, treated_id=treated_id, intervention_date=intervention_date, donor_ids=donor_ids)
+    return sc.result

--- a/polars_ts/causal/synthetic_control.py
+++ b/polars_ts/causal/synthetic_control.py
@@ -64,6 +64,8 @@ class SyntheticControlResult:
         Lower bound of total effect.
     total_effect_upper
         Upper bound of total effect.
+    observed_post
+        Observed values of the treated unit in the post period.
     pre_rmse
         Root mean squared error in the pre-intervention period.
 
@@ -81,6 +83,7 @@ class SyntheticControlResult:
     total_effect: float
     total_effect_lower: float
     total_effect_upper: float
+    observed_post: np.ndarray
     pre_rmse: float
 
 
@@ -240,6 +243,7 @@ class SyntheticControl:
             total_effect=total,
             total_effect_lower=total_lower,
             total_effect_upper=total_upper,
+            observed_post=post_treated,
             pre_rmse=pre_rmse,
         )
         self.is_fitted_ = True
@@ -261,15 +265,16 @@ class SyntheticControl:
 
         """
         r = self.result
+        n_post = len(r.point_effect)
         rows: list[dict[str, Any]] = []
-        for t in range(len(r.point_effect)):
+        for t in range(n_post):
             rows.append(
                 {
                     "step": t + 1,
-                    "observed": float(r.point_effect[t] + r.counterfactual[-len(r.point_effect) + t]),
-                    "counterfactual": float(r.counterfactual[-len(r.point_effect) + t]),
-                    "counterfactual_lower": float(r.counterfactual_lower[-len(r.point_effect) + t]),
-                    "counterfactual_upper": float(r.counterfactual_upper[-len(r.point_effect) + t]),
+                    "observed": float(r.observed_post[t]),
+                    "counterfactual": float(r.counterfactual[-n_post + t]),
+                    "counterfactual_lower": float(r.counterfactual_lower[-n_post + t]),
+                    "counterfactual_upper": float(r.counterfactual_upper[-n_post + t]),
                     "point_effect": float(r.point_effect[t]),
                     "point_effect_lower": float(r.point_effect_lower[t]),
                     "point_effect_upper": float(r.point_effect_upper[t]),
@@ -348,8 +353,7 @@ def _solve_sc_weights(y: np.ndarray, D: np.ndarray) -> np.ndarray:
     """Solve for synthetic control weights using constrained least squares.
 
     Minimizes ||y - D @ w||^2 subject to w >= 0, sum(w) = 1.
-    Falls back to unconstrained + normalization if scipy.optimize
-    is not available.
+    Uses SLSQP from scipy.optimize.
     """
     from scipy.optimize import minimize
 

--- a/tests/causal/conftest.py
+++ b/tests/causal/conftest.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+
+@pytest.fixture()
+def causal_df() -> pl.DataFrame:
+    """Panel with a single series and a clear intervention effect."""
+    rng = np.random.default_rng(42)
+    n_pre, n_post = 60, 20
+    n = n_pre + n_post
+    base = date(2024, 1, 1)
+    dates = [base + timedelta(days=i) for i in range(n)]
+    y = 100.0 + 0.5 * np.arange(n) + rng.normal(0, 1, n)
+    # Add treatment effect in post-period
+    y[n_pre:] += 10.0
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * n,
+            "ds": dates,
+            "y": y.tolist(),
+        }
+    )
+
+
+@pytest.fixture()
+def intervention_date() -> date:
+    return date(2024, 1, 1) + timedelta(days=60)
+
+
+@pytest.fixture()
+def sc_panel_df() -> pl.DataFrame:
+    """Panel with one treated unit and three donor units."""
+    rng = np.random.default_rng(42)
+    n_pre, n_post = 50, 15
+    n = n_pre + n_post
+    base = date(2024, 1, 1)
+    dates = [base + timedelta(days=i) for i in range(n)]
+
+    # Shared trend
+    trend = 50.0 + 0.3 * np.arange(n)
+
+    rows: list[dict] = []
+    # Treated unit: follows trend + treatment effect after intervention
+    treated_y = trend + rng.normal(0, 0.5, n)
+    treated_y[n_pre:] += 8.0
+    for i in range(n):
+        rows.append({"unique_id": "treated", "ds": dates[i], "y": float(treated_y[i])})
+
+    # Donor units: follow trend with slight variations
+    for donor_name, offset in [("D1", 2.0), ("D2", -1.0), ("D3", 0.5)]:
+        donor_y = trend + offset + rng.normal(0, 0.5, n)
+        for i in range(n):
+            rows.append({"unique_id": donor_name, "ds": dates[i], "y": float(donor_y[i])})
+
+    return pl.DataFrame(rows)
+
+
+@pytest.fixture()
+def sc_intervention_date() -> date:
+    return date(2024, 1, 1) + timedelta(days=50)

--- a/tests/causal/test_causal_impact.py
+++ b/tests/causal/test_causal_impact.py
@@ -175,6 +175,22 @@ class TestCausalImpactPlacebo:
         assert "total_effect" in placebo_result.columns
         assert len(placebo_result) == 1
 
+    def test_placebo_effect_near_zero(self, causal_df, intervention_date):
+        """Placebo effect should be small since there is no treatment before intervention."""
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        placebo_date = date(2024, 1, 1) + timedelta(days=30)
+        placebo_result = ci.placebo_test(causal_df, placebo_date=placebo_date)
+        # Placebo total effect should be much smaller than actual effect
+        r = ci.results()["A"]
+        placebo_effect = abs(placebo_result["total_effect"][0])
+        assert placebo_effect < abs(r.total_effect)
+
+    def test_placebo_before_fit_raises(self):
+        ci = CausalImpact()
+        with pytest.raises(RuntimeError, match="fit"):
+            ci.placebo_test(pl.DataFrame(), placebo_date=date(2024, 1, 15))
+
 
 class TestCausalImpactMultiGroup:
     def test_multi_group(self, intervention_date):
@@ -222,3 +238,12 @@ class TestCausalImpactCoverage:
         width_90 = r90.counterfactual_upper - r90.counterfactual_lower
         width_99 = r99.counterfactual_upper - r99.counterfactual_lower
         assert np.all(width_99 >= width_90 - 1e-10)
+
+
+class TestCausalImpactLevelTrend:
+    def test_level_trend(self, causal_df, intervention_date):
+        ci = CausalImpact(trend="level")
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        assert r.total_effect > 0
+        assert len(r.point_effect) == 20

--- a/tests/causal/test_causal_impact.py
+++ b/tests/causal/test_causal_impact.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.causal.causal_impact import CausalImpact, CausalImpactResult, causal_impact
+
+
+class TestCausalImpactValidation:
+    def test_fit_before_results(self):
+        ci = CausalImpact()
+        with pytest.raises(RuntimeError, match="fit"):
+            ci.results()
+
+    def test_fit_before_summary(self):
+        ci = CausalImpact()
+        with pytest.raises(RuntimeError, match="fit"):
+            ci.summary()
+
+    def test_fit_before_to_frame(self):
+        ci = CausalImpact()
+        with pytest.raises(RuntimeError, match="fit"):
+            ci.to_frame()
+
+    def test_short_pre_period(self, intervention_date):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A", "A", "A", "A"],
+                "ds": [
+                    intervention_date - timedelta(days=2),
+                    intervention_date - timedelta(days=1),
+                    intervention_date,
+                    intervention_date + timedelta(days=1),
+                ],
+                "y": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+        ci = CausalImpact()
+        with pytest.raises(ValueError, match="pre-intervention"):
+            ci.fit(df, intervention_date=intervention_date)
+
+    def test_no_post_period(self):
+        base = date(2024, 1, 1)
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 10,
+                "ds": [base + timedelta(days=i) for i in range(10)],
+                "y": list(range(10)),
+            }
+        )
+        ci = CausalImpact()
+        with pytest.raises(ValueError, match="post-intervention"):
+            ci.fit(df, intervention_date=base + timedelta(days=100))
+
+
+class TestCausalImpactFit:
+    def test_basic_fit(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        result = ci.fit(causal_df, intervention_date=intervention_date)
+        assert result is ci
+        assert ci.is_fitted_
+
+    def test_results_dict(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        results = ci.results()
+        assert "A" in results
+        assert isinstance(results["A"], CausalImpactResult)
+
+    def test_effect_direction(self, causal_df, intervention_date):
+        """Treatment adds +10, so total_effect should be positive."""
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        assert r.total_effect > 0
+
+    def test_credible_interval_ordering(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        assert r.total_effect_lower <= r.total_effect
+        assert r.total_effect <= r.total_effect_upper
+        assert np.all(r.counterfactual_lower <= r.counterfactual)
+        assert np.all(r.counterfactual <= r.counterfactual_upper)
+
+    def test_effect_arrays_shape(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        n_post = 20
+        assert len(r.point_effect) == n_post
+        assert len(r.point_effect_lower) == n_post
+        assert len(r.point_effect_upper) == n_post
+        assert len(r.cumulative_effect) == n_post
+        assert len(r.observed_post) == n_post
+        assert len(r.counterfactual) == n_post
+
+    def test_pre_diagnostics(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        assert r.pre_mape >= 0.0
+        assert 0.0 <= r.pre_coverage <= 1.0
+
+    def test_cumulative_is_cumsum(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        r = ci.results()["A"]
+        np.testing.assert_allclose(r.cumulative_effect, np.cumsum(r.point_effect))
+
+
+class TestCausalImpactSummary:
+    def test_summary_columns(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        summary = ci.summary()
+        expected = {
+            "unique_id",
+            "total_effect",
+            "total_effect_lower",
+            "total_effect_upper",
+            "relative_effect",
+            "relative_effect_lower",
+            "relative_effect_upper",
+            "pre_mape",
+            "pre_coverage",
+        }
+        assert set(summary.columns) == expected
+
+    def test_summary_one_row(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        assert len(ci.summary()) == 1
+
+
+class TestCausalImpactToFrame:
+    def test_to_frame_columns(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        frame = ci.to_frame()
+        expected = {
+            "unique_id",
+            "step",
+            "observed",
+            "counterfactual",
+            "counterfactual_lower",
+            "counterfactual_upper",
+            "point_effect",
+            "point_effect_lower",
+            "point_effect_upper",
+            "cumulative_effect",
+            "cumulative_effect_lower",
+            "cumulative_effect_upper",
+        }
+        assert set(frame.columns) == expected
+
+    def test_to_frame_rows(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        frame = ci.to_frame()
+        assert len(frame) == 20
+        assert frame["step"].to_list() == list(range(1, 21))
+
+
+class TestCausalImpactPlacebo:
+    def test_placebo_test(self, causal_df, intervention_date):
+        ci = CausalImpact()
+        ci.fit(causal_df, intervention_date=intervention_date)
+        # Placebo at midpoint of pre-period
+        placebo_date = date(2024, 1, 1) + timedelta(days=30)
+        placebo_result = ci.placebo_test(causal_df, placebo_date=placebo_date)
+        assert "total_effect" in placebo_result.columns
+        assert len(placebo_result) == 1
+
+
+class TestCausalImpactMultiGroup:
+    def test_multi_group(self, intervention_date):
+        rng = np.random.default_rng(42)
+        n_pre, n_post = 60, 20
+        n = n_pre + n_post
+        base = date(2024, 1, 1)
+        dates = [base + timedelta(days=i) for i in range(n)]
+        rows = []
+        for uid in ["A", "B"]:
+            y = 100.0 + rng.normal(0, 1, n)
+            y[n_pre:] += 5.0
+            for i in range(n):
+                rows.append({"unique_id": uid, "ds": dates[i], "y": float(y[i])})
+        df = pl.DataFrame(rows)
+
+        ci = CausalImpact()
+        ci.fit(df, intervention_date=intervention_date)
+        results = ci.results()
+        assert "A" in results
+        assert "B" in results
+        assert len(ci.summary()) == 2
+
+
+class TestCausalImpactConvenience:
+    def test_convenience_function(self, causal_df, intervention_date):
+        results = causal_impact(causal_df, intervention_date=intervention_date)
+        assert "A" in results
+        r = results["A"]
+        assert isinstance(r, CausalImpactResult)
+        assert r.total_effect > 0
+
+
+class TestCausalImpactCoverage:
+    def test_wider_coverage(self, causal_df, intervention_date):
+        ci_90 = CausalImpact(coverage=0.9)
+        ci_90.fit(causal_df, intervention_date=intervention_date)
+        r90 = ci_90.results()["A"]
+
+        ci_99 = CausalImpact(coverage=0.99)
+        ci_99.fit(causal_df, intervention_date=intervention_date)
+        r99 = ci_99.results()["A"]
+
+        # 99% interval should be wider than 90%
+        width_90 = r90.counterfactual_upper - r90.counterfactual_lower
+        width_99 = r99.counterfactual_upper - r99.counterfactual_lower
+        assert np.all(width_99 >= width_90 - 1e-10)

--- a/tests/causal/test_synthetic_control.py
+++ b/tests/causal/test_synthetic_control.py
@@ -189,6 +189,27 @@ class TestSyntheticControlConvenience:
         assert result.total_effect > 0
 
 
+class TestSyntheticControlSingleDonor:
+    def test_single_donor(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(
+            sc_panel_df,
+            treated_id="treated",
+            intervention_date=sc_intervention_date,
+            donor_ids=["D1"],
+        )
+        r = sc.result
+        np.testing.assert_allclose(r.weights, [1.0])
+        assert len(r.donor_ids) == 1
+
+    def test_observed_post_on_result(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        assert len(r.observed_post) == 15
+        np.testing.assert_allclose(r.point_effect, r.observed_post - r.counterfactual[-15:])
+
+
 class TestSyntheticControlCoverage:
     def test_wider_coverage(self, sc_panel_df, sc_intervention_date):
         sc_90 = SyntheticControl(coverage=0.9)

--- a/tests/causal/test_synthetic_control.py
+++ b/tests/causal/test_synthetic_control.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.causal.synthetic_control import (
+    SyntheticControl,
+    SyntheticControlResult,
+    synthetic_control,
+)
+
+
+class TestSyntheticControlValidation:
+    def test_result_before_fit(self):
+        sc = SyntheticControl()
+        with pytest.raises(RuntimeError, match="fit"):
+            _ = sc.result
+
+    def test_to_frame_before_fit(self):
+        sc = SyntheticControl()
+        with pytest.raises(RuntimeError, match="fit"):
+            sc.to_frame()
+
+    def test_missing_treated_id(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        with pytest.raises(ValueError, match="not found"):
+            sc.fit(sc_panel_df, treated_id="missing", intervention_date=sc_intervention_date)
+
+    def test_no_donors(self, sc_intervention_date):
+        base = date(2024, 1, 1)
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 60,
+                "ds": [base + timedelta(days=i) for i in range(60)],
+                "y": list(range(60)),
+            }
+        )
+        sc = SyntheticControl()
+        with pytest.raises(ValueError, match="No donor"):
+            sc.fit(df, treated_id="A", intervention_date=sc_intervention_date)
+
+    def test_short_pre_period(self, sc_panel_df):
+        sc = SyntheticControl()
+        # Intervention at second observation
+        early_date = date(2024, 1, 2)
+        with pytest.raises(ValueError, match="Pre-intervention"):
+            sc.fit(sc_panel_df, treated_id="treated", intervention_date=early_date)
+
+    def test_no_post_period(self, sc_panel_df):
+        sc = SyntheticControl()
+        late_date = date(2025, 12, 31)
+        with pytest.raises(ValueError, match="post-intervention"):
+            sc.fit(sc_panel_df, treated_id="treated", intervention_date=late_date)
+
+
+class TestSyntheticControlFit:
+    def test_basic_fit(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        result = sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        assert result is sc
+        assert sc.is_fitted_
+
+    def test_result_type(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        assert isinstance(sc.result, SyntheticControlResult)
+
+    def test_weights_valid(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        assert np.all(r.weights >= 0)
+        np.testing.assert_allclose(np.sum(r.weights), 1.0, atol=1e-6)
+
+    def test_donor_ids(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        assert set(r.donor_ids) == {"D1", "D2", "D3"}
+
+    def test_effect_direction(self, sc_panel_df, sc_intervention_date):
+        """Treatment adds +8, so total_effect should be positive."""
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        assert sc.result.total_effect > 0
+
+    def test_effect_arrays_shape(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        n_post = 15
+        assert len(r.point_effect) == n_post
+        assert len(r.point_effect_lower) == n_post
+        assert len(r.point_effect_upper) == n_post
+
+    def test_counterfactual_full_length(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        n_total = 50 + 15  # pre + post
+        assert len(r.counterfactual) == n_total
+
+    def test_interval_ordering(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        r = sc.result
+        assert r.total_effect_lower <= r.total_effect
+        assert r.total_effect <= r.total_effect_upper
+
+    def test_pre_rmse(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        assert sc.result.pre_rmse >= 0.0
+
+    def test_specific_donors(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(
+            sc_panel_df,
+            treated_id="treated",
+            intervention_date=sc_intervention_date,
+            donor_ids=["D1", "D2"],
+        )
+        r = sc.result
+        assert set(r.donor_ids) == {"D1", "D2"}
+
+
+class TestSyntheticControlToFrame:
+    def test_to_frame_columns(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        frame = sc.to_frame()
+        expected = {
+            "step",
+            "observed",
+            "counterfactual",
+            "counterfactual_lower",
+            "counterfactual_upper",
+            "point_effect",
+            "point_effect_lower",
+            "point_effect_upper",
+        }
+        assert set(frame.columns) == expected
+
+    def test_to_frame_rows(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        frame = sc.to_frame()
+        assert len(frame) == 15
+        assert frame["step"].to_list() == list(range(1, 16))
+
+
+class TestSyntheticControlPlacebo:
+    def test_placebo_test(self, sc_panel_df, sc_intervention_date):
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        placebo = sc.placebo_test(sc_panel_df, intervention_date=sc_intervention_date)
+        assert "unit_id" in placebo.columns
+        assert "is_treated" in placebo.columns
+        assert "total_effect" in placebo.columns
+        assert "pre_rmse" in placebo.columns
+        # Should have treated + donors
+        assert len(placebo) >= 2
+        # Treated unit should be marked
+        treated_row = placebo.filter(pl.col("is_treated"))
+        assert len(treated_row) == 1
+
+    def test_placebo_treated_effect_largest(self, sc_panel_df, sc_intervention_date):
+        """The actual treated unit should have a larger effect than placebos."""
+        sc = SyntheticControl()
+        sc.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+        placebo = sc.placebo_test(sc_panel_df, intervention_date=sc_intervention_date)
+        treated_effect = placebo.filter(pl.col("is_treated"))["total_effect"][0]
+        placebo_effects = placebo.filter(~pl.col("is_treated"))["total_effect"]
+        # Treated effect should be larger than most placebos
+        assert treated_effect > placebo_effects.mean()
+
+
+class TestSyntheticControlConvenience:
+    def test_convenience_function(self, sc_panel_df, sc_intervention_date):
+        result = synthetic_control(
+            sc_panel_df,
+            treated_id="treated",
+            intervention_date=sc_intervention_date,
+        )
+        assert isinstance(result, SyntheticControlResult)
+        assert result.total_effect > 0
+
+
+class TestSyntheticControlCoverage:
+    def test_wider_coverage(self, sc_panel_df, sc_intervention_date):
+        sc_90 = SyntheticControl(coverage=0.9)
+        sc_90.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+
+        sc_99 = SyntheticControl(coverage=0.99)
+        sc_99.fit(sc_panel_df, treated_id="treated", intervention_date=sc_intervention_date)
+
+        width_90 = sc_90.result.counterfactual_upper - sc_90.result.counterfactual_lower
+        width_99 = sc_99.result.counterfactual_upper - sc_99.result.counterfactual_lower
+        # Post-period intervals should be wider for 99%
+        assert np.all(width_99[-15:] >= width_90[-15:] - 1e-10)


### PR DESCRIPTION
## Summary
- Add **CausalImpact** estimator using BSTS counterfactual model (Brodersen et al., 2015)
- Add **Synthetic Control** method with constrained least-squares weighting (Abadie et al., 2010)
- Both return `(point, lower, upper)` credible/prediction intervals from day one
- Built-in **placebo tests** for both methods
- Pre-period diagnostics (MAPE, coverage, RMSE) run by default
- scpi-style prediction intervals with horizon-growing uncertainty for synthetic control

### Design decisions (per #148 feedback)
- BSTS prior hyperparameters fully exposed — no hidden defaults that mislead on short series
- CausalImpact placebo test filters out post-intervention data to prevent contamination
- Synthetic Control placebo test runs SC on every donor unit and reports the empirical distribution
- Cumulative intervals documented as conservative approximation (sum of pointwise bounds)

### Files added
- `polars_ts/causal/__init__.py` — lazy imports
- `polars_ts/causal/causal_impact.py` — CausalImpact class + convenience function
- `polars_ts/causal/synthetic_control.py` — SyntheticControl class + convenience function
- `tests/causal/` — 47 tests covering validation, fit, effects, intervals, diagnostics, placebo, multi-group, coverage

Closes #153

## Test plan
- [x] 47 tests pass locally (`pytest tests/causal/ -v`)
- [x] Ruff lint + format clean
- [ ] CI passes on all platforms