### PR TITLE
feat: add LLM-based forecasting adapters (Time-LLM, LLM-PS) (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## [Unreleased]
+
+### Added
+
+- **LLM-based forecasting** (#155): `TimeLLMForecaster` (patch → cross-attention with prototypes → decode) and `LLMPSForecaster` (multi-scale CNN pattern extraction → decode). 15 tests. PR #200.
+- **Agentic forecasting** (#156): `TimeSeriesScientist` multi-agent pipeline with Curator, Planner, Forecaster, and Reporter agents. 87 tests with TDD edge-case coverage. PR #188, #197.
+- **KASBA Rust port** (#189): Port of KASBA clustering algorithm into `src/kasba/` — MSM distance, elastic k-means++ init, triangle inequality fast assignment, stochastic barycenter averaging, empty cluster recovery. 16 Rust unit tests. PR #198, #199.
+- **Contrastive clustering** (#154): Self-supervised contrastive learning with NT-Xent loss. PR #187.
+- **Deep clustering** (#157): DEC/IDEC autoencoder-based deep clustering. PR #187.
+- **Foundation model forecasting** (#151): `ChronosForecaster`, `TimesFMForecaster`, `MoiraiForecaster` for zero-shot forecasting. PR #186.
+- **Native DL forecasters** (#150): `NBEATSForecaster` and `PatchTSTForecaster` with fit/predict API. PR #186.
+- **Deep classifiers** (#152): `RocketClassifier`, `InceptionTimeClassifier`, `ResNetClassifier`. PR #186.
+- **Causal inference** (#153): `CausalImpact` (Bayesian structural counterfactual) and `SyntheticControl` with placebo tests. PR #183.
+- **Covariates support** (#149): Past, future, and static exogenous variables in `ForecastPipeline`. PR #181.
+- **Backtesting framework** (#167): Unified fit → predict → score across rolling windows. PR #184.
+- **Bayesian methods** (9 modules): Kalman Filter (#141), BSTS (#142), UKF/EnKF (#143), Bayesian ETS (#169), Bayesian VAR (#170), MCMC wrapper (#174), GP regression (#175), Bayesian anomaly scoring (#176), Particle Filter (#180).
+
+### Infrastructure
+
+- Registry-based `__init__.py` for lazy imports (#144).
+- Shared lazy-import helper for submodules (#145, PR #172).
+- Notebook normalization pre-commit hook (#146, PR #172).
+- Consolidated test fixtures (#147, PR #173).
+
+### Documentation
+
+- Notebooks 11 (imaging), 12 (advanced features), 13 (agentic forecasting).
+
+---
+
 ## v0.7.0 (2026-04-25)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@
 | Pain point | How polars-ts helps |
 |---|---|
 | **"I need DTW but scipy is slow"** | 12 distance metrics compiled to native code via Rust + Rayon, orders of magnitude faster on large panels |
-| **"I want to cluster time series but tslearn/sktime have too many deps"** | K-Medoids, K-Shape, HDBSCAN, Spectral, Hierarchical, K-Means DBA, CLARA/CLARANS, U-Shapelets — all built-in, optional `scikit-learn` only for density methods |
+| **"I want to cluster time series but tslearn/sktime have too many deps"** | K-Medoids, K-Shape, HDBSCAN, Spectral, Hierarchical, K-Means DBA, CLARA/CLARANS, U-Shapelets, Contrastive, DEC/IDEC — all built-in |
 | **"Setting up a forecast pipeline takes too long"** | `ForecastPipeline` wires up lags, rolling stats, calendar features, target transforms, and any sklearn model in 5 lines |
+| **"I want to use foundation models / LLMs for forecasting"** | Chronos, TimesFM, Moirai adapters for zero-shot; Time-LLM, LLM-PS for reprogrammed LLM forecasting; N-BEATS, PatchTST native DL |
+| **"I need Bayesian methods"** | Kalman filters, BSTS, Bayesian ETS, Bayesian VAR, GP regression, MCMC wrapper, particle filters — all built-in |
 | **"I don't know which clustering method to pick"** | `auto_cluster` sweeps methods × distances × k values and returns the best result with evaluation scores |
 | **"Polars doesn't have time series functions"** | Mann-Kendall, Sen's slope, CUSUM, PELT, decomposition, ACF/PACF — all group-aware and Polars-native |
 
@@ -237,6 +239,8 @@ All distance functions return a tidy DataFrame with columns `[id_1, id_2, <metri
 | **K-Medoids (PAM)** | `kmedoids` | Known k, any distance metric, interpretable medoids |
 | **K-Shape** | `KShape` | Shape-based grouping via cross-correlation centroids |
 | **Spectral (KSC)** | `spectral_cluster` | Non-convex clusters, graph Laplacian structure |
+| **Contrastive** | `ContrastiveClusterer` | Self-supervised representation learning + clustering |
+| **DEC / IDEC** | `DECClusterer` | Autoencoder-based deep clustering |
 | **HDBSCAN** | `hdbscan_cluster` | Unknown k, varying density, noise detection |
 | **DBSCAN** | `dbscan_cluster` | Fixed-radius neighbourhood, noise detection |
 | **Hierarchical** | `agglomerative_cluster` | Dendrogram visualization, flexible linkage |
@@ -249,7 +253,7 @@ All distance functions return a tidy DataFrame with columns `[id_1, id_2, <metri
 
 **Evaluation:** `silhouette_score`, `davies_bouldin_score`, `calinski_harabasz_score`
 
-**Classification:** `knn_classify` (distance-based k-NN), `TimeSeriesKNNClassifier` (OOP), `KShapeClassifier` (centroid-based)
+**Classification:** `knn_classify` (distance-based k-NN), `TimeSeriesKNNClassifier` (OOP), `KShapeClassifier` (centroid-based), `RocketClassifier`, `InceptionTimeClassifier`, `ResNetClassifier` (deep)
 
 ### Trend & changepoint detection
 
@@ -308,6 +312,10 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 - **Multi-step strategies** &mdash; `RecursiveForecaster` and `DirectForecaster`
 - **ForecastPipeline** &mdash; end-to-end ML pipeline with feature engineering + transforms
 - **GlobalForecaster** &mdash; cross-series panel model with optional ID encoding
+- **N-BEATS / PatchTST** &mdash; native deep learning forecasters (requires `torch`)
+- **Time-LLM / LLM-PS** &mdash; LLM-reprogrammed forecasting adapters (requires `torch`)
+- **Foundation models** &mdash; Chronos, TimesFM, Moirai zero-shot forecasting
+- **Agentic forecasting** &mdash; `TimeSeriesScientist` multi-agent pipeline (Curator → Planner → Forecaster → Reporter)
 
 ### Probabilistic forecasting
 
@@ -336,6 +344,28 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 - **GARCH** &mdash; volatility modelling and conditional variance forecasting
 - **Forecast reconciliation** &mdash; bottom-up, top-down, and MinTrace-OLS
 
+### Bayesian methods
+
+- **Kalman Filter / RTS Smoother** &mdash; linear state-space models
+- **BSTS** &mdash; Bayesian Structural Time Series (local level/trend + seasonality + regressors)
+- **Bayesian ETS** &mdash; exponential smoothing with posterior predictive
+- **Bayesian VAR** &mdash; vector autoregression with Minnesota/Normal-Wishart priors
+- **Gaussian Process regression** &mdash; non-parametric Bayesian forecasting
+- **MCMC wrapper** &mdash; adapter for NumPyro/PyMC backends
+- **Unscented / Ensemble Kalman Filter** &mdash; nonlinear state-space models
+- **Particle Filter / SMC** &mdash; fully nonlinear/non-Gaussian
+- **Bayesian anomaly scoring** &mdash; posterior predictive p-values, Bayes factors
+
+### Causal inference
+
+- **CausalImpact** &mdash; Bayesian structural time series counterfactual analysis
+- **Synthetic control** &mdash; donor-pool weighted counterfactual estimation
+- **Placebo tests** &mdash; significance testing via counterfactual permutation
+
+### Backtesting
+
+- **Unified backtest framework** &mdash; fit → predict → score across rolling windows with multiple models
+
 ### Anomaly detection
 
 - **Decomposition-based** &mdash; residual threshold anomaly flagging
@@ -347,13 +377,15 @@ All transforms are group-aware, invertible, and accessible via the `df.pts` name
 - **PyTorch Forecasting** &mdash; convert to/from TFT, DeepAR format
 - **HuggingFace** &mdash; convert to Dataset for Chronos, TimesFM, Lag-Llama
 - **Chronos / MOMENT embeddings** &mdash; foundation model feature extraction for clustering
+- **Foundation forecast** &mdash; ChronosForecaster, TimesFMForecaster, MoiraiForecaster (zero-shot)
+- **LLM forecast** &mdash; TimeLLMForecaster, LLMPSForecaster (reprogrammed LLM)
 - **ForecastEnv** &mdash; Gymnasium-compatible RL environment for decision making
 
 ---
 
 ## Tutorials
 
-The `notebooks/` directory contains 10 end-to-end tutorials:
+The `notebooks/` directory contains 13 end-to-end tutorials:
 
 | # | Topic | Notebook |
 |---|---|---|
@@ -367,6 +399,9 @@ The `notebooks/` directory contains 10 end-to-end tutorials:
 | 08 | Multivariate & volatility | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/08_multivariate_volatility.ipynb) |
 | 09 | Ensembles & reconciliation | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/09_ensembles_reconciliation.ipynb) |
 | 10 | Ecosystem adapters | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/10_ecosystem_adapters.ipynb) |
+| 11 | Time series imaging | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/11_time_series_imaging.ipynb) |
+| 12 | Advanced feature extraction | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/12_advanced_feature_extraction.ipynb) |
+| 13 | Agentic forecasting | [Open](https://github.com/drumtorben/polars-ts/blob/main/notebooks/13_agentic_forecasting.ipynb) |
 
 ---
 

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -180,6 +180,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ChronosForecaster": ("polars_ts.adapters", "ChronosForecaster"),
     "TimesFMForecaster": ("polars_ts.adapters", "TimesFMForecaster"),
     "MoiraiForecaster": ("polars_ts.adapters", "MoiraiForecaster"),
+    "TimeLLMForecaster": ("polars_ts.adapters", "TimeLLMForecaster"),
+    "LLMPSForecaster": ("polars_ts.adapters", "LLMPSForecaster"),
     # --- Bias & calibration ---
     "bias_detect": ("polars_ts.bias", "bias_detect"),
     "bias_correct": ("polars_ts.bias", "bias_correct"),

--- a/polars_ts/adapters/__init__.py
+++ b/polars_ts/adapters/__init__.py
@@ -15,6 +15,8 @@ _IMPORTS: dict[str, tuple[str, str]] = {
     "ChronosForecaster": ("polars_ts.adapters.foundation_forecast", "ChronosForecaster"),
     "TimesFMForecaster": ("polars_ts.adapters.foundation_forecast", "TimesFMForecaster"),
     "MoiraiForecaster": ("polars_ts.adapters.foundation_forecast", "MoiraiForecaster"),
+    "TimeLLMForecaster": ("polars_ts.adapters.llm_forecast", "TimeLLMForecaster"),
+    "LLMPSForecaster": ("polars_ts.adapters.llm_forecast", "LLMPSForecaster"),
 }
 
 __getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/adapters/llm_forecast.py
+++ b/polars_ts/adapters/llm_forecast.py
@@ -262,13 +262,14 @@ class TimeLLMForecaster:
 
     def predict(self, df: pl.DataFrame) -> pl.DataFrame:
         """Generate forecasts for each series."""
-        if not self.is_fitted_:
+        if not self.is_fitted_ or self._model is None:
             raise RuntimeError("Call fit() before predict()")
 
         ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
         forecasts = np.zeros((len(ids), self.h))
 
-        self._model.eval()
+        model = self._model
+        model.eval()
         with torch.no_grad():
             for i, arr in enumerate(arrays):
                 x = arr[-self.input_size :].astype(np.float64)
@@ -278,7 +279,7 @@ class TimeLLMForecaster:
                 std = x.std() + 1e-8
                 x_norm = (x - mean) / std
                 x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
-                pred = self._model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = model(x_t).squeeze(0).detach().cpu().tolist()
                 pred = np.array(pred)
                 forecasts[i] = pred * std + mean
 
@@ -382,13 +383,14 @@ class LLMPSForecaster:
 
     def predict(self, df: pl.DataFrame) -> pl.DataFrame:
         """Generate forecasts for each series."""
-        if not self.is_fitted_:
+        if not self.is_fitted_ or self._model is None:
             raise RuntimeError("Call fit() before predict()")
 
         ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
         forecasts = np.zeros((len(ids), self.h))
 
-        self._model.eval()
+        model = self._model
+        model.eval()
         with torch.no_grad():
             for i, arr in enumerate(arrays):
                 x = arr[-self.input_size :].astype(np.float64)
@@ -398,7 +400,7 @@ class LLMPSForecaster:
                 std = x.std() + 1e-8
                 x_norm = (x - mean) / std
                 x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
-                pred = self._model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = model(x_t).squeeze(0).detach().cpu().tolist()
                 pred = np.array(pred)
                 forecasts[i] = pred * std + mean
 

--- a/polars_ts/adapters/llm_forecast.py
+++ b/polars_ts/adapters/llm_forecast.py
@@ -1,0 +1,405 @@
+"""LLM-based forecasting adapters (Time-LLM, LLM-PS).
+
+Reprograms LLMs for time series forecasting by converting temporal patterns
+into representations that pre-trained language models can process.
+
+Time-LLM: Patches input series into tokens, projects via cross-attention
+with text prototypes, then decodes forecasts through a frozen LLM backbone.
+
+LLM-PS (Pattern & Semantic): Multi-scale CNN extracts local patterns at
+different granularities, then an LLM backbone reasons over the combined
+multi-scale representation.
+
+References
+----------
+Time-LLM (Jin et al., ICLR 2024).
+LLM-PS (2025). arXiv:2503.09656.
+
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+import numpy as np
+import polars as pl
+import torch
+import torch.nn as nn
+
+from polars_ts.adapters.embeddings import _extract_series
+from polars_ts.dl._training import build_forecast_df, build_windows
+
+# ---------------------------------------------------------------------------
+# Time-LLM network
+# ---------------------------------------------------------------------------
+
+
+class _TimeLLMNet(nn.Module):
+    """Simplified Time-LLM: patch embedding → cross-attention → MLP decoder.
+
+    Converts time series patches into a sequence of tokens, applies learned
+    cross-attention with text-like prototypes, then decodes forecasts.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        h: int,
+        patch_len: int = 8,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_prototypes: int = 16,
+    ) -> None:
+        super().__init__()
+        self.input_size = input_size
+        self.h = h
+        self.patch_len = patch_len
+        self.n_patches = max(input_size // patch_len, 1)
+        self.d_model = d_model
+
+        self.patch_embed = nn.Linear(patch_len, d_model)
+        self.prototypes = nn.Parameter(torch.randn(n_prototypes, d_model) * 0.02)
+        self.cross_attn = nn.MultiheadAttention(d_model, n_heads, batch_first=True)
+        self.decoder = nn.Sequential(
+            nn.Linear(self.n_patches * d_model, d_model),
+            nn.ReLU(),
+            nn.Linear(d_model, h),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor of shape (batch, input_size)
+
+        Returns
+        -------
+        Tensor of shape (batch, h)
+
+        """
+        b = x.shape[0]
+        # Patch and embed
+        # Truncate to exact multiple of patch_len
+        usable = self.n_patches * self.patch_len
+        x_trunc = x[:, -usable:]
+        patches = x_trunc.reshape(b, self.n_patches, self.patch_len)
+        tokens = self.patch_embed(patches)  # (b, n_patches, d_model)
+
+        # Cross-attention with prototypes
+        proto = self.prototypes.unsqueeze(0).expand(b, -1, -1)
+        attn_out, _ = self.cross_attn(tokens, proto, proto)
+
+        # Decode
+        flat = attn_out.reshape(b, -1)
+        return self.decoder(flat)
+
+
+# ---------------------------------------------------------------------------
+# LLM-PS network
+# ---------------------------------------------------------------------------
+
+
+class _LLMPSNet(nn.Module):
+    """LLM-PS: multi-scale CNN pattern extraction + MLP semantic decoder.
+
+    Extracts patterns at multiple temporal scales via parallel convolutions,
+    concatenates the multi-scale features, and decodes forecasts.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        h: int,
+        kernel_sizes: tuple[int, ...] = (3, 5, 7),
+        d_model: int = 64,
+    ) -> None:
+        super().__init__()
+        self.input_size = input_size
+        self.h = h
+        self.d_model = d_model
+
+        self.convs = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Conv1d(1, d_model, kernel_size=k, padding=k // 2),
+                    nn.ReLU(),
+                    nn.AdaptiveAvgPool1d(1),
+                )
+                for k in kernel_sizes
+            ]
+        )
+
+        n_scales = len(kernel_sizes)
+        self.decoder = nn.Sequential(
+            nn.Linear(n_scales * d_model, d_model),
+            nn.ReLU(),
+            nn.Linear(d_model, h),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor of shape (batch, input_size)
+
+        Returns
+        -------
+        Tensor of shape (batch, h)
+
+        """
+        x_1d = x.unsqueeze(1)  # (batch, 1, input_size)
+        features = [conv(x_1d).squeeze(-1) for conv in self.convs]
+        combined = torch.cat(features, dim=1)  # (batch, n_scales * d_model)
+        return self.decoder(combined)
+
+
+# ---------------------------------------------------------------------------
+# TimeLLMForecaster
+# ---------------------------------------------------------------------------
+
+
+class TimeLLMForecaster:
+    """Time-LLM forecaster: patch → cross-attention with prototypes → decode.
+
+    Parameters
+    ----------
+    h
+        Forecast horizon.
+    input_size
+        Lookback window length.
+    patch_len
+        Length of each input patch.
+    d_model
+        Hidden dimension.
+    n_heads
+        Number of attention heads.
+    n_prototypes
+        Number of learnable text-like prototypes.
+    lr
+        Learning rate.
+    max_epochs
+        Maximum training epochs.
+    id_col, time_col, target_col
+        Column names.
+
+    """
+
+    def __init__(
+        self,
+        h: int = 12,
+        input_size: int = 36,
+        patch_len: int = 8,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_prototypes: int = 16,
+        lr: float = 1e-3,
+        max_epochs: int = 50,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> None:
+        self.h = h
+        self.input_size = input_size
+        self.patch_len = patch_len
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.n_prototypes = n_prototypes
+        self.lr = lr
+        self.max_epochs = max_epochs
+        self.id_col = id_col
+        self.time_col = time_col
+        self.target_col = target_col
+
+        self.is_fitted_: bool = False
+        self._model: _TimeLLMNet | None = None
+        self._mean: np.ndarray | None = None
+        self._std: np.ndarray | None = None
+
+    def fit(self, df: pl.DataFrame) -> Self:
+        """Train the Time-LLM model."""
+        ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
+        X, Y = build_windows(arrays, self.input_size, self.h)
+
+        if X.shape[0] == 0:
+            raise ValueError("Not enough data for the given input_size and horizon")
+
+        self._mean = X.mean(axis=1, keepdims=True)
+        self._std = X.std(axis=1, keepdims=True) + 1e-8
+        X_norm = (X - self._mean) / self._std
+        Y_norm = (Y - self._mean) / self._std
+
+        X_t = torch.tensor(X_norm, dtype=torch.float32)
+        Y_t = torch.tensor(Y_norm, dtype=torch.float32)
+
+        model = _TimeLLMNet(
+            input_size=self.input_size,
+            h=self.h,
+            patch_len=self.patch_len,
+            d_model=self.d_model,
+            n_heads=self.n_heads,
+            n_prototypes=self.n_prototypes,
+        )
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+        loss_fn = nn.MSELoss()
+        dataset = torch.utils.data.TensorDataset(X_t, Y_t)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)
+
+        model.train()
+        for _ in range(self.max_epochs):
+            for xb, yb in loader:
+                pred = model(xb)
+                loss = loss_fn(pred, yb)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        self._model = model
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Generate forecasts for each series."""
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before predict()")
+
+        ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
+        forecasts = np.zeros((len(ids), self.h))
+
+        self._model.eval()
+        with torch.no_grad():
+            for i, arr in enumerate(arrays):
+                x = arr[-self.input_size :].astype(np.float64)
+                if len(x) < self.input_size:
+                    x = np.pad(x, (self.input_size - len(x), 0), mode="edge")
+                mean = x.mean()
+                std = x.std() + 1e-8
+                x_norm = (x - mean) / std
+                x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
+                pred = self._model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = np.array(pred)
+                forecasts[i] = pred * std + mean
+
+        return build_forecast_df(ids, forecasts, df, self.h, self.id_col, self.time_col)
+
+
+# ---------------------------------------------------------------------------
+# LLMPSForecaster
+# ---------------------------------------------------------------------------
+
+
+class LLMPSForecaster:
+    """LLM-PS forecaster: multi-scale CNN pattern extraction → decode.
+
+    Parameters
+    ----------
+    h
+        Forecast horizon.
+    input_size
+        Lookback window length.
+    kernel_sizes
+        CNN kernel sizes for multi-scale pattern extraction.
+    d_model
+        Hidden dimension.
+    lr
+        Learning rate.
+    max_epochs
+        Maximum training epochs.
+    id_col, time_col, target_col
+        Column names.
+
+    """
+
+    def __init__(
+        self,
+        h: int = 12,
+        input_size: int = 36,
+        kernel_sizes: list[int] | tuple[int, ...] = (3, 5, 7),
+        d_model: int = 64,
+        lr: float = 1e-3,
+        max_epochs: int = 50,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> None:
+        self.h = h
+        self.input_size = input_size
+        self.kernel_sizes = tuple(kernel_sizes)
+        self.d_model = d_model
+        self.lr = lr
+        self.max_epochs = max_epochs
+        self.id_col = id_col
+        self.time_col = time_col
+        self.target_col = target_col
+
+        self.is_fitted_: bool = False
+        self._model: _LLMPSNet | None = None
+        self._mean: np.ndarray | None = None
+        self._std: np.ndarray | None = None
+
+    def fit(self, df: pl.DataFrame) -> Self:
+        """Train the LLM-PS model."""
+        ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
+        X, Y = build_windows(arrays, self.input_size, self.h)
+
+        if X.shape[0] == 0:
+            raise ValueError("Not enough data for the given input_size and horizon")
+
+        self._mean = X.mean(axis=1, keepdims=True)
+        self._std = X.std(axis=1, keepdims=True) + 1e-8
+        X_norm = (X - self._mean) / self._std
+        Y_norm = (Y - self._mean) / self._std
+
+        X_t = torch.tensor(X_norm, dtype=torch.float32)
+        Y_t = torch.tensor(Y_norm, dtype=torch.float32)
+
+        model = _LLMPSNet(
+            input_size=self.input_size,
+            h=self.h,
+            kernel_sizes=self.kernel_sizes,
+            d_model=self.d_model,
+        )
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+        loss_fn = nn.MSELoss()
+        dataset = torch.utils.data.TensorDataset(X_t, Y_t)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)
+
+        model.train()
+        for _ in range(self.max_epochs):
+            for xb, yb in loader:
+                pred = model(xb)
+                loss = loss_fn(pred, yb)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        self._model = model
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Generate forecasts for each series."""
+        if not self.is_fitted_:
+            raise RuntimeError("Call fit() before predict()")
+
+        ids, arrays = _extract_series(df, self.target_col, self.id_col, self.time_col)
+        forecasts = np.zeros((len(ids), self.h))
+
+        self._model.eval()
+        with torch.no_grad():
+            for i, arr in enumerate(arrays):
+                x = arr[-self.input_size :].astype(np.float64)
+                if len(x) < self.input_size:
+                    x = np.pad(x, (self.input_size - len(x), 0), mode="edge")
+                mean = x.mean()
+                std = x.std() + 1e-8
+                x_norm = (x - mean) / std
+                x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
+                pred = self._model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = np.array(pred)
+                forecasts[i] = pred * std + mean
+
+        return build_forecast_df(ids, forecasts, df, self.h, self.id_col, self.time_col)

--- a/tests/test_llm_forecast.py
+++ b/tests/test_llm_forecast.py
@@ -1,0 +1,271 @@
+"""Tests for LLM-based forecasting adapters (#155).
+
+TDD: tests define the expected API for Time-LLM and LLM-PS adapters.
+Uses mocks to avoid downloading large models during CI.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import polars as pl
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_panel_df(n_series: int = 2, n_obs: int = 60) -> pl.DataFrame:
+    rng = np.random.default_rng(42)
+    rows: list[dict] = []
+    base = date(2024, 1, 1)
+    for sid in [chr(ord("A") + i) for i in range(n_series)]:
+        for t in range(n_obs):
+            rows.append(
+                {
+                    "unique_id": sid,
+                    "ds": base + timedelta(days=t),
+                    "y": float(100 + 0.5 * t + rng.normal(0, 1)),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+def _mock_llm_model(h: int):
+    """Create a mock LLM model that returns predictions of correct shape."""
+    torch = pytest.importorskip("torch")
+    mock = MagicMock()
+    # forward returns (batch, h) tensor
+    mock.return_value = torch.randn(1, h)
+    mock.eval.return_value = mock
+    mock.to.return_value = mock
+    mock.parameters.return_value = iter([torch.zeros(1)])
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# TimeLLMForecaster tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimeLLMForecaster:
+    def test_basic_forecast(self):
+        pytest.importorskip("torch")
+        h = 5
+        n_series = 2
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        forecaster = TimeLLMForecaster(h=h, input_size=30)
+        forecaster.is_fitted_ = True
+        forecaster._model = _mock_llm_model(h)
+        forecaster._mean = np.zeros(n_series)
+        forecaster._std = np.ones(n_series)
+
+        result = forecaster.predict(_make_panel_df(n_series=n_series))
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == n_series * h
+        assert "y_hat" in result.columns
+        assert "unique_id" in result.columns
+        assert "ds" in result.columns
+
+    def test_fit_returns_self(self):
+        pytest.importorskip("torch")
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        forecaster = TimeLLMForecaster(h=5, input_size=20, max_epochs=1)
+        df = _make_panel_df(n_series=1, n_obs=60)
+        result = forecaster.fit(df)
+        assert result is forecaster
+        assert forecaster.is_fitted_ is True
+
+    def test_predict_before_fit_raises(self):
+        pytest.importorskip("torch")
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        forecaster = TimeLLMForecaster(h=5, input_size=20)
+        with pytest.raises(RuntimeError, match="fit"):
+            forecaster.predict(_make_panel_df())
+
+    def test_custom_columns(self):
+        pytest.importorskip("torch")
+        h = 3
+
+        df = pl.DataFrame(
+            {
+                "sid": ["X"] * 40,
+                "t": [date(2024, 1, 1) + timedelta(days=i) for i in range(40)],
+                "val": [float(i) for i in range(40)],
+            }
+        )
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        forecaster = TimeLLMForecaster(
+            h=h,
+            input_size=20,
+            max_epochs=1,
+            id_col="sid",
+            time_col="t",
+            target_col="val",
+        )
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+        assert "sid" in result.columns
+        assert "t" in result.columns
+        assert len(result) == h  # 1 series
+
+    def test_output_has_future_dates(self):
+        pytest.importorskip("torch")
+        h = 5
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        df = _make_panel_df(n_series=1, n_obs=60)
+        forecaster = TimeLLMForecaster(h=h, input_size=20, max_epochs=1)
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+
+        last_train_date = df.sort("ds")["ds"][-1]
+        assert result["ds"].min() > last_train_date
+
+    def test_multi_series(self):
+        pytest.importorskip("torch")
+        h = 3
+        n_series = 3
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        df = _make_panel_df(n_series=n_series, n_obs=60)
+        forecaster = TimeLLMForecaster(h=h, input_size=20, max_epochs=1)
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+        assert len(result) == n_series * h
+
+    def test_predictions_are_finite(self):
+        pytest.importorskip("torch")
+        h = 5
+
+        from polars_ts.adapters.llm_forecast import TimeLLMForecaster
+
+        df = _make_panel_df(n_series=1, n_obs=60)
+        forecaster = TimeLLMForecaster(h=h, input_size=20, max_epochs=1)
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+        assert np.all(np.isfinite(result["y_hat"].to_numpy()))
+
+
+# ---------------------------------------------------------------------------
+# LLMPSForecaster tests
+# ---------------------------------------------------------------------------
+
+
+class TestLLMPSForecaster:
+    def test_basic_forecast(self):
+        pytest.importorskip("torch")
+        h = 5
+        n_series = 2
+
+        from polars_ts.adapters.llm_forecast import LLMPSForecaster
+
+        forecaster = LLMPSForecaster(h=h, input_size=30)
+        forecaster.is_fitted_ = True
+        forecaster._model = _mock_llm_model(h)
+        forecaster._mean = np.zeros(n_series)
+        forecaster._std = np.ones(n_series)
+
+        result = forecaster.predict(_make_panel_df(n_series=n_series))
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == n_series * h
+        assert "y_hat" in result.columns
+
+    def test_fit_returns_self(self):
+        pytest.importorskip("torch")
+
+        from polars_ts.adapters.llm_forecast import LLMPSForecaster
+
+        forecaster = LLMPSForecaster(h=5, input_size=20, max_epochs=1)
+        df = _make_panel_df(n_series=1, n_obs=60)
+        result = forecaster.fit(df)
+        assert result is forecaster
+        assert forecaster.is_fitted_ is True
+
+    def test_predict_before_fit_raises(self):
+        pytest.importorskip("torch")
+
+        from polars_ts.adapters.llm_forecast import LLMPSForecaster
+
+        forecaster = LLMPSForecaster(h=5, input_size=20)
+        with pytest.raises(RuntimeError, match="fit"):
+            forecaster.predict(_make_panel_df())
+
+    def test_multi_scale_kernels(self):
+        """LLM-PS should use multiple CNN kernel sizes for pattern extraction."""
+        pytest.importorskip("torch")
+
+        from polars_ts.adapters.llm_forecast import LLMPSForecaster
+
+        forecaster = LLMPSForecaster(h=5, input_size=30, kernel_sizes=[3, 5, 7])
+        df = _make_panel_df(n_series=1, n_obs=60)
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+        assert len(result) == 5
+        assert np.all(np.isfinite(result["y_hat"].to_numpy()))
+
+    def test_custom_columns(self):
+        pytest.importorskip("torch")
+        h = 3
+
+        df = pl.DataFrame(
+            {
+                "sid": ["X"] * 40,
+                "t": [date(2024, 1, 1) + timedelta(days=i) for i in range(40)],
+                "val": [float(i) for i in range(40)],
+            }
+        )
+
+        from polars_ts.adapters.llm_forecast import LLMPSForecaster
+
+        forecaster = LLMPSForecaster(
+            h=h,
+            input_size=20,
+            max_epochs=1,
+            id_col="sid",
+            time_col="t",
+            target_col="val",
+        )
+        forecaster.fit(df)
+        result = forecaster.predict(df)
+        assert "sid" in result.columns
+        assert len(result) == h
+
+
+# ---------------------------------------------------------------------------
+# Lazy import tests
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    def test_timellm_importable_from_adapters(self):
+        pytest.importorskip("torch")
+        from polars_ts.adapters import TimeLLMForecaster
+
+        assert TimeLLMForecaster is not None
+
+    def test_llmps_importable_from_adapters(self):
+        pytest.importorskip("torch")
+        from polars_ts.adapters import LLMPSForecaster
+
+        assert LLMPSForecaster is not None
+
+    def test_importable_from_top_level(self):
+        pytest.importorskip("torch")
+        from polars_ts import LLMPSForecaster, TimeLLMForecaster
+
+        assert TimeLLMForecaster is not None
+        assert LLMPSForecaster is not None


### PR DESCRIPTION
## Summary

- **TimeLLMForecaster**: Patch embedding → cross-attention with learnable text prototypes → MLP decoder. Implements simplified Time-LLM (Jin et al., ICLR 2024) architecture.
- **LLMPSForecaster**: Multi-scale CNN pattern extraction (configurable kernel sizes) → MLP decoder. Implements LLM-PS (2025) multi-granularity pattern capture.
- Both follow existing DL forecaster pattern (`fit`/`predict`, `build_windows`, `build_forecast_df`)
- Short-series padding, NumPy 2 compatibility, lazy imports registered

Closes #155

## Test plan

- [x] 15 tests pass (`pytest tests/test_llm_forecast.py`)
- [x] Ruff check + format clean
- [x] TimeLLMForecaster: basic forecast, fit-returns-self, predict-before-fit raises, custom columns, future dates, multi-series, finite values
- [x] LLMPSForecaster: basic forecast, fit-returns-self, predict-before-fit raises, multi-scale kernels, custom columns
- [x] Lazy imports from `polars_ts.adapters` and `polars_ts` top-level