### PR TITLE
feat: register KASBA PyO3 bindings (kasba_fit, kasba_predict) (#192)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ts-rs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "itertools",
  "ndarray",

--- a/src/kasba_py.rs
+++ b/src/kasba_py.rs
@@ -1,0 +1,186 @@
+//! PyO3 bindings for KASBA clustering (issue #192).
+//!
+//! Exposes `kasba_fit` and `kasba_predict` as Python-callable functions
+//! that accept 3D numpy arrays of shape (n_cases, n_channels, n_timepoints).
+
+use numpy::ndarray::Array2;
+use numpy::{IntoPyArray, PyArray1, PyArray2, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+use crate::kasba::clustering;
+use crate::kasba::pairwise::{DistanceMethod, DistanceParams};
+
+/// Fit KASBA clustering on multivariate time series data.
+///
+/// # Arguments
+/// * `data` - 3D array of shape (n_cases, n_channels, n_timepoints), f64
+/// * `n_clusters` - Number of clusters
+/// * `c` - MSM cost parameter
+/// * `independent` - MSM mode (true=per-channel, false=multivariate dependent)
+/// * `ba_subset_size` - Fraction of cluster members for barycenter averaging
+/// * `initial_step_size` - Starting SGD step size
+/// * `decay_rate` - Exponential decay rate for step size
+/// * `n_iters` - Maximum clustering iterations
+/// * `random_seed` - Random seed for determinism
+///
+/// # Returns
+/// Tuple of (labels, centers, inertia, n_iter)
+#[pyfunction]
+#[pyo3(signature = (
+    data,
+    n_clusters = 8,
+    c = 1.0,
+    independent = true,
+    ba_subset_size = 0.5,
+    initial_step_size = 0.05,
+    decay_rate = 0.1,
+    n_iters = 10,
+    random_seed = 42
+))]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn kasba_fit<'py>(
+    py: Python<'py>,
+    data: PyReadonlyArray3<'py, f64>,
+    n_clusters: usize,
+    c: f64,
+    independent: bool,
+    ba_subset_size: f64,
+    initial_step_size: f64,
+    decay_rate: f64,
+    n_iters: usize,
+    random_seed: u64,
+) -> PyResult<(Bound<'py, PyArray1<i64>>, Bound<'py, PyArray2<f64>>, f64, usize)> {
+    let shape = data.shape();
+    let n_cases = shape[0];
+    let n_channels = shape[1];
+    let ts_len = shape[2];
+
+    if n_cases == 0 || n_channels == 0 || ts_len == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "data dimensions must all be > 0",
+        ));
+    }
+    if n_clusters < 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "n_clusters must be >= 1",
+        ));
+    }
+    if n_clusters > n_cases {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "n_clusters ({n_clusters}) must be <= n_cases ({n_cases})"
+        )));
+    }
+
+    // Flatten to channel-major layout: for each series, channels are contiguous
+    // Input numpy shape: (n_cases, n_channels, n_timepoints) — already channel-major per series
+    let array = data.as_array();
+    let mut flat = Vec::with_capacity(n_cases * n_channels * ts_len);
+    for case in 0..n_cases {
+        for ch in 0..n_channels {
+            for t in 0..ts_len {
+                flat.push(array[[case, ch, t]]);
+            }
+        }
+    }
+
+    let (labels, centers, inertia, n_iter) = clustering::kasba_fit(
+        &flat,
+        n_cases,
+        n_channels,
+        ts_len,
+        n_clusters,
+        independent,
+        c,
+        n_iters,
+        1e-6,             // tol
+        ba_subset_size,
+        initial_step_size,
+        decay_rate,
+        random_seed,
+        50,    // max_ba_iters
+        false, // verbose
+    );
+
+    // Convert labels to i64 numpy array
+    let labels_i64: Vec<i64> = labels.into_iter().map(|l| l as i64).collect();
+    let labels_array = labels_i64.into_pyarray(py);
+
+    // Reshape centers to (n_clusters, n_channels * ts_len)
+    let stride = n_channels * ts_len;
+    let centers_array = Array2::from_shape_vec((n_clusters, stride), centers)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Center reshape failed: {e}")))?;
+    let centers_py = centers_array.into_pyarray(py);
+
+    Ok((labels_array, centers_py, inertia, n_iter))
+}
+
+/// Predict cluster assignments for new data using pre-computed centers.
+///
+/// # Arguments
+/// * `centers` - 2D array of shape (n_clusters, n_channels * n_timepoints)
+/// * `data` - 3D array of shape (n_cases, n_channels, n_timepoints)
+/// * `c` - MSM cost parameter
+/// * `independent` - MSM mode
+///
+/// # Returns
+/// 1D array of cluster labels
+#[pyfunction]
+#[pyo3(signature = (centers, data, c = 1.0, independent = true))]
+pub fn kasba_predict<'py>(
+    py: Python<'py>,
+    centers: PyReadonlyArray2<'py, f64>,
+    data: PyReadonlyArray3<'py, f64>,
+    c: f64,
+    independent: bool,
+) -> PyResult<Bound<'py, PyArray1<i64>>> {
+    let data_shape = data.shape();
+    let n_cases = data_shape[0];
+    let n_channels = data_shape[1];
+    let ts_len = data_shape[2];
+
+    let centers_shape = centers.shape();
+    let n_clusters = centers_shape[0];
+    let expected_stride = n_channels * ts_len;
+
+    if centers_shape[1] != expected_stride {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "centers shape[1] ({}) must equal n_channels * n_timepoints ({})",
+            centers_shape[1], expected_stride
+        )));
+    }
+
+    let params = DistanceParams {
+        method: DistanceMethod::Msm,
+        n_channels,
+        independent,
+        c,
+    };
+
+    // Flatten data (channel-major per series)
+    let data_arr = data.as_array();
+    let mut flat_data = Vec::with_capacity(n_cases * n_channels * ts_len);
+    for case in 0..n_cases {
+        for ch in 0..n_channels {
+            for t in 0..ts_len {
+                flat_data.push(data_arr[[case, ch, t]]);
+            }
+        }
+    }
+
+    // Flatten centers — already stored as (n_clusters, n_channels * ts_len) row-major
+    let centers_arr = centers.as_array();
+    let flat_centers: Vec<f64> = centers_arr.iter().copied().collect();
+
+    let labels = clustering::kasba_predict(
+        &flat_data,
+        &flat_centers,
+        n_cases,
+        n_clusters,
+        n_channels,
+        ts_len,
+        &params,
+    );
+
+    let labels_i64: Vec<i64> = labels.into_iter().map(|l| l as i64).collect();
+    Ok(labels_i64.into_pyarray(py))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod kmedoids;
 mod pelt;
 #[allow(dead_code, clippy::too_many_arguments, clippy::ptr_arg)]
 mod kasba;
