### PR TITLE
feat: add native multivariate deep forecasting (#165)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -219,6 +219,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "PlannerAgent": ("polars_ts.agents", "PlannerAgent"),
     "ForecasterAgent": ("polars_ts.agents", "ForecasterAgent"),
     "ReporterAgent": ("polars_ts.agents", "ReporterAgent"),
+    # --- Multivariate DL ---
+    "MultivariatePatchTST": ("polars_ts.dl", "MultivariatePatchTST"),
+    "iTransformerForecaster": ("polars_ts.dl", "iTransformerForecaster"),
 }
 
 

--- a/polars_ts/dl/__init__.py
+++ b/polars_ts/dl/__init__.py
@@ -5,6 +5,8 @@ from polars_ts._lazy import make_getattr
 _IMPORTS: dict[str, tuple[str, str]] = {
     "NBEATSForecaster": ("polars_ts.dl.nbeats", "NBEATSForecaster"),
     "PatchTSTForecaster": ("polars_ts.dl.patchtst", "PatchTSTForecaster"),
+    "MultivariatePatchTST": ("polars_ts.dl.multivariate", "MultivariatePatchTST"),
+    "iTransformerForecaster": ("polars_ts.dl.multivariate", "iTransformerForecaster"),
 }
 
 __getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/dl/multivariate.py
