### PR TITLE
test: KASBA edge-cases, validation & benchmarks (#194, #195)

### DIFF
--- a/polars_ts/reconciliation.py
+++ b/polars_ts/reconciliation.py
@@ -97,7 +97,6 @@ def reconcile(
     if method not in valid_methods:
         raise ValueError(f"Unknown method {method!r}. Choose from {sorted(valid_methods)}")
 
-<<<<<<< feat/grouped-hierarchies-166
     grouped = _normalize_hierarchy(hierarchy)
 
     # Projection-based methods work with grouped hierarchies natively
@@ -118,27 +117,6 @@ def reconcile(
             tree = {k: v[0] for k, v in grouped.items()}
             return _bottom_up(df, tree, forecast_col, id_col, time_col)
         return _bottom_up_grouped(df, grouped, forecast_col, id_col, time_col)
-=======
-    if method == "middle_out":
-        if middle_level is None:
-            raise ValueError("middle_level is required for method='middle_out'")
-        return _middle_out(df, hierarchy, forecast_col, id_col, time_col, middle_level)
-    if method == "permbu":
-        if residuals is None:
-            raise ValueError("residuals is required for method='permbu'")
-        return _permbu(df, hierarchy, forecast_col, id_col, time_col, residuals)
-    if method == "mint_cv":
-        if train_data is None:
-            raise ValueError("train_data is required for method='mint_cv'")
-        return _mint_cv(df, hierarchy, forecast_col, id_col, time_col, train_data, n_folds)
-
-    # Methods that support interval_cols via projection matrix
-    if method == "bottom_up":
-        return _bottom_up(df, hierarchy, forecast_col, id_col, time_col)
-    if method == "top_down":
-        return _top_down(df, hierarchy, forecast_col, id_col, time_col)
-    return _ols(df, hierarchy, forecast_col, id_col, time_col, interval_cols=interval_cols)
->>>>>>> main
 
     # Tree-only methods
     tree = _to_tree(grouped) if not _is_tree(grouped) else {k: v[0] for k, v in grouped.items()}
@@ -317,7 +295,6 @@ def _top_down(
 
 
 def _build_summing_matrix(
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
 ) -> tuple[np.ndarray, list[str], list[str], dict[str, int]]:
     """Build the summing matrix S for tree or grouped hierarchies.
@@ -330,20 +307,12 @@ def _build_summing_matrix(
         all_parents.update(parents)
     all_nodes = sorted(set(hierarchy.keys()) | all_parents)
     bottom = _get_bottom_nodes_grouped(hierarchy)
-=======
-    hierarchy: dict[str, str],
-) -> tuple[np.ndarray, list[str], list[str], dict[str, int]]:
-    """Build the summing matrix S and return (S, all_nodes, bottom, node_idx)."""
-    all_nodes = sorted(set(hierarchy.keys()) | set(hierarchy.values()))
-    bottom = _get_bottom_nodes(hierarchy)
->>>>>>> main
     n_total = len(all_nodes)
     n_bottom = len(bottom)
     node_idx = {node: i for i, node in enumerate(all_nodes)}
 
     S = np.zeros((n_total, n_bottom))
     for j, b in enumerate(bottom):
-<<<<<<< feat/grouped-hierarchies-166
         # BFS to find all ancestors
         S[node_idx[b], j] = 1.0
         queue = [b]
@@ -412,75 +381,6 @@ def _ols(
     where S is the summing matrix.
     """
     S, all_nodes, _bottom, node_idx = _build_summing_matrix(hierarchy)
-=======
-        current = b
-        S[node_idx[current], j] = 1.0
-        while current in hierarchy:
-            current = hierarchy[current]
-            S[node_idx[current], j] = 1.0
->>>>>>> main
-
-    return S, all_nodes, bottom, node_idx
-
-
-<<<<<<< feat/grouped-hierarchies-166
-    return _apply_projection(df, P, all_nodes, node_idx, forecast_col, id_col, time_col, extra_cols=interval_cols)
-
-=======
-def _apply_projection(
-    df: pl.DataFrame,
-    P: np.ndarray,
-    all_nodes: list[str],
-    node_idx: dict[str, int],
-    forecast_col: str,
-    id_col: str,
-    time_col: str,
-    extra_cols: list[str] | None = None,
-) -> pl.DataFrame:
-    """Apply projection matrix P to forecasts, optionally to extra columns too."""
-    cols_to_project = [forecast_col] + (extra_cols or [])
-    n_total = len(all_nodes)
-    times = sorted(df[time_col].unique().to_list())
-    result_rows: list[dict[str, Any]] = []
-
-    for t in times:
-        t_data = df.filter(pl.col(time_col) == t)
-        row_map = {row[id_col]: row for row in t_data.iter_rows(named=True)}
-
-        for col in cols_to_project:
-            y_hat = np.zeros(n_total)
-            for node, idx in node_idx.items():
-                if node in row_map:
-                    y_hat[idx] = row_map[node][col]
-            if col == cols_to_project[0]:
-                y_tildes = {col: P @ y_hat}
-            else:
-                y_tildes[col] = P @ y_hat
-
-        for node, idx in node_idx.items():
-            row_dict: dict[str, Any] = {id_col: node, time_col: t}
-            for col in cols_to_project:
-                row_dict[col] = y_tildes[col][idx]
-            result_rows.append(row_dict)
-
-    return pl.DataFrame(result_rows).sort(id_col, time_col)
-
-
-def _ols(
-    df: pl.DataFrame,
-    hierarchy: dict[str, str],
-    forecast_col: str,
-    id_col: str,
-    time_col: str,
-    *,
-    interval_cols: list[str] | None = None,
-) -> pl.DataFrame:
-    """MinTrace-OLS reconciliation.
-
-    Computes reconciled forecasts as: y_tilde = S @ (S'S)^{-1} @ S' @ y_hat
-    where S is the summing matrix.
-    """
-    S, all_nodes, _bottom, node_idx = _build_summing_matrix(hierarchy)
 
     # Reconciliation: P = S @ (S'S)^{-1} @ S'
     StS_inv = np.linalg.pinv(S.T @ S)
@@ -488,7 +388,6 @@ def _ols(
 
     return _apply_projection(df, P, all_nodes, node_idx, forecast_col, id_col, time_col, extra_cols=interval_cols)
 
->>>>>>> main
 
 def _middle_out(
     df: pl.DataFrame,
@@ -503,11 +402,7 @@ def _middle_out(
     Below the middle level: disaggregate using historical proportions.
     Above the middle level: aggregate by summing children.
     """
-<<<<<<< feat/grouped-hierarchies-166
     bottom = _get_bottom_nodes_tree(hierarchy)
-=======
-    bottom = _get_bottom_nodes(hierarchy)
->>>>>>> main
 
     # --- Disaggregate downward from middle to bottom ---
     # For each middle node, find its descendant bottom nodes
@@ -587,11 +482,7 @@ def _middle_out(
 
 def _permbu(
     df: pl.DataFrame,
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
-=======
-    hierarchy: dict[str, str],
->>>>>>> main
     forecast_col: str,
     id_col: str,
     time_col: str,
@@ -633,11 +524,7 @@ def _permbu(
 
 def _mint_cv(
     df: pl.DataFrame,
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
-=======
-    hierarchy: dict[str, str],
->>>>>>> main
     forecast_col: str,
     id_col: str,
     time_col: str,

--- a/tests/clustering/test_kasba.py
+++ b/tests/clustering/test_kasba.py
@@ -1,4 +1,4 @@
-"""Tests for KASBAClusterer Python wrapper (issue #193)."""
+"""Tests for KASBAClusterer Python wrapper (issue #193, #194)."""
 
 from __future__ import annotations
 
@@ -7,6 +7,52 @@ import polars as pl
 import pytest
 
 from polars_ts.clustering.kasba import KASBAClusterer, kasba
+
+# ---------------------------------------------------------------------------
+# Helper factories for edge-case tests (#194)
+# ---------------------------------------------------------------------------
+
+
+def make_n_series(n: int, length: int, *, seed: int = 0) -> pl.DataFrame:
+    """Create *n* random series each of *length* timepoints."""
+    rng = np.random.default_rng(seed)
+    rows: dict[str, list] = {"unique_id": [], "y": []}
+    for i in range(n):
+        uid = f"S{i}"
+        vals = rng.normal(loc=i * 10.0, scale=1.0, size=length)
+        rows["unique_id"].extend([uid] * length)
+        rows["y"].extend(vals.tolist())
+    return pl.DataFrame(rows)
+
+
+def make_well_separated_series(
+    k: int = 2, n_per_cluster: int = 5, length: int = 20, separation: float = 100.0, *, seed: int = 0
+) -> pl.DataFrame:
+    """Create well-separated clusters that should converge quickly."""
+    rng = np.random.default_rng(seed)
+    rows: dict[str, list] = {"unique_id": [], "y": []}
+    idx = 0
+    for cluster_idx in range(k):
+        for _ in range(n_per_cluster):
+            vals = rng.normal(loc=cluster_idx * separation, scale=0.01, size=length)
+            uid = f"S{idx}"
+            rows["unique_id"].extend([uid] * length)
+            rows["y"].extend(vals.tolist())
+            idx += 1
+    return pl.DataFrame(rows)
+
+
+def make_borderline_series(*, seed: int = 0) -> pl.DataFrame:
+    """Create borderline-separable series for parameter sensitivity tests."""
+    rng = np.random.default_rng(seed)
+    rows: dict[str, list] = {"unique_id": [], "y": []}
+    for i in range(10):
+        uid = f"S{i}"
+        # Two groups with slight offset — sensitive to distance parameter
+        base = rng.normal(loc=(i % 2) * 2.0, scale=1.5, size=15)
+        rows["unique_id"].extend([uid] * 15)
+        rows["y"].extend(base.tolist())
+    return pl.DataFrame(rows)
 
 
 @pytest.fixture
@@ -110,3 +156,70 @@ class TestKASBAMultivariate:
         # Both produce valid output
         assert labels_ind.shape == labels_dep.shape
         assert labels_ind.shape[0] == 6
+
+
+class TestKASBAEdgeCases:
+    """Edge-case and robustness tests for KASBA clustering (issue #194)."""
+
+    def test_single_series_single_cluster(self):
+        """One series, one cluster — should assign to cluster 0."""
+        df = pl.DataFrame({"unique_id": ["A"] * 10, "y": list(range(10))})
+        result = kasba(df, k=1)
+        assert result["cluster"].to_list() == [0]
+
+    def test_k_equals_n(self):
+        """K == number of series — each series its own cluster."""
+        df = make_n_series(n=5, length=20)
+        result = kasba(df, k=5)
+        assert result["cluster"].n_unique() == 5
+
+    def test_k_greater_than_n_raises(self):
+        """K > n_series should raise ValueError."""
+        df = make_n_series(n=3, length=20)
+        with pytest.raises(ValueError, match="n_clusters.*must be <= n_cases"):
+            kasba(df, k=10)
+
+    def test_empty_cluster_recovery(self):
+        """Verify no cluster label is unused in output when k=3."""
+        df = make_well_separated_series(k=3, n_per_cluster=7, length=15, separation=200.0, seed=0)
+        result = kasba(df, k=3, seed=0)
+        assert result["cluster"].n_unique() == 3
+
+    def test_convergence_before_max_iter(self):
+        """Well-separated clusters should converge in < max_iter."""
+        df = make_well_separated_series(k=2, separation=100.0)
+        clf = KASBAClusterer(n_clusters=2, max_iter=50).fit(df)
+        assert clf.n_iter_ < 50
+
+    def test_all_identical_series(self):
+        """All series identical — should still produce valid labels."""
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 5 + ["B"] * 5 + ["C"] * 5,
+                "y": vals * 3,
+            }
+        )
+        result = kasba(df, k=2)
+        assert result.shape[0] == 3
+        assert result["cluster"].min() >= 0
+
+    def test_different_length_series_padded(self):
+        """Series of different lengths should be zero-padded."""
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * 3 + ["B"] * 5 + ["C"] * 7,
+                "y": [1.0, 2.0, 3.0] + [4.0, 5.0, 6.0, 7.0, 8.0] + [1.0] * 7,
+            }
+        )
+        result = kasba(df, k=2)
+        assert result.shape[0] == 3
+
+    def test_msm_cost_parameter_effect(self):
+        """Different c values should produce valid clusterings."""
+        df = make_borderline_series()
+        labels_low_c = kasba(df, k=2, c=0.01)
+        labels_high_c = kasba(df, k=2, c=100.0)
+        assert labels_low_c.shape == labels_high_c.shape
+        assert labels_low_c["cluster"].n_unique() >= 1
+        assert labels_high_c["cluster"].n_unique() >= 1

--- a/tests/clustering/test_kasba_validation.py
+++ b/tests/clustering/test_kasba_validation.py
@@ -1,0 +1,181 @@
+"""Validation and benchmark tests for KASBA clustering (issue #195)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from polars_ts_rs.polars_ts_rs import kasba_fit
+from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+
+from polars_ts.clustering.kasba import kasba
+
+try:
+    from aeon.clustering import TimeSeriesKMeans
+
+    HAS_AEON = True
+except ImportError:
+    HAS_AEON = False
+
+# ---------------------------------------------------------------------------
+# Synthetic data generators with known ground-truth labels
+# ---------------------------------------------------------------------------
+
+
+def make_synthetic_clusters(
+    k: int = 3,
+    n_per_cluster: int = 20,
+    length: int = 50,
+    noise: float = 0.1,
+    *,
+    seed: int = 42,
+) -> tuple[pl.DataFrame, list[int]]:
+    """Create synthetic time series with known cluster membership.
+
+    Each cluster has a distinct base pattern (sinusoid with different
+    frequency), and series within a cluster are noisy copies.
+
+    Returns (DataFrame, ground_truth_labels) where labels are ordered
+    by sorted unique_id.
+    """
+    rng = np.random.default_rng(seed)
+    rows: dict[str, list] = {"unique_id": [], "y": []}
+    labels: dict[str, int] = {}
+    t = np.linspace(0, 2 * np.pi, length)
+
+    idx = 0
+    for cluster in range(k):
+        # Each cluster gets a distinct sinusoidal frequency
+        freq = 1.0 + cluster * 2.0
+        base = np.sin(freq * t) * (cluster + 1)
+        for _ in range(n_per_cluster):
+            uid = f"S{idx:04d}"
+            vals = base + rng.normal(0, noise, size=length)
+            rows["unique_id"].extend([uid] * length)
+            rows["y"].extend(vals.tolist())
+            labels[uid] = cluster
+            idx += 1
+
+    df = pl.DataFrame(rows)
+    # Return labels sorted by unique_id to match kasba() output order
+    sorted_ids = sorted(labels.keys())
+    true_labels = [labels[uid] for uid in sorted_ids]
+    return df, true_labels
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestKASBAValidation:
+    """Validate KASBA clustering quality against known ground truth."""
+
+    def test_ari_on_synthetic_clusters(self):
+        """Known ground-truth clusters — ARI should be > 0.9."""
+        df, true_labels = make_synthetic_clusters(k=3, n_per_cluster=20, length=50, noise=0.1)
+        result = kasba(df, k=3, seed=42)
+        predicted = result.sort("unique_id")["cluster"].to_list()
+        ari = adjusted_rand_score(true_labels, predicted)
+        assert ari > 0.9, f"ARI {ari:.3f} is below 0.9 threshold"
+
+    def test_nmi_on_synthetic_clusters(self):
+        """NMI should be > 0.85 on well-separated synthetic data."""
+        df, true_labels = make_synthetic_clusters(k=3, n_per_cluster=20, length=50, noise=0.1)
+        result = kasba(df, k=3, seed=42)
+        predicted = result.sort("unique_id")["cluster"].to_list()
+        nmi = normalized_mutual_info_score(true_labels, predicted)
+        assert nmi > 0.85, f"NMI {nmi:.3f} is below 0.85 threshold"
+
+    def test_ari_degrades_with_noise(self):
+        """Higher noise should produce lower (but still reasonable) ARI."""
+        df_low, labels_low = make_synthetic_clusters(k=3, n_per_cluster=15, length=40, noise=0.05)
+        df_high, labels_high = make_synthetic_clusters(k=3, n_per_cluster=15, length=40, noise=0.5)
+
+        result_low = kasba(df_low, k=3, seed=42)
+        result_high = kasba(df_high, k=3, seed=42)
+
+        ari_low = adjusted_rand_score(labels_low, result_low.sort("unique_id")["cluster"].to_list())
+        ari_high = adjusted_rand_score(labels_high, result_high.sort("unique_id")["cluster"].to_list())
+
+        assert ari_low >= ari_high, f"Low-noise ARI {ari_low:.3f} < high-noise ARI {ari_high:.3f}"
+        assert ari_low > 0.8, f"Low-noise ARI {ari_low:.3f} is below 0.8"
+
+    @pytest.mark.skipif(not HAS_AEON, reason="aeon not installed")
+    def test_clustering_quality_vs_aeon(self):
+        """ARI between polars-ts KASBA and aeon should be > 0.8."""
+        df, true_labels = make_synthetic_clusters(k=3, n_per_cluster=15, length=30, noise=0.1)
+
+        # polars-ts KASBA
+        result_pts = kasba(df, k=3, seed=42)
+        predicted_pts = result_pts.sort("unique_id")["cluster"].to_list()
+
+        # aeon reference
+        sorted_ids = sorted(df["unique_id"].unique().to_list())
+        data_3d = np.zeros((len(sorted_ids), 1, 30))
+        for i, uid in enumerate(sorted_ids):
+            vals = df.filter(pl.col("unique_id") == uid)["y"].to_numpy()
+            data_3d[i, 0, : len(vals)] = vals
+
+        aeon_km = TimeSeriesKMeans(n_clusters=3, metric="msm", random_state=42)
+        aeon_labels = aeon_km.fit_predict(data_3d)
+
+        ari = adjusted_rand_score(aeon_labels, predicted_pts)
+        assert ari > 0.8, f"Cross-impl ARI {ari:.3f} is below 0.8 threshold"
+
+
+# ---------------------------------------------------------------------------
+# Benchmark tests
+# ---------------------------------------------------------------------------
+
+
+class TestKASBABenchmark:
+    """Benchmark KASBA performance using pytest-benchmark."""
+
+    def test_kasba_fit_100x100(self, benchmark):
+        """Benchmark full KASBA fit on 100 series x 100 timepoints."""
+        rng = np.random.default_rng(0)
+        data = np.zeros((100, 1, 100), dtype=np.float64)
+        for i in range(100):
+            cluster = i % 5
+            data[i, 0, :] = rng.normal(loc=cluster * 10.0, scale=0.5, size=100)
+
+        result = benchmark(
+            kasba_fit,
+            data,
+            n_clusters=5,
+            c=1.0,
+            independent=True,
+            ba_subset_size=0.5,
+            initial_step_size=0.05,
+            decay_rate=0.1,
+            n_iters=10,
+            random_seed=42,
+        )
+        labels, centers, inertia, n_iter = result
+        assert len(labels) == 100
+        assert centers.shape[0] == 5
+
+    def test_kasba_fit_50x200(self, benchmark):
+        """Benchmark KASBA fit on 50 series x 200 timepoints (longer series)."""
+        rng = np.random.default_rng(0)
+        data = np.zeros((50, 1, 200), dtype=np.float64)
+        for i in range(50):
+            cluster = i % 3
+            data[i, 0, :] = rng.normal(loc=cluster * 20.0, scale=1.0, size=200)
+
+        result = benchmark(
+            kasba_fit,
+            data,
+            n_clusters=3,
+            c=1.0,
+            independent=True,
+            ba_subset_size=0.5,
+            initial_step_size=0.05,
+            decay_rate=0.1,
+            n_iters=10,
+            random_seed=42,
+        )
+        labels, centers, inertia, n_iter = result
+        assert len(labels) == 50
+        assert centers.shape[0] == 3

--- a/tests/clustering/test_kasba_validation.py
+++ b/tests/clustering/test_kasba_validation.py
@@ -6,9 +6,15 @@ import numpy as np
 import polars as pl
 import pytest
 from polars_ts_rs.polars_ts_rs import kasba_fit
-from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
 
 from polars_ts.clustering.kasba import kasba
+
+try:
+    from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+
+    HAS_SKLEARN = True
+except ImportError:
+    HAS_SKLEARN = False
 
 try:
     from aeon.clustering import TimeSeriesKMeans
@@ -68,6 +74,7 @@ def make_synthetic_clusters(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not HAS_SKLEARN, reason="scikit-learn not installed")
 class TestKASBAValidation:
     """Validate KASBA clustering quality against known ground truth."""
 


### PR DESCRIPTION
## Summary
- Add 8 edge-case/robustness tests for KASBA clustering (#194)
- Add 3 validation tests (ARI, NMI, noise degradation) + 2 benchmarks (#195)
- Fix unresolved merge conflict markers in `reconciliation.py`
- 3 helper factories for edge-case data, 1 synthetic cluster generator for validation

## Tests added

### Edge cases (`test_kasba.py`) — #194
| Test | Boundary condition |
|------|--------------------|
| `test_single_series_single_cluster` | n=1, k=1 |
| `test_k_equals_n` | k == n_series |
| `test_k_greater_than_n_raises` | k > n_series → `ValueError` |
| `test_empty_cluster_recovery` | All k clusters populated |
| `test_convergence_before_max_iter` | Early convergence on trivial data |
| `test_all_identical_series` | Degenerate identical series |
| `test_different_length_series_padded` | Variable-length zero-padding |
| `test_msm_cost_parameter_effect` | Extreme MSM cost values |

### Validation & benchmarks (`test_kasba_validation.py`) — #195
| Test | Metric |
|------|--------|
| `test_ari_on_synthetic_clusters` | ARI > 0.9 |
| `test_nmi_on_synthetic_clusters` | NMI > 0.85 |
| `test_ari_degrades_with_noise` | Low-noise ARI ≥ high-noise ARI |
| `test_clustering_quality_vs_aeon` | Cross-impl ARI > 0.8 (skipped if aeon not installed) |
| `test_kasba_fit_100x100` | Benchmark: 100 series × 100 timepoints |
| `test_kasba_fit_50x200` | Benchmark: 50 series × 200 timepoints |

## Test plan
- [x] All 8 edge-case tests passing
- [x] ARI > 0.9 on synthetic clusters
- [x] NMI > 0.85 on synthetic clusters
- [x] 2 benchmark tests producing reasonable numbers
- [x] Validation tests skip gracefully when scikit-learn/aeon not installed
- [x] ruff check + format clean
- [x] No regression in existing test suite

Closes #194
Closes #195