### PR TITLE
feat: add multi-agent RL for portfolio optimization (#158)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -217,6 +217,13 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "PlannerAgent": ("polars_ts.agents", "PlannerAgent"),
     "ForecasterAgent": ("polars_ts.agents", "ForecasterAgent"),
     "ReporterAgent": ("polars_ts.agents", "ReporterAgent"),
+    # --- Multi-agent RL ---
+    "PortfolioEnv": ("polars_ts.marl", "PortfolioEnv"),
+    "MARLOrchestrator": ("polars_ts.marl", "MARLOrchestrator"),
+    "MARLResult": ("polars_ts.marl", "MARLResult"),
+    "RiskAgent": ("polars_ts.marl", "RiskAgent"),
+    "ReturnAgent": ("polars_ts.marl", "ReturnAgent"),
+    "AllocationAgent": ("polars_ts.marl", "AllocationAgent"),
 }
 
 

--- a/polars_ts/marl/__init__.py
+++ b/polars_ts/marl/__init__.py
@@ -1,0 +1,18 @@
+"""Multi-agent RL framework for portfolio optimization and sequential decisions.
+
+Provides specialized agents (risk, return, allocation) that collaborate
+to produce portfolio weights, evaluated in a PortfolioEnv.  Closes #158.
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "PortfolioEnv": ("polars_ts.marl.env", "PortfolioEnv"),
+    "RiskAgent": ("polars_ts.marl.agents", "RiskAgent"),
+    "ReturnAgent": ("polars_ts.marl.agents", "ReturnAgent"),
+    "AllocationAgent": ("polars_ts.marl.agents", "AllocationAgent"),
+    "MARLOrchestrator": ("polars_ts.marl.orchestrator", "MARLOrchestrator"),
+    "MARLResult": ("polars_ts.marl.orchestrator", "MARLResult"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/marl/agents.py
+++ b/polars_ts/marl/agents.py
@@ -1,0 +1,124 @@
+"""Specialized agents for multi-agent RL portfolio decisions."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class RiskAgent:
+    """Assesses per-asset risk from recent return history.
+
+    Uses rolling volatility (standard deviation of returns) as the risk metric.
+
+    Parameters
+    ----------
+    window_size
+        Number of recent periods to compute volatility over.
+
+    """
+
+    def __init__(self, window_size: int = 20) -> None:
+        self.window_size = window_size
+
+    def assess(self, returns: np.ndarray) -> np.ndarray:
+        """Return per-asset risk scores (higher = riskier).
+
+        Parameters
+        ----------
+        returns
+            Array of shape ``(n_steps, n_assets)``.
+
+        Returns
+        -------
+        np.ndarray
+            Risk scores of shape ``(n_assets,)``.
+
+        """
+        recent = returns[-self.window_size :]
+        return np.std(recent, axis=0)
+
+
+class ReturnAgent:
+    """Predicts expected per-asset returns from recent history.
+
+    Uses exponentially weighted moving average of returns.
+
+    Parameters
+    ----------
+    window_size
+        Number of recent periods to consider.
+    decay
+        Exponential decay factor (higher = more weight on recent data).
+
+    """
+
+    def __init__(self, window_size: int = 20, decay: float = 0.94) -> None:
+        self.window_size = window_size
+        self.decay = decay
+
+    def predict(self, returns: np.ndarray) -> np.ndarray:
+        """Return expected per-asset returns.
+
+        Parameters
+        ----------
+        returns
+            Array of shape ``(n_steps, n_assets)``.
+
+        Returns
+        -------
+        np.ndarray
+            Expected returns of shape ``(n_assets,)``.
+
+        """
+        recent = returns[-self.window_size :]
+        n = len(recent)
+        weights = np.array([self.decay ** (n - 1 - i) for i in range(n)])
+        weights /= weights.sum()
+        return weights @ recent
+
+
+class AllocationAgent:
+    """Produces portfolio weights from risk and return estimates.
+
+    Uses a risk-adjusted return score (return / risk) to allocate weights
+    proportionally.
+
+    Parameters
+    ----------
+    risk_aversion
+        Higher values penalize risk more.
+
+    """
+
+    def __init__(self, risk_aversion: float = 1.0) -> None:
+        self.risk_aversion = risk_aversion
+
+    def allocate(
+        self,
+        risk_scores: np.ndarray,
+        expected_returns: np.ndarray,
+        n_assets: int,  # noqa: ARG002
+    ) -> np.ndarray:
+        """Return normalized portfolio weights.
+
+        Parameters
+        ----------
+        risk_scores
+            Per-asset risk scores from ``RiskAgent``.
+        expected_returns
+            Per-asset expected returns from ``ReturnAgent``.
+        n_assets
+            Number of assets (must match array lengths).
+
+        Returns
+        -------
+        np.ndarray
+            Portfolio weights summing to 1, shape ``(n_assets,)``.
+
+        """
+        safe_risk = np.maximum(risk_scores, 1e-10)
+        scores = expected_returns / (safe_risk * self.risk_aversion)
+        # Shift to positive then normalize
+        shifted = scores - scores.min() + 1e-10
+        weights = shifted / shifted.sum()
+        return weights