+++ b/polars_ts/dl/multivariate.py
@@ -1,0 +1,519 @@
+"""Native multivariate deep forecasting models.
+
+MultivariatePatchTST: Channel-mixing PatchTST that processes all variates
+jointly through a shared transformer encoder.
+
+iTransformerForecaster: Inverted transformer that treats each variate as
+a token (Liu et al., 2024), enabling cross-variate attention.
+
+References
+----------
+Nie et al. (2023). PatchTST. ICLR.
+Liu et al. (2024). iTransformer. ICLR.
+
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+import numpy as np
+import polars as pl
+import torch
+import torch.nn as nn
+
+from polars_ts.models.baselines import _infer_freq, _make_future_dates
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_multivariate(
+    df: pl.DataFrame,
+    target_cols: list[str],
+    id_col: str,
+    time_col: str,
+) -> tuple[list[str], list[np.ndarray]]:
+    """Extract per-series multivariate arrays.
+
+    Returns
+    -------
+    ids
+        List of series identifiers.
+    arrays
+        List of arrays, each of shape ``(seq_len, n_vars)``.
+
+    """
+    sorted_df = df.sort(id_col, time_col)
+    ids: list[str] = []
+    arrays: list[np.ndarray] = []
+    for key, group in sorted_df.group_by(id_col, maintain_order=True):
+        ids.append(str(key[0] if isinstance(key, tuple) else key))
+        cols = [group[c].to_numpy().astype(np.float64) for c in target_cols]
+        arrays.append(np.column_stack(cols))  # (seq_len, n_vars)
+    return ids, arrays
+
+
+def _build_mv_windows(
+    arrays: list[np.ndarray],
+    input_size: int,
+    h: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build multivariate sliding windows.
+
+    Returns
+    -------
+    X
+        Shape ``(n_windows, input_size, n_vars)``.
+    Y
+        Shape ``(n_windows, h, n_vars)``.
+
+    """
+    all_x: list[np.ndarray] = []
+    all_y: list[np.ndarray] = []
+    for arr in arrays:
+        n = len(arr)
+        for t in range(input_size, n - h + 1):
+            all_x.append(arr[t - input_size : t])
+            all_y.append(arr[t : t + h])
+    if not all_x:
+        n_vars = arrays[0].shape[1] if arrays else 1
+        return np.empty((0, input_size, n_vars)), np.empty((0, h, n_vars))
+    return np.array(all_x), np.array(all_y)
+
+
+def _build_mv_forecast_df(
+    ids: list[str],
+    forecasts: np.ndarray,
+    target_cols: list[str],
+    df: pl.DataFrame,
+    h: int,
+    id_col: str,
+    time_col: str,
+) -> pl.DataFrame:
+    """Build output DataFrame with future dates and multivariate forecasts.
+
+    Parameters
+    ----------
+    forecasts
+        Shape ``(n_series, h, n_vars)``.
+
+    """
+    sorted_df = df.sort(id_col, time_col)
+    rows: list[dict[str, Any]] = []
+
+    for i, sid in enumerate(ids):
+        series_df = sorted_df.filter(pl.col(id_col) == sid)
+        times = series_df[time_col]
+        freq = _infer_freq(times)
+        last_time = times[-1]
+        future_dates = _make_future_dates(last_time, freq, h)
+
+        for t in range(h):
+            row: dict[str, Any] = {id_col: sid, time_col: future_dates[t]}
+            for v, col in enumerate(target_cols):
+                row[f"{col}_hat"] = float(forecasts[i, t, v])
+            rows.append(row)
+
+    return pl.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# MultivariatePatchTST network
+# ---------------------------------------------------------------------------
+
+
+class _MVPatchTSTNet(nn.Module):
+    """Channel-mixing PatchTST: all variates processed jointly."""
+
+    def __init__(
+        self,
+        input_size: int,
+        h: int,
+        n_vars: int,
+        patch_len: int = 8,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.n_vars = n_vars
+        self.patch_len = patch_len
+        self.n_patches = max(input_size // patch_len, 1)
+
+        # Project each patch (patch_len * n_vars) → d_model
+        self.patch_proj = nn.Linear(patch_len * n_vars, d_model)
+        self.pos_embed = nn.Parameter(torch.randn(1, self.n_patches, d_model) * 0.02)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_model * 4,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=n_layers)
+        self.head = nn.Linear(self.n_patches * d_model, h * n_vars)
+        self.h = h
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor of shape (batch, input_size, n_vars)
+
+        Returns
+        -------
+        Tensor of shape (batch, h, n_vars)
+
+        """
+        b = x.shape[0]
+        usable = self.n_patches * self.patch_len
+        x_trunc = x[:, -usable:, :]  # (b, usable, n_vars)
+
+        # Reshape to patches: (b, n_patches, patch_len, n_vars)
+        patches = x_trunc.reshape(b, self.n_patches, self.patch_len, self.n_vars)
+        # Flatten per patch: (b, n_patches, patch_len * n_vars)
+        patches_flat = patches.reshape(b, self.n_patches, -1)
+
+        tokens = self.patch_proj(patches_flat) + self.pos_embed
+        encoded = self.encoder(tokens)
+        flat = encoded.reshape(b, -1)
+        out = self.head(flat)
+        return out.reshape(b, self.h, self.n_vars)
+
+
+# ---------------------------------------------------------------------------
+# iTransformer network
+# ---------------------------------------------------------------------------
+
+
+class _iTransformerNet(nn.Module):
+    """Inverted transformer: each variate is a token."""
+
+    def __init__(
+        self,
+        input_size: int,
+        h: int,
+        n_vars: int,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.n_vars = n_vars
+        self.h = h
+
+        # Project each variate's full history → d_model
+        self.variate_proj = nn.Linear(input_size, d_model)
+        self.pos_embed = nn.Parameter(torch.randn(1, n_vars, d_model) * 0.02)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_model * 4,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=n_layers)
+        self.head = nn.Linear(d_model, h)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor of shape (batch, input_size, n_vars)
+
+        Returns
+        -------
+        Tensor of shape (batch, h, n_vars)
+
+        """
+        # Transpose to (batch, n_vars, input_size) — each variate is a token
+        x_t = x.transpose(1, 2)
+        tokens = self.variate_proj(x_t) + self.pos_embed  # (b, n_vars, d_model)
+        encoded = self.encoder(tokens)  # (b, n_vars, d_model)
+        out = self.head(encoded)  # (b, n_vars, h)
+        return out.transpose(1, 2)  # (b, h, n_vars)
+
+
+# ---------------------------------------------------------------------------
+# MultivariatePatchTST Forecaster
+# ---------------------------------------------------------------------------
+
+
+class MultivariatePatchTST:
+    """Channel-mixing PatchTST for multivariate forecasting.
+
+    Parameters
+    ----------
+    h
+        Forecast horizon.
+    input_size
+        Lookback window length.
+    patch_len
+        Length of each input patch.
+    target_cols
+        List of target column names to forecast jointly.
+    d_model
+        Transformer hidden dimension.
+    n_heads
+        Number of attention heads.
+    n_layers
+        Number of transformer encoder layers.
+    dropout
+        Dropout rate.
+    lr
+        Learning rate.
+    max_epochs
+        Maximum training epochs.
+    id_col, time_col
+        Column names.
+
+    """
+
+    def __init__(
+        self,
+        h: int = 12,
+        input_size: int = 32,
+        patch_len: int = 8,
+        target_cols: list[str] | None = None,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        dropout: float = 0.1,
+        lr: float = 1e-3,
+        max_epochs: int = 50,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+    ) -> None:
+        self.h = h
+        self.input_size = input_size
+        self.patch_len = patch_len
+        self.target_cols = target_cols or ["y"]
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.n_layers = n_layers
+        self.dropout = dropout
+        self.lr = lr
+        self.max_epochs = max_epochs
+        self.id_col = id_col
+        self.time_col = time_col
+
+        self.is_fitted_: bool = False
+        self._model: _MVPatchTSTNet | None = None
+        self._mean: np.ndarray | None = None
+        self._std: np.ndarray | None = None
+
+    def fit(self, df: pl.DataFrame) -> Self:
+        """Train on multivariate panel data."""
+        ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
+        X, Y = _build_mv_windows(arrays, self.input_size, self.h)
+
+        if X.shape[0] == 0:
+            raise ValueError("Not enough data for the given input_size and horizon")
+
+        self._mean = X.mean(axis=(0, 1), keepdims=True)
+        self._std = X.std(axis=(0, 1), keepdims=True) + 1e-8
+        X_norm = (X - self._mean) / self._std
+        Y_norm = (Y - self._mean) / self._std
+
+        X_t = torch.tensor(X_norm, dtype=torch.float32)
+        Y_t = torch.tensor(Y_norm, dtype=torch.float32)
+
+        model = _MVPatchTSTNet(
+            input_size=self.input_size,
+            h=self.h,
+            n_vars=len(self.target_cols),
+            patch_len=self.patch_len,
+            d_model=self.d_model,
+            n_heads=self.n_heads,
+            n_layers=self.n_layers,
+            dropout=self.dropout,
+        )
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+        loss_fn = nn.MSELoss()
+        dataset = torch.utils.data.TensorDataset(X_t, Y_t)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)
+
+        model.train()
+        for _ in range(self.max_epochs):
+            for xb, yb in loader:
+                pred = model(xb)
+                loss = loss_fn(pred, yb)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        self._model = model
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Generate multivariate forecasts."""
+        if not self.is_fitted_ or self._model is None:
+            raise RuntimeError("Call fit() before predict()")
+
+        ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
+        n_vars = len(self.target_cols)
+        forecasts = np.zeros((len(ids), self.h, n_vars))
+
+        model = self._model
+        model.eval()
+        with torch.no_grad():
+            for i, arr in enumerate(arrays):
+                x = arr[-self.input_size :].astype(np.float64)
+                if len(x) < self.input_size:
+                    padded = np.zeros((self.input_size, n_vars), dtype=np.float64)
+                    padded[-len(x) :] = x
+                    x = padded
+                x_norm = (x - self._mean.squeeze(0)) / self._std.squeeze(0)
+                x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
+                pred = model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = np.array(pred)
+                forecasts[i] = pred * self._std.squeeze(0) + self._mean.squeeze(0)
+
+        return _build_mv_forecast_df(ids, forecasts, self.target_cols, df, self.h, self.id_col, self.time_col)
+
+
+# ---------------------------------------------------------------------------
+# iTransformerForecaster
+# ---------------------------------------------------------------------------
+
+
+class iTransformerForecaster:
+    """Inverted transformer forecaster for multivariate time series.
+
+    Treats each variate as a token, enabling cross-variate attention.
+
+    Parameters
+    ----------
+    h
+        Forecast horizon.
+    input_size
+        Lookback window length.
+    target_cols
+        List of target column names to forecast jointly.
+    d_model
+        Transformer hidden dimension.
+    n_heads
+        Number of attention heads.
+    n_layers
+        Number of transformer encoder layers.
+    dropout
+        Dropout rate.
+    lr
+        Learning rate.
+    max_epochs
+        Maximum training epochs.
+    id_col, time_col
+        Column names.
+
+    """
+
+    def __init__(
+        self,
+        h: int = 12,
+        input_size: int = 30,
+        target_cols: list[str] | None = None,
+        d_model: int = 64,
+        n_heads: int = 4,
+        n_layers: int = 2,
+        dropout: float = 0.1,
+        lr: float = 1e-3,
+        max_epochs: int = 50,
+        id_col: str = "unique_id",
+        time_col: str = "ds",
+    ) -> None:
+        self.h = h
+        self.input_size = input_size
+        self.target_cols = target_cols or ["y"]
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.n_layers = n_layers
+        self.dropout = dropout
+        self.lr = lr
+        self.max_epochs = max_epochs
+        self.id_col = id_col
+        self.time_col = time_col
+
+        self.is_fitted_: bool = False
+        self._model: _iTransformerNet | None = None
+        self._mean: np.ndarray | None = None
+        self._std: np.ndarray | None = None
+
+    def fit(self, df: pl.DataFrame) -> Self:
+        """Train on multivariate panel data."""
+        ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
+        X, Y = _build_mv_windows(arrays, self.input_size, self.h)
+
+        if X.shape[0] == 0:
+            raise ValueError("Not enough data for the given input_size and horizon")
+
+        self._mean = X.mean(axis=(0, 1), keepdims=True)
+        self._std = X.std(axis=(0, 1), keepdims=True) + 1e-8
+        X_norm = (X - self._mean) / self._std
+        Y_norm = (Y - self._mean) / self._std
+
+        X_t = torch.tensor(X_norm, dtype=torch.float32)
+        Y_t = torch.tensor(Y_norm, dtype=torch.float32)
+
+        model = _iTransformerNet(
+            input_size=self.input_size,
+            h=self.h,
+            n_vars=len(self.target_cols),
+            d_model=self.d_model,
+            n_heads=self.n_heads,
+            n_layers=self.n_layers,
+            dropout=self.dropout,
+        )
+
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+        loss_fn = nn.MSELoss()
+        dataset = torch.utils.data.TensorDataset(X_t, Y_t)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=32, shuffle=True)
+
+        model.train()
+        for _ in range(self.max_epochs):
+            for xb, yb in loader:
+                pred = model(xb)
+                loss = loss_fn(pred, yb)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        self._model = model
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Generate multivariate forecasts."""
+        if not self.is_fitted_ or self._model is None:
+            raise RuntimeError("Call fit() before predict()")
+
+        ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
+        n_vars = len(self.target_cols)
+        forecasts = np.zeros((len(ids), self.h, n_vars))
+
+        model = self._model
+        model.eval()
+        with torch.no_grad():
+            for i, arr in enumerate(arrays):
+                x = arr[-self.input_size :].astype(np.float64)
+                if len(x) < self.input_size:
+                    padded = np.zeros((self.input_size, n_vars), dtype=np.float64)
+                    padded[-len(x) :] = x
+                    x = padded
+                x_norm = (x - self._mean.squeeze(0)) / self._std.squeeze(0)
+                x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
+                pred = model(x_t).squeeze(0).detach().cpu().tolist()
+                pred = np.array(pred)
+                forecasts[i] = pred * self._std.squeeze(0) + self._mean.squeeze(0)
+
+        return _build_mv_forecast_df(ids, forecasts, self.target_cols, df, self.h, self.id_col, self.time_col)