+mod kasba_py;
 
 #[global_allocator]
 static ALLOC: PolarsAllocator = PolarsAllocator::new();
@@ -59,5 +60,7 @@ fn polars_ts_rs(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ets::ets_holt_winters, m)?)?;
     m.add_function(wrap_pyfunction!(kmedoids::kmedoids_pam, m)?)?;
     m.add_function(wrap_pyfunction!(pelt::pelt, m)?)?;
+    m.add_function(wrap_pyfunction!(kasba_py::kasba_fit, m)?)?;
+    m.add_function(wrap_pyfunction!(kasba_py::kasba_predict, m)?)?;
     Ok(())
 }

--- a/tests/test_kasba_bindings.py
+++ b/tests/test_kasba_bindings.py
@@ -1,0 +1,136 @@
+"""Tests for KASBA PyO3 bindings (issue #192)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from polars_ts_rs.polars_ts_rs import kasba_fit, kasba_predict
+
+
+@pytest.fixture
+def sample_3d_array():
+    """Create sample univariate data: 10 series, 1 channel, 20 timepoints."""
+    rng = np.random.default_rng(42)
+    # Two distinct clusters: linear up vs linear down
+    cluster_a = np.array([np.arange(20, dtype=np.float64) + rng.normal(0, 0.1, 20) for _ in range(5)])
+    cluster_b = np.array([np.arange(19, -1, -1, dtype=np.float64) + rng.normal(0, 0.1, 20) for _ in range(5)])
+    data = np.concatenate([cluster_a, cluster_b], axis=0)
+    # Reshape to (n_cases, n_channels, n_timepoints)
+    return data.reshape(10, 1, 20)
+
+
+@pytest.fixture
+def multivariate_3d_array():
+    """Create multivariate data: 12 series, 3 channels, 15 timepoints."""
+    rng = np.random.default_rng(123)
+    data = np.zeros((12, 3, 15), dtype=np.float64)
+    for i in range(4):
+        data[i] = rng.normal(0, 1, (3, 15))
+    for i in range(4, 8):
+        data[i] = rng.normal(5, 1, (3, 15))
+    for i in range(8, 12):
+        data[i] = rng.normal(-5, 1, (3, 15))
+    return data
+
+
+class TestKASBAFit:
+    """Test kasba_fit binding."""
+
+    def test_returns_correct_types(self, sample_3d_array):
+        labels, centers, inertia, n_iter = kasba_fit(sample_3d_array, n_clusters=2)
+        assert isinstance(labels, np.ndarray)
+        assert isinstance(centers, np.ndarray)
+        assert isinstance(inertia, float)
+        assert isinstance(n_iter, int)
+
+    def test_labels_shape_and_dtype(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert labels.shape == (10,)
+        assert labels.dtype == np.int64
+
+    def test_centers_shape(self, sample_3d_array):
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        # Centers: (n_clusters, n_channels * n_timepoints)
+        assert centers.shape == (2, 1 * 20)
+
+    def test_inertia_non_negative(self, sample_3d_array):
+        _, _, inertia, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert inertia >= 0.0
+
+    def test_deterministic_with_same_seed(self, sample_3d_array):
+        r1 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=42)
+        r2 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=42)
+        np.testing.assert_array_equal(r1[0], r2[0])
+        np.testing.assert_array_almost_equal(r1[1], r2[1])
+
+    def test_different_seed_may_differ(self, sample_3d_array):
+        r1 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=1)
+        r2 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=999)
+        # Labels may differ (not guaranteed, but likely with different seeds)
+        # At minimum, both should be valid
+        assert set(r1[0].tolist()).issubset({0, 1})
+        assert set(r2[0].tolist()).issubset({0, 1})
+
+    def test_multivariate_independent(self, multivariate_3d_array):
+        labels, centers, inertia, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=True)
+        assert labels.shape == (12,)
+        assert centers.shape == (3, 3 * 15)
+        assert inertia >= 0.0
+
+    def test_multivariate_dependent(self, multivariate_3d_array):
+        labels, centers, inertia, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=False)
+        assert labels.shape == (12,)
+        assert centers.shape == (3, 3 * 15)
+        assert inertia >= 0.0
+
+    def test_all_labels_in_range(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert all(0 <= lbl < 2 for lbl in labels)
+
+    def test_custom_parameters(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(
+            sample_3d_array,
+            n_clusters=2,
+            c=2.0,
+            ba_subset_size=0.3,
+            initial_step_size=0.1,
+            decay_rate=0.2,
+            n_iters=5,
+            random_seed=7,
+        )
+        assert labels.shape == (10,)
+
+
+class TestKASBAPredict:
+    """Test kasba_predict binding."""
+
+    def test_predict_returns_labels(self, sample_3d_array):
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        pred_labels = kasba_predict(centers, sample_3d_array)
+        assert isinstance(pred_labels, np.ndarray)
+        assert pred_labels.shape == (10,)
+        assert pred_labels.dtype == np.int64
+
+    def test_predict_matches_fit_labels(self, sample_3d_array):
+        labels, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        pred_labels = kasba_predict(centers, sample_3d_array)
+        np.testing.assert_array_equal(labels, pred_labels)
+
+    def test_predict_multivariate(self, multivariate_3d_array):
+        labels, centers, _, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=True)
+        pred_labels = kasba_predict(centers, multivariate_3d_array, independent=True)
+        np.testing.assert_array_equal(labels, pred_labels)
+
+    def test_predict_new_data(self, sample_3d_array):
+        """Predict on new data should return valid labels."""
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        # Create new data similar to cluster A (ascending)
+        new_data = np.arange(20, dtype=np.float64).reshape(1, 1, 20)
+        pred = kasba_predict(centers, new_data)
+        assert pred.shape == (1,)
+        assert 0 <= pred[0] < 2
+
+    def test_predict_dependent_mode(self, multivariate_3d_array):
+        labels, centers, _, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=False)
+        pred_labels = kasba_predict(centers, multivariate_3d_array, independent=False)
+        np.testing.assert_array_equal(labels, pred_labels)


### PR DESCRIPTION
## Summary

Exposes `kasba_fit` and `kasba_predict` as `#[pyfunction]` entries in the `polars_ts_rs` Python module, closing #192.

- **`kasba_fit(data, n_clusters, ...)`** — accepts 3D numpy array `(n_cases, n_channels, n_timepoints)`, returns `(labels, centers, inertia, n_iter)`
- **`kasba_predict(centers, data, ...)`** — accepts 2D centers + 3D data, returns cluster labels

Includes input validation (n_clusters bounds, empty dimensions, centers shape) and 15 Python-level tests.

## Test plan

- [x] 15 pytest tests (TDD — written before implementation)
- [x] `kasba_fit`: return types, shapes, dtypes, determinism, multivariate independent/dependent, custom params
- [x] `kasba_predict`: label output, matches fit labels, new data assignment, multivariate modes
- [x] `maturin build --release` succeeds
- [x] Existing `polars_ts_rs` functions unaffected
- [x] Clippy clean (suppressed expected `too_many_arguments`)