--- a/polars_ts/marl/env.py
+++ b/polars_ts/marl/env.py
@@ -1,0 +1,123 @@
+"""Portfolio environment for multi-agent RL decision making."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+
+class PortfolioEnv:
+    """Gymnasium-like environment for portfolio allocation.
+
+    At each step, the agent observes recent returns for all assets and
+    produces portfolio weights. The reward is the portfolio return minus
+    transaction costs.
+
+    Parameters
+    ----------
+    returns
+        Array of shape ``(n_steps, n_assets)`` with per-period returns.
+    window_size
+        Number of recent return periods provided as the observation.
+    transaction_cost
+        Proportional cost applied to weight changes between steps.
+
+    """
+
+    def __init__(
+        self,
+        returns: np.ndarray,
+        window_size: int = 10,
+        transaction_cost: float = 0.0,
+    ) -> None:
+        self.returns = np.asarray(returns, dtype=np.float64)
+        self.window_size = window_size
+        self.transaction_cost = transaction_cost
+        self.n_assets = self.returns.shape[1]
+        self._step = 0
+        self._max_steps = len(self.returns) - window_size
+        self._prev_weights = np.ones(self.n_assets) / self.n_assets
+
+        if self._max_steps <= 0:
+            raise ValueError("returns must have more rows than window_size")
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: pl.DataFrame,
+        window_size: int = 10,
+        transaction_cost: float = 0.0,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> PortfolioEnv:
+        """Create environment from a polars panel DataFrame of prices.
+
+        Converts prices to log returns and pivots to wide format.
+        """
+        sorted_df = df.sort(id_col, time_col)
+        assets = sorted_df[id_col].unique(maintain_order=True).to_list()
+        returns_list = []
+        for asset in assets:
+            prices = sorted_df.filter(pl.col(id_col) == asset)[target_col].to_numpy().astype(np.float64)
+            if np.any(prices <= 0):
+                raise ValueError(f"Prices for {asset} contain zero or negative values — cannot compute log returns")
+            rets = np.diff(np.log(prices))
+            returns_list.append(rets)
+
+        min_len = min(len(r) for r in returns_list)
+        returns = np.column_stack([r[:min_len] for r in returns_list])
+        return cls(returns, window_size=window_size, transaction_cost=transaction_cost)
+
+    def reset(self) -> np.ndarray:
+        """Reset and return initial observation of shape ``(window_size, n_assets)``."""
+        self._step = 0
+        self._prev_weights = np.ones(self.n_assets) / self.n_assets
+        return self._get_obs()
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, dict[str, Any]]:
+        """Take one step with portfolio weights.
+
+        Parameters
+        ----------
+        action
+            Raw portfolio weights (will be normalized to sum to 1).
+
+        Returns
+        -------
+        tuple
+            ``(observation, reward, done, info)``
+
+        """
+        weights = np.abs(action)
+        w_sum = weights.sum()
+        if w_sum > 0:
+            weights = weights / w_sum
+        else:
+            weights = np.ones(self.n_assets) / self.n_assets
+
+        idx = self.window_size + self._step
+        period_returns = self.returns[idx]
+        portfolio_return = float(np.dot(weights, period_returns))
+
+        # Transaction cost from weight changes
+        turnover = float(np.sum(np.abs(weights - self._prev_weights)))
+        cost = self.transaction_cost * turnover
+        reward = portfolio_return - cost
+
+        self._prev_weights = weights.copy()
+        self._step += 1
+        done = self._step >= self._max_steps
+
+        obs = self._get_obs() if not done else np.zeros((self.window_size, self.n_assets))
+        info = {"portfolio_return": portfolio_return, "weights": weights.tolist(), "turnover": turnover}
+
+        return obs, reward, done, info
+
+    def _get_obs(self) -> np.ndarray:
+        """Build observation: recent returns window of shape ``(window_size, n_assets)``."""
+        start = self._step
+        end = start + self.window_size
+        return self.returns[start:end].copy()

--- a/polars_ts/marl/orchestrator.py
+++ b/polars_ts/marl/orchestrator.py
@@ -1,0 +1,136 @@
+"""MARLOrchestrator: chains risk, return, and allocation agents over a PortfolioEnv."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.marl.agents import AllocationAgent, ReturnAgent, RiskAgent
+from polars_ts.marl.env import PortfolioEnv
+
+
+@dataclass
+class MARLResult:
+    """Output of a MARLOrchestrator run."""
+
+    weights_history: np.ndarray
+    portfolio_returns: np.ndarray
+    sharpe_ratio: float
+    total_return: float
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+
+class MARLOrchestrator:
+    """Orchestrates specialized agents over a portfolio environment.
+
+    At each step:
+    1. RiskAgent assesses per-asset volatility.
+    2. ReturnAgent predicts expected returns.
+    3. AllocationAgent combines risk/return into portfolio weights.
+    4. PortfolioEnv evaluates the resulting allocation.
+
+    Parameters
+    ----------
+    window_size
+        Observation window for the environment and agents.
+    risk_aversion
+        Passed to ``AllocationAgent``.
+    transaction_cost
+        Proportional cost for weight changes.
+
+    """
+
+    def __init__(
+        self,
+        window_size: int = 10,
+        risk_aversion: float = 1.0,
+        transaction_cost: float = 0.0,
+    ) -> None:
+        self.window_size = window_size
+        self.risk_aversion = risk_aversion
+        self.transaction_cost = transaction_cost
+
+    def run(self, returns: np.ndarray) -> MARLResult:
+        """Run the multi-agent loop over a returns matrix.
+
+        Parameters
+        ----------
+        returns
+            Array of shape ``(n_steps, n_assets)``.
+
+        Returns
+        -------
+        MARLResult
+
+        """
+        env = PortfolioEnv(returns, window_size=self.window_size, transaction_cost=self.transaction_cost)
+        return self._run_loop(env, returns)
+
+    def run_from_dataframe(
+        self,
+        df: pl.DataFrame,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+        target_col: str = "y",
+    ) -> MARLResult:
+        """Run from a polars panel DataFrame of prices."""
+        env = PortfolioEnv.from_dataframe(
+            df,
+            window_size=self.window_size,
+            transaction_cost=self.transaction_cost,
+            id_col=id_col,
+            time_col=time_col,
+            target_col=target_col,
+        )
+        return self._run_loop(env, env.returns)
+
+    def _run_loop(self, env: PortfolioEnv, returns: np.ndarray) -> MARLResult:
+        risk_agent = RiskAgent(window_size=self.window_size)
+        return_agent = ReturnAgent(window_size=self.window_size)
+        alloc_agent = AllocationAgent(risk_aversion=self.risk_aversion)
+
+        history: list[dict[str, Any]] = []
+        weights_list: list[np.ndarray] = []
+        returns_list: list[float] = []
+
+        obs = env.reset()
+        done = False
+
+        while not done:
+            step_idx = env._step
+            # Agents observe the full history up to current step
+            hist_end = self.window_size + step_idx
+            hist_returns = returns[:hist_end]
+
+            risk_scores = risk_agent.assess(hist_returns)
+            history.append({"agent": "risk", "message": f"Risk scores: {risk_scores.tolist()}"})
+
+            expected_rets = return_agent.predict(hist_returns)
+            history.append({"agent": "return", "message": f"Expected returns: {expected_rets.tolist()}"})
+
+            weights = alloc_agent.allocate(risk_scores, expected_rets, env.n_assets)
+            history.append({"agent": "allocation", "message": f"Weights: {weights.tolist()}"})
+
+            obs, reward, done, info = env.step(weights)
+            weights_list.append(weights)
+            returns_list.append(info["portfolio_return"])
+
+        weights_history = np.array(weights_list)
+        portfolio_returns = np.array(returns_list)
+
+        # Compute metrics
+        mean_ret = portfolio_returns.mean()
+        std_ret = portfolio_returns.std() + 1e-10
+        sharpe_ratio = float(mean_ret / std_ret * np.sqrt(252))  # annualized
+        total_return = float(np.prod(1 + portfolio_returns) - 1)
+
+        return MARLResult(
+            weights_history=weights_history,
+            portfolio_returns=portfolio_returns,
+            sharpe_ratio=sharpe_ratio,
+            total_return=total_return,
+            history=history,
+        )