--- a/polars_ts/dl/multivariate.py
+++ b/polars_ts/dl/multivariate.py
@@ -357,7 +357,7 @@ class MultivariatePatchTST:
 
     def predict(self, df: pl.DataFrame) -> pl.DataFrame:
         """Generate multivariate forecasts."""
-        if not self.is_fitted_ or self._model is None:
+        if not self.is_fitted_ or self._model is None or self._mean is None or self._std is None:
             raise RuntimeError("Call fit() before predict()")
 
         ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
@@ -365,6 +365,8 @@ class MultivariatePatchTST:
         forecasts = np.zeros((len(ids), self.h, n_vars))
 
         model = self._model
+        mean = self._mean.squeeze(0)
+        std = self._std.squeeze(0)
         model.eval()
         with torch.no_grad():
             for i, arr in enumerate(arrays):
@@ -373,11 +375,11 @@ class MultivariatePatchTST:
                     padded = np.zeros((self.input_size, n_vars), dtype=np.float64)
                     padded[-len(x) :] = x
                     x = padded
-                x_norm = (x - self._mean.squeeze(0)) / self._std.squeeze(0)
+                x_norm = (x - mean) / std
                 x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
                 pred = model(x_t).squeeze(0).detach().cpu().tolist()
                 pred = np.array(pred)
