### PR TITLE
feat: add KASBAClusterer Python wrapper + kasba() convenience function (#193)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ts-rs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "itertools",
  "ndarray",

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -97,6 +97,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "IDECClusterer": ("polars_ts.clustering.deep_cluster", "IDECClusterer"),
     "dec_cluster": ("polars_ts.clustering.deep_cluster", "dec_cluster"),
     "idec_cluster": ("polars_ts.clustering.deep_cluster", "idec_cluster"),
+    "KASBAClusterer": ("polars_ts.clustering.kasba", "KASBAClusterer"),
+    "kasba": ("polars_ts.clustering.kasba", "kasba"),
     # --- Classification ---
     "knn_classify": ("polars_ts.classification.knn", "knn_classify"),
     "TimeSeriesKNNClassifier": ("polars_ts.classification.knn", "TimeSeriesKNNClassifier"),

--- a/polars_ts/clustering/__init__.py
+++ b/polars_ts/clustering/__init__.py
@@ -26,6 +26,8 @@ _IMPORTS: dict[str, tuple[str, str]] = {
     "IDECClusterer": ("polars_ts.clustering.deep_cluster", "IDECClusterer"),
     "dec_cluster": ("polars_ts.clustering.deep_cluster", "dec_cluster"),
     "idec_cluster": ("polars_ts.clustering.deep_cluster", "idec_cluster"),
+    "KASBAClusterer": ("polars_ts.clustering.kasba", "KASBAClusterer"),
+    "kasba": ("polars_ts.clustering.kasba", "kasba"),
 }
 
 __getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/clustering/kasba.py
+++ b/polars_ts/clustering/kasba.py
@@ -1,0 +1,262 @@
+"""KASBA: K-means with Accelerated Stochastic Barycenter Averaging.
+
+Uses MSM (Move-Split-Merge) elastic distance — a proper metric that
+enables triangle inequality pruning for 10-30x speedup over aeon.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+from polars_ts_rs.polars_ts_rs import kasba_fit, kasba_predict
+
+
+class KASBAClusterer:
+    """KASBA clustering for univariate and multivariate time series.
+
+    Parameters
+    ----------
+    n_clusters
+        Number of clusters. Default 8.
+    c
+        MSM cost coefficient. Default 1.0.
+    independent
+        If True, compute MSM per-channel independently (sum).
+        If False, use dependent cross-channel MSM. Default True.
+    ba_subset_size
+        Proportion of cluster members used in barycenter SGD. Default 0.5.
+    initial_step_size
+        SGD initial learning rate. Default 0.05.
+    decay_rate
+        Exponential decay rate for step size. Default 0.1.
+    max_iter
+        Maximum k-means iterations. Default 10.
+    seed
+        Random seed for reproducibility. Default 42.
+
+    """
+
+    def __init__(
+        self,
+        n_clusters: int = 8,
+        c: float = 1.0,
+        independent: bool = True,
+        ba_subset_size: float = 0.5,
+        initial_step_size: float = 0.05,
+        decay_rate: float = 0.1,
+        max_iter: int = 10,
+        seed: int = 42,
+    ) -> None:
+        self.n_clusters = n_clusters
+        self.c = c
+        self.independent = independent
+        self.ba_subset_size = ba_subset_size
+        self.initial_step_size = initial_step_size
+        self.decay_rate = decay_rate
+        self.max_iter = max_iter
+        self.seed = seed
+
+        self.labels_: pl.DataFrame | None = None
+        self.centroids_: np.ndarray | None = None
+        self.inertia_: float = 0.0
+        self.n_iter_: int = 0
+        self._is_fitted = False
+        self._id_col: str = "unique_id"
+        self._id_dtype: Any = None
+        self._n_channels: int = 1
+        self._ts_len: int = 0
+
+    def fit(
+        self,
+        df: pl.DataFrame,
+        id_col: str = "unique_id",
+        target_col: str = "y",
+        channel_col: str | None = None,
+    ) -> KASBAClusterer:
+        """Fit KASBA clustering.
+
+        Parameters
+        ----------
+        df
+            DataFrame with time series data.
+        id_col
+            Column identifying each time series.
+        target_col
+            Column with the time series values.
+        channel_col
+            Column identifying channels for multivariate series.
+            If None, assumes univariate data.
+
+        """
+        self._id_col = id_col
+        self._id_dtype = df[id_col].dtype
+
+        data_3d, ids = self._to_3d_array(df, id_col, target_col, channel_col)
+
+        labels_arr, centers, inertia, n_iter = kasba_fit(
+            data_3d,
+            n_clusters=self.n_clusters,
+            c=self.c,
+            independent=self.independent,
+            ba_subset_size=self.ba_subset_size,
+            initial_step_size=self.initial_step_size,
+            decay_rate=self.decay_rate,
+            n_iters=self.max_iter,
+            random_seed=self.seed,
+        )
+
+        self.centroids_ = centers
+        self.inertia_ = inertia
+        self.n_iter_ = n_iter
+        self.labels_ = pl.DataFrame(
+            {id_col: ids, "cluster": labels_arr.tolist()},
+            schema={id_col: pl.String, "cluster": pl.Int64},
+        ).with_columns(pl.col(id_col).cast(self._id_dtype))
+        self._is_fitted = True
+        return self
+
+    def predict(
+        self,
+        df: pl.DataFrame,
+        id_col: str = "unique_id",
+        target_col: str = "y",
+        channel_col: str | None = None,
+    ) -> pl.DataFrame:
+        """Predict cluster assignments for new data.
+
+        Parameters
+        ----------
+        df
+            DataFrame with time series data.
+
+        Returns
+        -------
+        pl.DataFrame
+            DataFrame with columns ``[id_col, "cluster"]``.
+
+        """
+        if not self._is_fitted:
+            raise RuntimeError("Call fit() before predict()")
+
+        data_3d, ids = self._to_3d_array(df, id_col, target_col, channel_col)
+
+        pred_labels = kasba_predict(
+            self.centroids_,
+            data_3d,
+            c=self.c,
+            independent=self.independent,
+        )
+
+        return pl.DataFrame(
+            {id_col: ids, "cluster": pred_labels.tolist()},
+            schema={id_col: pl.String, "cluster": pl.Int64},
+        ).with_columns(pl.col(id_col).cast(self._id_dtype))
+
+    def _to_3d_array(
+        self,
+        df: pl.DataFrame,
+        id_col: str,
+        target_col: str,
+        channel_col: str | None,
+    ) -> tuple[np.ndarray, list[str]]:
+        """Convert DataFrame to 3D numpy array (n_cases, n_channels, n_timepoints)."""
+        ids = sorted(df[id_col].unique().cast(pl.String).to_list())
+        n_cases = len(ids)
+
+        if channel_col is None:
+            # Univariate: (n_cases, 1, n_timepoints)
+            series_list = []
+            for uid in ids:
+                vals = df.filter(pl.col(id_col).cast(pl.String) == uid)[target_col].to_numpy()
+                series_list.append(vals.astype(np.float64))
+
+            # Pad to max length
+            max_len = max(len(s) for s in series_list)
+            self._ts_len = max_len
+            self._n_channels = 1
+
+            data = np.zeros((n_cases, 1, max_len), dtype=np.float64)
+            for i, s in enumerate(series_list):
+                data[i, 0, : len(s)] = s
+        else:
+            # Multivariate: (n_cases, n_channels, n_timepoints)
+            channels = sorted(df[channel_col].unique().cast(pl.String).to_list())
+            n_channels = len(channels)
+            self._n_channels = n_channels
+
+            # Find max timepoints per (id, channel) combination
+            max_len = 0
+            for uid in ids:
+                for ch in channels:
+                    n = df.filter(
+                        (pl.col(id_col).cast(pl.String) == uid) & (pl.col(channel_col).cast(pl.String) == ch)
+                    ).height
+                    max_len = max(max_len, n)
+            self._ts_len = max_len
+
+            data = np.zeros((n_cases, n_channels, max_len), dtype=np.float64)
+            for i, uid in enumerate(ids):
+                for j, ch in enumerate(channels):
+                    vals = df.filter(
+                        (pl.col(id_col).cast(pl.String) == uid) & (pl.col(channel_col).cast(pl.String) == ch)
+                    )[target_col].to_numpy()
+                    data[i, j, : len(vals)] = vals.astype(np.float64)
+
+        return data, ids
+
+
+def kasba(
+    df: pl.DataFrame,
+    k: int,
+    *,
+    c: float = 1.0,
+    independent: bool = True,
+    max_iter: int = 10,
+    seed: int = 42,
+    id_col: str = "unique_id",
+    target_col: str = "y",
+    channel_col: str | None = None,
+    **kwargs: Any,
+) -> pl.DataFrame:
+    """KASBA clustering convenience function.
+
+    Parameters
+    ----------
+    df
+        DataFrame with time series data.
+    k
+        Number of clusters.
+    c
+        MSM cost coefficient. Default 1.0.
+    independent
+        MSM mode. Default True.
+    max_iter
+        Maximum iterations. Default 10.
+    seed
+        Random seed. Default 42.
+    id_col
+        Series identifier column. Default ``"unique_id"``.
+    target_col
+        Values column. Default ``"y"``.
+    channel_col
+        Channel column for multivariate data. Default None.
+
+    Returns
+    -------
+    pl.DataFrame
+        DataFrame with columns ``[id_col, "cluster"]``.
+
+    """
+    clf = KASBAClusterer(
+        n_clusters=k,
+        c=c,
+        independent=independent,
+        max_iter=max_iter,
+        seed=seed,
+        **kwargs,
+    )
+    clf.fit(df, id_col=id_col, target_col=target_col, channel_col=channel_col)
+    assert clf.labels_ is not None
+    return clf.labels_

--- a/src/kasba_py.rs
+++ b/src/kasba_py.rs
@@ -1,0 +1,186 @@
+//! PyO3 bindings for KASBA clustering (issue #192).
+//!
+//! Exposes `kasba_fit` and `kasba_predict` as Python-callable functions
+//! that accept 3D numpy arrays of shape (n_cases, n_channels, n_timepoints).
+
+use numpy::ndarray::Array2;
+use numpy::{IntoPyArray, PyArray1, PyArray2, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+use crate::kasba::clustering;
+use crate::kasba::pairwise::{DistanceMethod, DistanceParams};
+
+/// Fit KASBA clustering on multivariate time series data.
+///
+/// # Arguments
+/// * `data` - 3D array of shape (n_cases, n_channels, n_timepoints), f64
+/// * `n_clusters` - Number of clusters
+/// * `c` - MSM cost parameter
+/// * `independent` - MSM mode (true=per-channel, false=multivariate dependent)
+/// * `ba_subset_size` - Fraction of cluster members for barycenter averaging
+/// * `initial_step_size` - Starting SGD step size
+/// * `decay_rate` - Exponential decay rate for step size
+/// * `n_iters` - Maximum clustering iterations
+/// * `random_seed` - Random seed for determinism
+///
+/// # Returns
+/// Tuple of (labels, centers, inertia, n_iter)
+#[pyfunction]
+#[pyo3(signature = (
+    data,
+    n_clusters = 8,
+    c = 1.0,
+    independent = true,
+    ba_subset_size = 0.5,
+    initial_step_size = 0.05,
+    decay_rate = 0.1,
+    n_iters = 10,
+    random_seed = 42
+))]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn kasba_fit<'py>(
+    py: Python<'py>,
+    data: PyReadonlyArray3<'py, f64>,
+    n_clusters: usize,
+    c: f64,
+    independent: bool,
+    ba_subset_size: f64,
+    initial_step_size: f64,
+    decay_rate: f64,
+    n_iters: usize,
+    random_seed: u64,
+) -> PyResult<(Bound<'py, PyArray1<i64>>, Bound<'py, PyArray2<f64>>, f64, usize)> {
+    let shape = data.shape();
+    let n_cases = shape[0];
+    let n_channels = shape[1];
+    let ts_len = shape[2];
+
+    if n_cases == 0 || n_channels == 0 || ts_len == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "data dimensions must all be > 0",
+        ));
+    }
+    if n_clusters < 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "n_clusters must be >= 1",
+        ));
+    }
+    if n_clusters > n_cases {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "n_clusters ({n_clusters}) must be <= n_cases ({n_cases})"
+        )));
+    }
+
+    // Flatten to channel-major layout: for each series, channels are contiguous
+    // Input numpy shape: (n_cases, n_channels, n_timepoints) — already channel-major per series
+    let array = data.as_array();
+    let mut flat = Vec::with_capacity(n_cases * n_channels * ts_len);
+    for case in 0..n_cases {
+        for ch in 0..n_channels {
+            for t in 0..ts_len {
+                flat.push(array[[case, ch, t]]);
+            }
+        }
+    }
+
+    let (labels, centers, inertia, n_iter) = clustering::kasba_fit(
+        &flat,
+        n_cases,
+        n_channels,
+        ts_len,
+        n_clusters,
+        independent,
+        c,
+        n_iters,
+        1e-6,             // tol
+        ba_subset_size,
+        initial_step_size,
+        decay_rate,
+        random_seed,
+        50,    // max_ba_iters
+        false, // verbose
+    );
+
+    // Convert labels to i64 numpy array
+    let labels_i64: Vec<i64> = labels.into_iter().map(|l| l as i64).collect();
+    let labels_array = labels_i64.into_pyarray(py);
+
+    // Reshape centers to (n_clusters, n_channels * ts_len)
+    let stride = n_channels * ts_len;
+    let centers_array = Array2::from_shape_vec((n_clusters, stride), centers)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Center reshape failed: {e}")))?;
+    let centers_py = centers_array.into_pyarray(py);
+
+    Ok((labels_array, centers_py, inertia, n_iter))
+}
+
+/// Predict cluster assignments for new data using pre-computed centers.
+///
+/// # Arguments
+/// * `centers` - 2D array of shape (n_clusters, n_channels * n_timepoints)
+/// * `data` - 3D array of shape (n_cases, n_channels, n_timepoints)
+/// * `c` - MSM cost parameter
+/// * `independent` - MSM mode
+///
+/// # Returns
+/// 1D array of cluster labels
+#[pyfunction]
+#[pyo3(signature = (centers, data, c = 1.0, independent = true))]
+pub fn kasba_predict<'py>(
+    py: Python<'py>,
+    centers: PyReadonlyArray2<'py, f64>,
+    data: PyReadonlyArray3<'py, f64>,
+    c: f64,
+    independent: bool,
+) -> PyResult<Bound<'py, PyArray1<i64>>> {
+    let data_shape = data.shape();
+    let n_cases = data_shape[0];
+    let n_channels = data_shape[1];
+    let ts_len = data_shape[2];
+
+    let centers_shape = centers.shape();
+    let n_clusters = centers_shape[0];
+    let expected_stride = n_channels * ts_len;
+
+    if centers_shape[1] != expected_stride {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "centers shape[1] ({}) must equal n_channels * n_timepoints ({})",
+            centers_shape[1], expected_stride
+        )));
+    }
+
+    let params = DistanceParams {
+        method: DistanceMethod::Msm,
+        n_channels,
+        independent,
+        c,
+    };
+
+    // Flatten data (channel-major per series)
+    let data_arr = data.as_array();
+    let mut flat_data = Vec::with_capacity(n_cases * n_channels * ts_len);
+    for case in 0..n_cases {
+        for ch in 0..n_channels {
+            for t in 0..ts_len {
+                flat_data.push(data_arr[[case, ch, t]]);
+            }
+        }
+    }
+
+    // Flatten centers — already stored as (n_clusters, n_channels * ts_len) row-major
+    let centers_arr = centers.as_array();
+    let flat_centers: Vec<f64> = centers_arr.iter().copied().collect();
+
+    let labels = clustering::kasba_predict(
+        &flat_data,
+        &flat_centers,
+        n_cases,
+        n_clusters,
+        n_channels,
+        ts_len,
+        &params,
+    );
+
+    let labels_i64: Vec<i64> = labels.into_iter().map(|l| l as i64).collect();
+    Ok(labels_i64.into_pyarray(py))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod kmedoids;
 mod pelt;
 #[allow(dead_code, clippy::too_many_arguments, clippy::ptr_arg)]
 mod kasba;
+mod kasba_py;
 
 #[global_allocator]
 static ALLOC: PolarsAllocator = PolarsAllocator::new();
@@ -59,5 +60,7 @@ fn polars_ts_rs(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ets::ets_holt_winters, m)?)?;
     m.add_function(wrap_pyfunction!(kmedoids::kmedoids_pam, m)?)?;
     m.add_function(wrap_pyfunction!(pelt::pelt, m)?)?;
+    m.add_function(wrap_pyfunction!(kasba_py::kasba_fit, m)?)?;
+    m.add_function(wrap_pyfunction!(kasba_py::kasba_predict, m)?)?;
     Ok(())
 }

--- a/tests/clustering/test_kasba.py
+++ b/tests/clustering/test_kasba.py
@@ -1,0 +1,112 @@
+"""Tests for KASBAClusterer Python wrapper (issue #193)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.clustering.kasba import KASBAClusterer, kasba
+
+
+@pytest.fixture
+def cluster_df():
+    """Univariate data: 6 series, two clear groups."""
+    ascending = [float(i) for i in range(10)]
+    descending = [float(9 - i) for i in range(10)]
+    return pl.DataFrame(
+        {
+            "unique_id": (["A1"] * 10 + ["A2"] * 10 + ["A3"] * 10 + ["B1"] * 10 + ["B2"] * 10 + ["B3"] * 10),
+            "y": (
+                ascending
+                + [x + 0.1 for x in ascending]
+                + [x - 0.1 for x in ascending]
+                + descending
+                + [x + 0.1 for x in descending]
+                + [x - 0.1 for x in descending]
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def multivariate_cluster_df():
+    """Multivariate data: 6 series, 2 channels."""
+    rng = np.random.default_rng(42)
+    rows = []
+    for sid in ["A1", "A2", "A3", "B1", "B2", "B3"]:
+        for ch in ["x", "y"]:
+            base = rng.normal(0 if sid.startswith("A") else 5, 0.1, 8)
+            for val in base:
+                rows.append({"unique_id": sid, "channel": ch, "y": float(val)})
+    return pl.DataFrame(rows)
+
+
+class TestKASBAClusterer:
+    """Test KASBAClusterer class."""
+
+    def test_fit_returns_self(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2)
+        result = clf.fit(cluster_df)
+        assert result is clf
+
+    def test_labels_dataframe_schema(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(cluster_df)
+        assert clf.labels_ is not None
+        assert "unique_id" in clf.labels_.columns
+        assert "cluster" in clf.labels_.columns
+        assert clf.labels_.shape[0] == cluster_df["unique_id"].n_unique()
+
+    def test_predict_matches_fit(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(cluster_df)
+        pred = clf.predict(cluster_df)
+        assert pred.shape[0] == cluster_df["unique_id"].n_unique()
+        assert "cluster" in pred.columns
+
+    def test_predict_before_fit_raises(self, cluster_df):
+        with pytest.raises(RuntimeError, match="fit"):
+            KASBAClusterer().predict(cluster_df)
+
+    def test_inertia_nonnegative(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(cluster_df)
+        assert clf.inertia_ >= 0.0
+
+    def test_n_iter_positive(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(cluster_df)
+        assert clf.n_iter_ >= 1
+
+    def test_reproducible_with_seed(self, cluster_df):
+        labels1 = KASBAClusterer(n_clusters=2, seed=7).fit(cluster_df).labels_
+        labels2 = KASBAClusterer(n_clusters=2, seed=7).fit(cluster_df).labels_
+        assert labels1.equals(labels2)
+
+    def test_centroids_stored(self, cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(cluster_df)
+        assert clf.centroids_ is not None
+        assert clf.centroids_.shape[0] == 2
+
+    def test_convenience_function(self, cluster_df):
+        result = kasba(cluster_df, k=2)
+        assert isinstance(result, pl.DataFrame)
+        assert set(result.columns) == {"unique_id", "cluster"}
+        assert result.shape[0] == 6
+
+
+class TestKASBAMultivariate:
+    """Test multivariate KASBA clustering."""
+
+    def test_multivariate_fit(self, multivariate_cluster_df):
+        clf = KASBAClusterer(n_clusters=2).fit(multivariate_cluster_df, channel_col="channel")
+        assert clf.labels_ is not None
+        assert clf.labels_.shape[0] == multivariate_cluster_df["unique_id"].n_unique()
+
+    def test_independent_vs_dependent(self, multivariate_cluster_df):
+        labels_ind = (
+            KASBAClusterer(n_clusters=2, independent=True).fit(multivariate_cluster_df, channel_col="channel").labels_
+        )
+        labels_dep = (
+            KASBAClusterer(n_clusters=2, independent=False).fit(multivariate_cluster_df, channel_col="channel").labels_
+        )
+        # Both produce valid output
+        assert labels_ind.shape == labels_dep.shape
+        assert labels_ind.shape[0] == 6

--- a/tests/test_kasba_bindings.py
+++ b/tests/test_kasba_bindings.py
@@ -1,0 +1,136 @@
+"""Tests for KASBA PyO3 bindings (issue #192)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from polars_ts_rs.polars_ts_rs import kasba_fit, kasba_predict
+
+
+@pytest.fixture
+def sample_3d_array():
+    """Create sample univariate data: 10 series, 1 channel, 20 timepoints."""
+    rng = np.random.default_rng(42)
+    # Two distinct clusters: linear up vs linear down
+    cluster_a = np.array([np.arange(20, dtype=np.float64) + rng.normal(0, 0.1, 20) for _ in range(5)])
+    cluster_b = np.array([np.arange(19, -1, -1, dtype=np.float64) + rng.normal(0, 0.1, 20) for _ in range(5)])
+    data = np.concatenate([cluster_a, cluster_b], axis=0)
+    # Reshape to (n_cases, n_channels, n_timepoints)
+    return data.reshape(10, 1, 20)
+
+
+@pytest.fixture
+def multivariate_3d_array():
+    """Create multivariate data: 12 series, 3 channels, 15 timepoints."""
+    rng = np.random.default_rng(123)
+    data = np.zeros((12, 3, 15), dtype=np.float64)
+    for i in range(4):
+        data[i] = rng.normal(0, 1, (3, 15))
+    for i in range(4, 8):
+        data[i] = rng.normal(5, 1, (3, 15))
+    for i in range(8, 12):
+        data[i] = rng.normal(-5, 1, (3, 15))
+    return data
+
+
+class TestKASBAFit:
+    """Test kasba_fit binding."""
+
+    def test_returns_correct_types(self, sample_3d_array):
+        labels, centers, inertia, n_iter = kasba_fit(sample_3d_array, n_clusters=2)
+        assert isinstance(labels, np.ndarray)
+        assert isinstance(centers, np.ndarray)
+        assert isinstance(inertia, float)
+        assert isinstance(n_iter, int)
+
+    def test_labels_shape_and_dtype(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert labels.shape == (10,)
+        assert labels.dtype == np.int64
+
+    def test_centers_shape(self, sample_3d_array):
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        # Centers: (n_clusters, n_channels * n_timepoints)
+        assert centers.shape == (2, 1 * 20)
+
+    def test_inertia_non_negative(self, sample_3d_array):
+        _, _, inertia, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert inertia >= 0.0
+
+    def test_deterministic_with_same_seed(self, sample_3d_array):
+        r1 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=42)
+        r2 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=42)
+        np.testing.assert_array_equal(r1[0], r2[0])
+        np.testing.assert_array_almost_equal(r1[1], r2[1])
+
+    def test_different_seed_may_differ(self, sample_3d_array):
+        r1 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=1)
+        r2 = kasba_fit(sample_3d_array, n_clusters=2, random_seed=999)
+        # Labels may differ (not guaranteed, but likely with different seeds)
+        # At minimum, both should be valid
+        assert set(r1[0].tolist()).issubset({0, 1})
+        assert set(r2[0].tolist()).issubset({0, 1})
+
+    def test_multivariate_independent(self, multivariate_3d_array):
+        labels, centers, inertia, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=True)
+        assert labels.shape == (12,)
+        assert centers.shape == (3, 3 * 15)
+        assert inertia >= 0.0
+
+    def test_multivariate_dependent(self, multivariate_3d_array):
+        labels, centers, inertia, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=False)
+        assert labels.shape == (12,)
+        assert centers.shape == (3, 3 * 15)
+        assert inertia >= 0.0
+
+    def test_all_labels_in_range(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        assert all(0 <= lbl < 2 for lbl in labels)
+
+    def test_custom_parameters(self, sample_3d_array):
+        labels, _, _, _ = kasba_fit(
+            sample_3d_array,
+            n_clusters=2,
+            c=2.0,
+            ba_subset_size=0.3,
+            initial_step_size=0.1,
+            decay_rate=0.2,
+            n_iters=5,
+            random_seed=7,
+        )
+        assert labels.shape == (10,)
+
+
+class TestKASBAPredict:
+    """Test kasba_predict binding."""
+
+    def test_predict_returns_labels(self, sample_3d_array):
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        pred_labels = kasba_predict(centers, sample_3d_array)
+        assert isinstance(pred_labels, np.ndarray)
+        assert pred_labels.shape == (10,)
+        assert pred_labels.dtype == np.int64
+
+    def test_predict_matches_fit_labels(self, sample_3d_array):
+        labels, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        pred_labels = kasba_predict(centers, sample_3d_array)
+        np.testing.assert_array_equal(labels, pred_labels)
+
+    def test_predict_multivariate(self, multivariate_3d_array):
+        labels, centers, _, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=True)
+        pred_labels = kasba_predict(centers, multivariate_3d_array, independent=True)
+        np.testing.assert_array_equal(labels, pred_labels)
+
+    def test_predict_new_data(self, sample_3d_array):
+        """Predict on new data should return valid labels."""
+        _, centers, _, _ = kasba_fit(sample_3d_array, n_clusters=2)
+        # Create new data similar to cluster A (ascending)
+        new_data = np.arange(20, dtype=np.float64).reshape(1, 1, 20)
+        pred = kasba_predict(centers, new_data)
+        assert pred.shape == (1,)
+        assert 0 <= pred[0] < 2
+
+    def test_predict_dependent_mode(self, multivariate_3d_array):
+        labels, centers, _, _ = kasba_fit(multivariate_3d_array, n_clusters=3, independent=False)
+        pred_labels = kasba_predict(centers, multivariate_3d_array, independent=False)
+        np.testing.assert_array_equal(labels, pred_labels)


### PR DESCRIPTION
## Summary

Creates `polars_ts/clustering/kasba.py` with `KASBAClusterer` class and `kasba()` convenience function, closing #193. Depends on #192 (PyO3 bindings).

- **`KASBAClusterer`** — class with `fit()`/`predict()` following `TimeSeriesKMeans` pattern
- **`kasba()`** — convenience function returning `DataFrame[id_col, "cluster"]`
- Supports univariate (`channel_col=None`) and multivariate (`channel_col="channel"`) data
- Pads to max length for unequal-length series
- Stores `labels_`, `centroids_`, `inertia_`, `n_iter_` on instance

## Test plan

- [x] 11 pytest tests (TDD)
- [x] `KASBAClusterer`: fit returns self, labels schema, predict matches fit, predict before fit raises, inertia non-negative, n_iter positive, reproducible with seed, centroids stored
- [x] Convenience function: correct output schema
- [x] Multivariate: fit with channel_col, independent vs dependent modes
- [x] mypy clean, ruff clean
- [x] Lazy import registration (clustering + top-level)