--- a/tests/test_marl.py
+++ b/tests/test_marl.py
@@ -1,0 +1,250 @@
+"""Tests for multi-agent RL framework (#158).
+
+TDD: tests define the expected API for PortfolioEnv, specialized agents,
+and the MARLOrchestrator before implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def price_panel() -> pl.DataFrame:
+    """Multi-asset daily price panel (3 assets, 100 days)."""
+    from datetime import date, timedelta
+
+    rng = np.random.default_rng(42)
+    n = 100
+    base = date(2024, 1, 1)
+    rows: list[dict] = []
+    for asset in ["AAPL", "GOOG", "MSFT"]:
+        prices = 100 + np.cumsum(rng.normal(0, 1, n))
+        for t in range(n):
+            rows.append({"unique_id": asset, "ds": base + timedelta(days=t), "y": float(prices[t])})
+    return pl.DataFrame(rows)
+
+
+@pytest.fixture
+def returns_matrix() -> np.ndarray:
+    """Create a returns matrix of shape (n_steps, n_assets)."""
+    rng = np.random.default_rng(42)
+    return rng.normal(0.001, 0.02, (100, 3))
+
+
+# ---------------------------------------------------------------------------
+# PortfolioEnv tests
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioEnv:
+    def test_creation(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10)
+        assert env._max_steps > 0
+
+    def test_reset_returns_observation(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10)
+        obs = env.reset()
+        assert isinstance(obs, np.ndarray)
+        # obs shape: (window_size, n_assets)
+        assert obs.shape == (10, 3)
+
+    def test_step_returns_tuple(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10)
+        env.reset()
+        # action is portfolio weights: (n_assets,)
+        action = np.array([0.4, 0.3, 0.3])
+        obs, reward, done, info = env.step(action)
+        assert isinstance(reward, float)
+        assert isinstance(done, bool)
+        assert "portfolio_return" in info
+        assert "weights" in info
+
+    def test_weights_normalized(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10)
+        env.reset()
+        action = np.array([2.0, 3.0, 5.0])  # not normalized
+        _, _, _, info = env.step(action)
+        assert abs(sum(info["weights"]) - 1.0) < 1e-10
+
+    def test_episode_terminates(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10)
+        env.reset()
+        action = np.array([1 / 3, 1 / 3, 1 / 3])
+        done = False
+        steps = 0
+        while not done:
+            _, _, done, _ = env.step(action)
+            steps += 1
+        assert steps == len(returns_matrix) - 10
+
+    def test_custom_transaction_cost(self, returns_matrix):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv(returns_matrix, window_size=10, transaction_cost=0.001)
+        env.reset()
+        action = np.array([0.5, 0.3, 0.2])
+        _, r1, _, _ = env.step(action)
+        # Change allocation → incur cost
+        action2 = np.array([0.2, 0.5, 0.3])
+        _, r2, _, _ = env.step(action2)
+        assert isinstance(r2, float)
+
+    def test_from_dataframe(self, price_panel):
+        from polars_ts.marl import PortfolioEnv
+
+        env = PortfolioEnv.from_dataframe(price_panel, window_size=10)
+        obs = env.reset()
+        assert obs.shape[1] == 3  # 3 assets
+
+
+# ---------------------------------------------------------------------------
+# Agent tests
+# ---------------------------------------------------------------------------
+
+
+class TestRiskAgent:
+    def test_assess_returns_risk_scores(self, returns_matrix):
+        from polars_ts.marl import RiskAgent
+
+        agent = RiskAgent(window_size=20)
+        scores = agent.assess(returns_matrix[:30])
+        assert isinstance(scores, np.ndarray)
+        assert len(scores) == returns_matrix.shape[1]
+        assert np.all(np.isfinite(scores))
+
+    def test_risk_higher_for_volatile_asset(self):
+        from polars_ts.marl import RiskAgent
+
+        rng = np.random.default_rng(42)
+        # Asset 0: low vol, Asset 1: high vol
+        returns = np.column_stack([rng.normal(0, 0.01, 50), rng.normal(0, 0.1, 50)])
+        agent = RiskAgent(window_size=20)
+        scores = agent.assess(returns)
+        assert scores[1] > scores[0]  # higher risk for volatile asset
+
+
+class TestReturnAgent:
+    def test_predict_returns_expected_returns(self, returns_matrix):
+        from polars_ts.marl import ReturnAgent
+
+        agent = ReturnAgent(window_size=20)
+        expected = agent.predict(returns_matrix[:30])
+        assert isinstance(expected, np.ndarray)
+        assert len(expected) == returns_matrix.shape[1]
+        assert np.all(np.isfinite(expected))
+
+
+class TestAllocationAgent:
+    def test_allocate_returns_weights(self, returns_matrix):
+        from polars_ts.marl import AllocationAgent
+
+        n_assets = returns_matrix.shape[1]
+        risk_scores = np.array([0.5, 0.3, 0.2])
+        expected_returns = np.array([0.01, 0.02, 0.015])
+
+        agent = AllocationAgent()
+        weights = agent.allocate(risk_scores, expected_returns, n_assets)
+        assert isinstance(weights, np.ndarray)
+        assert len(weights) == n_assets
+        assert abs(weights.sum() - 1.0) < 1e-10
+        assert np.all(weights >= 0)
+
+    def test_favors_high_return_low_risk(self):
+        from polars_ts.marl import AllocationAgent
+
+        agent = AllocationAgent()
+        risk = np.array([0.1, 0.5, 0.3])
+        ret = np.array([0.05, 0.01, 0.03])
+        weights = agent.allocate(risk, ret, 3)
+        # Asset 0 has best return/risk ratio → should get highest weight
+        assert weights[0] > weights[1]
+
+
+# ---------------------------------------------------------------------------
+# MARLOrchestrator tests
+# ---------------------------------------------------------------------------
+
+
+class TestMARLOrchestrator:
+    def test_run_returns_result(self, returns_matrix):
+        from polars_ts.marl import MARLOrchestrator, MARLResult
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run(returns_matrix)
+        assert isinstance(result, MARLResult)
+
+    def test_result_has_weights_history(self, returns_matrix):
+        from polars_ts.marl import MARLOrchestrator
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run(returns_matrix)
+        assert isinstance(result.weights_history, np.ndarray)
+        n_steps = len(returns_matrix) - 10
+        assert result.weights_history.shape == (n_steps, returns_matrix.shape[1])
+
+    def test_result_has_portfolio_returns(self, returns_matrix):
+        from polars_ts.marl import MARLOrchestrator
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run(returns_matrix)
+        assert isinstance(result.portfolio_returns, np.ndarray)
+        assert len(result.portfolio_returns) == len(returns_matrix) - 10
+
+    def test_result_has_metrics(self, returns_matrix):
+        from polars_ts.marl import MARLOrchestrator
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run(returns_matrix)
+        assert isinstance(result.sharpe_ratio, float)
+        assert isinstance(result.total_return, float)
+        assert np.isfinite(result.sharpe_ratio)
+
+    def test_from_dataframe(self, price_panel):
+        from polars_ts.marl import MARLOrchestrator
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run_from_dataframe(price_panel)
+        assert result.weights_history.shape[1] == 3
+
+    def test_history_logged(self, returns_matrix):
+        from polars_ts.marl import MARLOrchestrator
+
+        orch = MARLOrchestrator(window_size=10)
+        result = orch.run(returns_matrix)
+        assert len(result.history) >= 3  # risk, return, allocation agents logged
+
+
+# ---------------------------------------------------------------------------
+# Lazy import tests
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    def test_importable_from_marl(self):
+        from polars_ts.marl import MARLOrchestrator, PortfolioEnv
+
+        assert PortfolioEnv is not None
+        assert MARLOrchestrator is not None
+
+    def test_importable_from_top_level(self):
+        from polars_ts import MARLOrchestrator, PortfolioEnv
+
+        assert PortfolioEnv is not None
+        assert MARLOrchestrator is not None


### PR DESCRIPTION
## Summary

- **PortfolioEnv**: Gymnasium-like multi-asset environment with weight normalization, transaction costs, and `from_dataframe` factory (prices → log returns)
- **RiskAgent**: Per-asset volatility via rolling standard deviation
- **ReturnAgent**: Expected returns via exponentially weighted moving average
- **AllocationAgent**: Risk-adjusted return scoring with configurable risk aversion
- **MARLOrchestrator**: Chains all agents over the environment, computes annualized Sharpe ratio and total return
- Zero-price validation, lazy imports registered

Closes #158

## Test plan

- [x] 20 tests pass (`pytest tests/test_marl.py`)
- [x] Ruff check + format clean
- [x] PortfolioEnv: creation, reset, step, weight normalization, episode termination, transaction costs, from_dataframe
- [x] RiskAgent: risk scores, volatile-asset detection
- [x] ReturnAgent: expected returns
- [x] AllocationAgent: weight normalization, return/risk preference
- [x] MARLOrchestrator: result type, weights history, portfolio returns, metrics, DataFrame integration, history logging
- [x] Lazy imports from `polars_ts.marl` and `polars_ts` top-level