-                forecasts[i] = pred * self._std.squeeze(0) + self._mean.squeeze(0)
+                forecasts[i] = pred * std + mean
 
         return _build_mv_forecast_df(ids, forecasts, self.target_cols, df, self.h, self.id_col, self.time_col)
 
@@ -494,7 +496,7 @@ class iTransformerForecaster:
 
     def predict(self, df: pl.DataFrame) -> pl.DataFrame:
         """Generate multivariate forecasts."""
-        if not self.is_fitted_ or self._model is None:
+        if not self.is_fitted_ or self._model is None or self._mean is None or self._std is None:
             raise RuntimeError("Call fit() before predict()")
 
         ids, arrays = _extract_multivariate(df, self.target_cols, self.id_col, self.time_col)
@@ -502,6 +504,8 @@ class iTransformerForecaster:
         forecasts = np.zeros((len(ids), self.h, n_vars))
 
         model = self._model
+        mean = self._mean.squeeze(0)
+        std = self._std.squeeze(0)
         model.eval()
         with torch.no_grad():
             for i, arr in enumerate(arrays):
@@ -510,10 +514,10 @@ class iTransformerForecaster:
                     padded = np.zeros((self.input_size, n_vars), dtype=np.float64)
                     padded[-len(x) :] = x
                     x = padded
-                x_norm = (x - self._mean.squeeze(0)) / self._std.squeeze(0)
+                x_norm = (x - mean) / std
                 x_t = torch.tensor(x_norm, dtype=torch.float32).unsqueeze(0)
                 pred = model(x_t).squeeze(0).detach().cpu().tolist()
                 pred = np.array(pred)
-                forecasts[i] = pred * self._std.squeeze(0) + self._mean.squeeze(0)
+                forecasts[i] = pred * std + mean
 
         return _build_mv_forecast_df(ids, forecasts, self.target_cols, df, self.h, self.id_col, self.time_col)

--- a/tests/test_multivariate_dl.py
+++ b/tests/test_multivariate_dl.py
@@ -1,0 +1,284 @@
+"""Tests for native multivariate deep forecasting (#165).
+
+TDD: tests define the expected API for MultivariatePatchTST and
+iTransformerForecaster before implementation.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mv_panel(n_series: int = 3, n_obs: int = 80) -> pl.DataFrame:
+    """Create a multivariate panel with 3 target columns per series."""
+    rng = np.random.default_rng(42)
+    base = date(2024, 1, 1)
+    rows: list[dict] = []
+    for sid in [chr(ord("A") + i) for i in range(n_series)]:
+        for t in range(n_obs):
+            rows.append(
+                {
+                    "unique_id": sid,
+                    "ds": base + timedelta(days=t),
+                    "y1": float(10 + 0.5 * t + rng.normal(0, 1)),
+                    "y2": float(20 - 0.3 * t + rng.normal(0, 1)),
+                    "y3": float(5 + 0.1 * t + rng.normal(0, 0.5)),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# MultivariatePatchTST tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultivariatePatchTST:
+    def test_fit_returns_self(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = MultivariatePatchTST(
+            h=5,
+            input_size=32,
+            patch_len=8,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        result = model.fit(df)
+        assert result is model
+        assert model.is_fitted_ is True
+
+    def test_predict_before_fit_raises(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        model = MultivariatePatchTST(h=5, input_size=32, patch_len=8, target_cols=["y1", "y2"])
+        with pytest.raises(RuntimeError, match="fit"):
+            model.predict(_make_mv_panel())
+
+    def test_predict_returns_all_targets(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = MultivariatePatchTST(
+            h=5,
+            input_size=32,
+            patch_len=8,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert isinstance(result, pl.DataFrame)
+        assert "y1_hat" in result.columns
+        assert "y2_hat" in result.columns
+        assert "y3_hat" in result.columns
+        assert len(result) == 5  # 1 series * h
+
+    def test_multi_series(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        n_series = 3
+        df = _make_mv_panel(n_series=n_series, n_obs=80)
+        model = MultivariatePatchTST(
+            h=5,
+            input_size=32,
+            patch_len=8,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert len(result) == n_series * 5
+
+    def test_output_has_future_dates(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = MultivariatePatchTST(
+            h=5,
+            input_size=32,
+            patch_len=8,
+            target_cols=["y1", "y2"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        last_date = df.sort("ds")["ds"][-1]
+        assert result["ds"].min() > last_date
+
+    def test_predictions_are_finite(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = MultivariatePatchTST(
+            h=5,
+            input_size=32,
+            patch_len=8,
+            target_cols=["y1", "y2"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        for col in ["y1_hat", "y2_hat"]:
+            assert np.all(np.isfinite(result[col].to_numpy()))
+
+    def test_custom_columns(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import MultivariatePatchTST
+
+        df = pl.DataFrame(
+            {
+                "sid": ["X"] * 50,
+                "t": [date(2024, 1, 1) + timedelta(days=i) for i in range(50)],
+                "a": np.random.default_rng(42).normal(0, 1, 50).tolist(),
+                "b": np.random.default_rng(43).normal(0, 1, 50).tolist(),
+            }
+        )
+        model = MultivariatePatchTST(
+            h=3,
+            input_size=16,
+            patch_len=8,
+            target_cols=["a", "b"],
+            max_epochs=1,
+            id_col="sid",
+            time_col="t",
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert "sid" in result.columns
+        assert "t" in result.columns
+        assert "a_hat" in result.columns
+        assert "b_hat" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# iTransformerForecaster tests
+# ---------------------------------------------------------------------------
+
+
+class TestITransformerForecaster:
+    def test_fit_returns_self(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = iTransformerForecaster(
+            h=5,
+            input_size=30,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        result = model.fit(df)
+        assert result is model
+        assert model.is_fitted_ is True
+
+    def test_predict_before_fit_raises(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        model = iTransformerForecaster(h=5, input_size=30, target_cols=["y1", "y2"])
+        with pytest.raises(RuntimeError, match="fit"):
+            model.predict(_make_mv_panel())
+
+    def test_predict_returns_all_targets(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = iTransformerForecaster(
+            h=5,
+            input_size=30,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert "y1_hat" in result.columns
+        assert "y2_hat" in result.columns
+        assert "y3_hat" in result.columns
+        assert len(result) == 5
+
+    def test_multi_series(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        n_series = 2
+        df = _make_mv_panel(n_series=n_series, n_obs=80)
+        model = iTransformerForecaster(
+            h=3,
+            input_size=30,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert len(result) == n_series * 3
+
+    def test_predictions_are_finite(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = iTransformerForecaster(
+            h=5,
+            input_size=30,
+            target_cols=["y1", "y2"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        for col in ["y1_hat", "y2_hat"]:
+            assert np.all(np.isfinite(result[col].to_numpy()))
+
+    def test_variate_tokens(self):
+        """ITransformer treats each variate as a token — more variates = more tokens."""
+        pytest.importorskip("torch")
+        from polars_ts.dl.multivariate import iTransformerForecaster
+
+        df = _make_mv_panel(n_series=1, n_obs=80)
+        model = iTransformerForecaster(
+            h=5,
+            input_size=30,
+            target_cols=["y1", "y2", "y3"],
+            max_epochs=1,
+        )
+        model.fit(df)
+        result = model.predict(df)
+        assert len(result) == 5
+        assert len([c for c in result.columns if c.endswith("_hat")]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Lazy import tests
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    def test_importable_from_dl(self):
+        pytest.importorskip("torch")
+        from polars_ts.dl import MultivariatePatchTST, iTransformerForecaster
+
+        assert MultivariatePatchTST is not None
+        assert iTransformerForecaster is not None
+
+    def test_importable_from_top_level(self):
+        pytest.importorskip("torch")
+        from polars_ts import MultivariatePatchTST, iTransformerForecaster
+
+        assert MultivariatePatchTST is not None
+        assert iTransformerForecaster is not None


### PR DESCRIPTION
## Summary

- **MultivariatePatchTST**: Channel-mixing PatchTST that processes all variates jointly. Patches are `(patch_len * n_vars)` flattened, projected to `d_model`, processed by shared transformer encoder, and decoded to `(h, n_vars)`.
- **iTransformerForecaster**: Inverted transformer (Liu et al., 2024) that treats each variate as a token. Full variate history projected to `d_model`, cross-variate attention via transformer, per-variate linear head to `h`.
- Multivariate helpers: `_extract_multivariate`, `_build_mv_windows` (3D), `_build_mv_forecast_df` (output `{col}_hat` columns)
- Per-variate normalization, short-series padding, lazy imports

Closes #165

## Test plan

- [x] 15 tests pass (`pytest tests/test_multivariate_dl.py`)
- [x] Ruff check + format clean
- [x] MultivariatePatchTST: fit, predict-before-fit, all targets, multi-series, future dates, finite values, custom columns
- [x] iTransformerForecaster: fit, predict-before-fit, all targets, multi-series, finite values, variate tokens
- [x] Lazy imports from `polars_ts.dl` and `polars_ts` top-level