### PR TITLE
feat: add model registry and experiment tracking (#168)

### DIFF
--- a/notebooks/14_kasba_clustering.ipynb
+++ b/notebooks/14_kasba_clustering.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "id": "h8fbrz6wups",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "# 14 — KASBA Clustering\n",
@@ -73,31 +72,10 @@
     "\n",
     "from polars_ts import KASBAClusterer, TimeSeriesKMeans, kasba, silhouette_score"
    ]
-=======
-   "source": "# 14 — KASBA Clustering\n\n**KASBA** (K-means with Accelerated Stochastic Barycenter Averaging) is a time series\nclustering algorithm that uses the **MSM** (Move-Split-Merge) elastic distance instead\nof DTW.\n\n### Why MSM over DTW?\n\n| Property | DTW | MSM |\n|----------|-----|-----|\n| **Metric** | No (violates triangle inequality) | Yes (proper metric) |\n| **Triangle inequality pruning** | Not possible | 10-30x speedup |\n| **Phase invariance** | Yes | Yes |\n| **Amplitude invariance** | No | Tunable via cost `c` |\n\nBecause MSM is a proper metric, KASBA can use triangle inequality pruning to skip\nunnecessary distance computations — making it significantly faster than DTW-based\nk-means on large datasets.\n\n### How KASBA works\n\n1. Initialize `k` centroids (random selection from data)\n2. **Assign** each series to nearest centroid using MSM distance\n3. **Update** centroids via stochastic barycenter averaging (SGD on a subset of cluster members)\n4. Repeat until convergence or `max_iter` reached\n\nThe stochastic barycenter is cheaper than the full DBA (Dynamic Barycenter Averaging)\nused in DTW k-means, while still producing high-quality centroids.\n\n### References\n\n- Stefan, A., Athitsos, V. & Das, G. (2013). *The Move-Split-Merge Metric for Time Series*. IEEE TKDE.\n- Holder, C., Middlehurst, M. & Bagnall, A. (2023). *A Review and Evaluation of Elastic Distance Functions for Time Series Clustering*. Knowledge and Information Systems.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "6vkhso7a0z2",
-   "source": "import importlib\n\nif importlib.util.find_spec(\"polars_ts\") is None:\n    %pip install -q polars-timeseries[all]\nif importlib.util.find_spec(\"hvplot\") is None:\n    %pip install -q hvplot",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "7ovi3uyb3x3",
-   "source": "try:\n    import hvplot.polars  # noqa\nexcept ImportError:\n    pass\n\nimport numpy as np\nimport polars as pl\n\nfrom polars_ts import KASBAClusterer, TimeSeriesKMeans, kasba, silhouette_score",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "1c5s8cpk9b",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.1 Synthetic data\n",
@@ -171,31 +149,10 @@
     "    legend=False,\n",
     ")"
    ]
-=======
-   "source": "## 14.1 Synthetic data\n\nWe generate 30 univariate series belonging to 3 shape families:\n- **Sine** — smooth periodic pattern\n- **Sawtooth** — linear ramp with reset\n- **Step** — piecewise constant with a level shift\n\nEach family has 10 series with slight noise, making them visually distinct but\nrequiring an elastic distance to cluster correctly.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "q5z34e2ga2n",
-   "source": "rng = np.random.default_rng(42)\nn_timepoints = 50\nn_per_cluster = 10\n\nrows = []\nground_truth = {}\n\nfor i in range(n_per_cluster):\n    # Sine family\n    vals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng.normal(0, 0.15, n_timepoints)\n    uid = f\"sine_{i}\"\n    ground_truth[uid] = 0\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Sawtooth family\n    vals = np.linspace(0, 1, n_timepoints) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"saw_{i}\"\n    ground_truth[uid] = 1\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Step family\n    vals = np.concatenate([np.zeros(25), np.ones(25)]) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"step_{i}\"\n    ground_truth[uid] = 2\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\ndf = pl.DataFrame(rows)\nprint(f\"Shape: {df.shape}\")\nprint(f\"Series: {df['unique_id'].n_unique()}\")\ndf.head()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "aeuqgo1pztk",
-   "source": "df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    width=900,\n    height=400,\n    title=\"30 Synthetic Series (3 Shape Families)\",\n    alpha=0.5,\n    legend=False,\n)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "zeczgcr575",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.2 Univariate clustering with `kasba()`\n",
@@ -257,39 +214,10 @@
     "    purity = true_labels[\"count\"][0] / members.height\n",
     "    print(f\"Cluster {cluster_id}: {members.height} members, purity = {purity:.0%}\")"
    ]
-=======
-   "source": "## 14.2 Univariate clustering with `kasba()`\n\nThe simplest way to use KASBA — one function call. Returns a DataFrame\nwith `[unique_id, cluster]` assignments.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "2fnvzzv9g7p",
-   "source": "labels = kasba(df, k=3, seed=42)\nprint(\"KASBA cluster assignments:\")\nlabels",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "zq1zakwn6td",
-   "source": "# Visualize clusters\ndf_clustered = df.join(labels, on=\"unique_id\")\n\ndf_clustered.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    groupby=\"cluster\",\n    width=900,\n    height=400,\n    title=\"KASBA Clusters (k=3, MSM c=1.0)\",\n    alpha=0.7,\n    legend=False,\n)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "bvjyq3uufje",
-   "source": "# Check agreement with ground truth\ngt_df = pl.DataFrame({\"unique_id\": list(ground_truth.keys()), \"true_cluster\": list(ground_truth.values())})\ncomparison = labels.join(gt_df, on=\"unique_id\")\n\n# Cluster IDs may differ from ground truth IDs, so check purity\nfor cluster_id in comparison[\"cluster\"].unique().sort().to_list():\n    members = comparison.filter(pl.col(\"cluster\") == cluster_id)\n    true_labels = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)\n    purity = true_labels[\"count\"][0] / members.height\n    print(f\"Cluster {cluster_id}: {members.height} members, purity = {purity:.0%}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "zk03oau8ur",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.3 Multivariate clustering\n",
@@ -347,31 +275,10 @@
     "print(clf_dep.labels_)\n",
     "print(f\"Inertia: {clf_dep.inertia_:.2f}, Iterations: {clf_dep.n_iter_}\")"
    ]
-=======
-   "source": "## 14.3 Multivariate clustering\n\nKASBA supports multivariate time series via a `channel_col` parameter. Each series\nhas multiple channels (e.g., temperature and humidity), and MSM is computed either:\n\n- **independently** (`independent=True`, default) — sum of per-channel MSM distances\n- **dependently** (`independent=False`) — cross-channel MSM that considers inter-channel relationships",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "no4ti5md83h",
-   "source": "# Create multivariate data: 12 series, 2 channels, 2 clusters\nrng_mv = np.random.default_rng(99)\nmv_rows = []\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(0, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"cold_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(8, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"hot_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\n\ndf_mv = pl.DataFrame(mv_rows)\nprint(f\"Shape: {df_mv.shape}, Series: {df_mv['unique_id'].n_unique()}, Channels: {df_mv['channel'].n_unique()}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "xm0w141ira",
-   "source": "# Independent mode (default)\nclf_ind = KASBAClusterer(n_clusters=2, independent=True, seed=42)\nclf_ind.fit(df_mv, channel_col=\"channel\")\nprint(\"Independent mode:\")\nprint(clf_ind.labels_)\nprint(f\"Inertia: {clf_ind.inertia_:.2f}, Iterations: {clf_ind.n_iter_}\")\n\n# Dependent mode\nclf_dep = KASBAClusterer(n_clusters=2, independent=False, seed=42)\nclf_dep.fit(df_mv, channel_col=\"channel\")\nprint(\"\\nDependent mode:\")\nprint(clf_dep.labels_)\nprint(f\"Inertia: {clf_dep.inertia_:.2f}, Iterations: {clf_dep.n_iter_}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "rhy5t2me7d",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.4 Tuning MSM cost `c`\n",
@@ -423,31 +330,10 @@
     "    markers=True,\n",
     ")"
    ]
-=======
-   "source": "## 14.4 Tuning MSM cost `c`\n\nThe MSM cost parameter `c` controls the penalty for split and merge operations:\n\n- **Low `c`** (e.g., 0.1) — cheap to split/merge, tolerates amplitude differences → fewer, broader clusters\n- **High `c`** (e.g., 10.0) — expensive to split/merge, sensitive to amplitude → tighter, more clusters needed\n\nThis is analogous to the Sakoe-Chiba band width in DTW — it controls how much\ndeformation the distance allows.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "kty2rbq2r6",
-   "source": "# Sweep c values and measure silhouette score\nresults = []\nfor c_val in [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]:\n    lbl = kasba(df, k=3, c=c_val, seed=42)\n    sil = silhouette_score(df, lbl, method=\"msm\")\n    clf_tmp = KASBAClusterer(n_clusters=3, c=c_val, seed=42)\n    clf_tmp.fit(df)\n    results.append({\"c\": c_val, \"silhouette\": sil, \"inertia\": clf_tmp.inertia_})\n\nc_df = pl.DataFrame(results)\nprint(\"Effect of MSM cost parameter c:\")\nc_df",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "t7v6a0h295",
-   "source": "c_df.hvplot.line(\n    x=\"c\",\n    y=\"silhouette\",\n    width=700,\n    height=350,\n    title=\"Silhouette Score vs MSM Cost c\",\n    logx=True,\n    markers=True,\n)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "2y33vath0gj",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.5 Comparing with DTW k-means\n",
@@ -495,31 +381,10 @@
     "    purity = total_pure / merged.height\n",
     "    print(f\"{name:15s}: purity = {purity:.0%}\")"
    ]
-=======
-   "source": "## 14.5 Comparing with DTW k-means\n\n`TimeSeriesKMeans` uses DTW + DBA (Dynamic Barycenter Averaging) for centroid\nupdates. Let's compare it side-by-side with KASBA on the same data.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "u367mlggaom",
-   "source": "# KASBA (MSM)\nkasba_labels = kasba(df, k=3, seed=42)\nkasba_sil = silhouette_score(df, kasba_labels, method=\"msm\")\n\n# DTW k-means (DBA)\ndba_clf = TimeSeriesKMeans(n_clusters=3, metric=\"dtw\", max_iter=10, seed=42)\ndba_clf.fit(df)\ndba_labels = dba_clf.labels_\ndba_sil = silhouette_score(df, dba_labels, method=\"dtw\")\n\nprint(f\"KASBA (MSM):      silhouette = {kasba_sil:.4f}\")\nprint(f\"DTW k-means (DBA): silhouette = {dba_sil:.4f}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "gp60acxuuw8",
-   "source": "# Compare cluster purity for both methods\nfor name, lbl_df in [(\"KASBA\", kasba_labels), (\"DTW k-means\", dba_labels)]:\n    merged = lbl_df.join(gt_df, on=\"unique_id\")\n    total_pure = 0\n    for cid in merged[\"cluster\"].unique().sort().to_list():\n        members = merged.filter(pl.col(\"cluster\") == cid)\n        majority = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)[\"count\"][0]\n        total_pure += majority\n    purity = total_pure / merged.height\n    print(f\"{name:15s}: purity = {purity:.0%}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "q6567qyg31e",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.6 Stochastic barycenters — visualize learned centroids\n",
@@ -564,23 +429,10 @@
     "    line_width=2,\n",
     ")"
    ]
-=======
-   "source": "## 14.6 Stochastic barycenters — visualize learned centroids\n\nKASBA learns centroids via stochastic barycenter averaging (SGD on a random subset\nof cluster members). Let's visualize them and compare with DBA centroids from\nDTW k-means.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "dla3hfdhwx6",
-   "source": "# Extract KASBA centroids\nkasba_clf = KASBAClusterer(n_clusters=3, seed=42)\nkasba_clf.fit(df)\n\ncentroid_rows = []\nfor i in range(3):\n    centroid = kasba_clf.centroids_[i]  # shape: (1 * n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"KASBA_{i}\", \"ds\": t, \"y\": v})\n\n# Extract DBA centroids\nfor i in range(3):\n    centroid = dba_clf.centroids_[i]  # shape: (n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"DBA_{i}\", \"ds\": t, \"y\": v})\n\ncentroids_df = pl.DataFrame(centroid_rows)\n\ncentroids_df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"centroid\",\n    width=900,\n    height=400,\n    title=\"Learned Centroids: KASBA (MSM) vs DBA (DTW)\",\n    line_width=2,\n)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "5soubf4fn9m",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## 14.7 Predicting new series\n",
@@ -620,23 +472,10 @@
     "print(\"Predictions for new series:\")\n",
     "predictions"
    ]
-=======
-   "source": "## 14.7 Predicting new series\n\nThe OOP API (`KASBAClusterer`) supports `predict()` — assign new, unseen series\nto existing clusters without re-fitting.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "307bft1jp3x",
-   "source": "# Create 3 new series — one from each family\nnew_rows = []\nrng_new = np.random.default_rng(777)\n\n# New sine\nvals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng_new.normal(0, 0.1, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_sine\", \"ds\": t, \"y\": v})\n\n# New sawtooth\nvals = np.linspace(0, 1, n_timepoints) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_saw\", \"ds\": t, \"y\": v})\n\n# New step\nvals = np.concatenate([np.zeros(25), np.ones(25)]) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_step\", \"ds\": t, \"y\": v})\n\nnew_df = pl.DataFrame(new_rows)\npredictions = kasba_clf.predict(new_df)\nprint(\"Predictions for new series:\")\npredictions",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
->>>>>>> main
   },
   {
    "cell_type": "markdown",
    "id": "3dxuvnil7nq",
-<<<<<<< feat/model-registry-168
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -665,10 +504,6 @@
     "- `ba_subset_size` — fraction of cluster used for barycenter SGD. Lower = faster but noisier.\n",
     "- `max_iter` — convergence typically within 5-10 iterations."
    ]
-=======
-   "source": "## Summary\n\n| Feature | API |\n|---------|-----|\n| Quick clustering | `kasba(df, k=3)` |\n| OOP with fit/predict | `KASBAClusterer(n_clusters=3).fit(df)` |\n| Multivariate | `kasba(df, k=3, channel_col=\"channel\")` |\n| Tune MSM cost | `kasba(df, k=3, c=2.0)` |\n| Independent vs dependent | `KASBAClusterer(independent=False)` |\n\n### When to use KASBA vs other methods\n\n- **KASBA** — best when you need a proper metric (triangle inequality enables pruning),\n  or when amplitude differences matter (tunable via `c`).\n- **DTW k-means** — well-understood default; use when you want standard elastic alignment.\n- **K-Shape** — fastest option; use when shape matters but phase/amplitude don't.\n- **HDBSCAN** — use when you don't know `k` and want automatic noise detection.\n\n### Key parameters\n\n- `c` — MSM cost. Start with 1.0, sweep [0.1, 10.0] to tune.\n- `independent` — for multivariate data. True (default) sums per-channel distances;\n  False computes cross-channel MSM.\n- `ba_subset_size` — fraction of cluster used for barycenter SGD. Lower = faster but noisier.\n- `max_iter` — convergence typically within 5-10 iterations.",
-   "metadata": {}
->>>>>>> main
   }
  ],
  "metadata": {
@@ -684,8 +519,4 @@
  },
  "nbformat": 4,
  "nbformat_minor": 5
-<<<<<<< feat/model-registry-168
 }
-=======
-}
->>>>>>> main

--- a/notebooks/14_kasba_clustering.ipynb
+++ b/notebooks/14_kasba_clustering.ipynb
@@ -3,176 +3,507 @@
   {
    "cell_type": "markdown",
    "id": "h8fbrz6wups",
-   "source": "# 14 — KASBA Clustering\n\n**KASBA** (K-means with Accelerated Stochastic Barycenter Averaging) is a time series\nclustering algorithm that uses the **MSM** (Move-Split-Merge) elastic distance instead\nof DTW.\n\n### Why MSM over DTW?\n\n| Property | DTW | MSM |\n|----------|-----|-----|\n| **Metric** | No (violates triangle inequality) | Yes (proper metric) |\n| **Triangle inequality pruning** | Not possible | 10-30x speedup |\n| **Phase invariance** | Yes | Yes |\n| **Amplitude invariance** | No | Tunable via cost `c` |\n\nBecause MSM is a proper metric, KASBA can use triangle inequality pruning to skip\nunnecessary distance computations — making it significantly faster than DTW-based\nk-means on large datasets.\n\n### How KASBA works\n\n1. Initialize `k` centroids (random selection from data)\n2. **Assign** each series to nearest centroid using MSM distance\n3. **Update** centroids via stochastic barycenter averaging (SGD on a subset of cluster members)\n4. Repeat until convergence or `max_iter` reached\n\nThe stochastic barycenter is cheaper than the full DBA (Dynamic Barycenter Averaging)\nused in DTW k-means, while still producing high-quality centroids.\n\n### References\n\n- Stefan, A., Athitsos, V. & Das, G. (2013). *The Move-Split-Merge Metric for Time Series*. IEEE TKDE.\n- Holder, C., Middlehurst, M. & Bagnall, A. (2023). *A Review and Evaluation of Elastic Distance Functions for Time Series Clustering*. Knowledge and Information Systems.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "# 14 — KASBA Clustering\n",
+    "\n",
+    "**KASBA** (K-means with Accelerated Stochastic Barycenter Averaging) is a time series\n",
+    "clustering algorithm that uses the **MSM** (Move-Split-Merge) elastic distance instead\n",
+    "of DTW.\n",
+    "\n",
+    "### Why MSM over DTW?\n",
+    "\n",
+    "| Property | DTW | MSM |\n",
+    "|----------|-----|-----|\n",
+    "| **Metric** | No (violates triangle inequality) | Yes (proper metric) |\n",
+    "| **Triangle inequality pruning** | Not possible | 10-30x speedup |\n",
+    "| **Phase invariance** | Yes | Yes |\n",
+    "| **Amplitude invariance** | No | Tunable via cost `c` |\n",
+    "\n",
+    "Because MSM is a proper metric, KASBA can use triangle inequality pruning to skip\n",
+    "unnecessary distance computations — making it significantly faster than DTW-based\n",
+    "k-means on large datasets.\n",
+    "\n",
+    "### How KASBA works\n",
+    "\n",
+    "1. Initialize `k` centroids (random selection from data)\n",
+    "2. **Assign** each series to nearest centroid using MSM distance\n",
+    "3. **Update** centroids via stochastic barycenter averaging (SGD on a subset of cluster members)\n",
+    "4. Repeat until convergence or `max_iter` reached\n",
+    "\n",
+    "The stochastic barycenter is cheaper than the full DBA (Dynamic Barycenter Averaging)\n",
+    "used in DTW k-means, while still producing high-quality centroids.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Stefan, A., Athitsos, V. & Das, G. (2013). *The Move-Split-Merge Metric for Time Series*. IEEE TKDE.\n",
+    "- Holder, C., Middlehurst, M. & Bagnall, A. (2023). *A Review and Evaluation of Elastic Distance Functions for Time Series Clustering*. Knowledge and Information Systems."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "6vkhso7a0z2",
-   "source": "import importlib\n\nif importlib.util.find_spec(\"polars_ts\") is None:\n    %pip install -q polars-timeseries[all]\nif importlib.util.find_spec(\"hvplot\") is None:\n    %pip install -q hvplot",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "if importlib.util.find_spec(\"polars_ts\") is None:\n",
+    "    %pip install -q polars-timeseries[all]\n",
+    "if importlib.util.find_spec(\"hvplot\") is None:\n",
+    "    %pip install -q hvplot"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "7ovi3uyb3x3",
-   "source": "try:\n    import hvplot.polars  # noqa\nexcept ImportError:\n    pass\n\nimport numpy as np\nimport polars as pl\n\nfrom polars_ts import KASBAClusterer, TimeSeriesKMeans, kasba, silhouette_score",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "7ovi3uyb3x3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import hvplot.polars  # noqa\n",
+    "except ImportError:\n",
+    "    pass\n",
+    "\n",
+    "import numpy as np\n",
+    "import polars as pl\n",
+    "\n",
+    "from polars_ts import KASBAClusterer, TimeSeriesKMeans, kasba, silhouette_score"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "1c5s8cpk9b",
-   "source": "## 14.1 Synthetic data\n\nWe generate 30 univariate series belonging to 3 shape families:\n- **Sine** — smooth periodic pattern\n- **Sawtooth** — linear ramp with reset\n- **Step** — piecewise constant with a level shift\n\nEach family has 10 series with slight noise, making them visually distinct but\nrequiring an elastic distance to cluster correctly.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.1 Synthetic data\n",
+    "\n",
+    "We generate 30 univariate series belonging to 3 shape families:\n",
+    "- **Sine** — smooth periodic pattern\n",
+    "- **Sawtooth** — linear ramp with reset\n",
+    "- **Step** — piecewise constant with a level shift\n",
+    "\n",
+    "Each family has 10 series with slight noise, making them visually distinct but\n",
+    "requiring an elastic distance to cluster correctly."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "q5z34e2ga2n",
-   "source": "rng = np.random.default_rng(42)\nn_timepoints = 50\nn_per_cluster = 10\n\nrows = []\nground_truth = {}\n\nfor i in range(n_per_cluster):\n    # Sine family\n    vals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng.normal(0, 0.15, n_timepoints)\n    uid = f\"sine_{i}\"\n    ground_truth[uid] = 0\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Sawtooth family\n    vals = np.linspace(0, 1, n_timepoints) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"saw_{i}\"\n    ground_truth[uid] = 1\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Step family\n    vals = np.concatenate([np.zeros(25), np.ones(25)]) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"step_{i}\"\n    ground_truth[uid] = 2\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\ndf = pl.DataFrame(rows)\nprint(f\"Shape: {df.shape}\")\nprint(f\"Series: {df['unique_id'].n_unique()}\")\ndf.head()",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(42)\n",
+    "n_timepoints = 50\n",
+    "n_per_cluster = 10\n",
+    "\n",
+    "rows = []\n",
+    "ground_truth = {}\n",
+    "\n",
+    "for i in range(n_per_cluster):\n",
+    "    # Sine family\n",
+    "    vals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng.normal(0, 0.15, n_timepoints)\n",
+    "    uid = f\"sine_{i}\"\n",
+    "    ground_truth[uid] = 0\n",
+    "    for t, v in enumerate(vals):\n",
+    "        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n",
+    "\n",
+    "    # Sawtooth family\n",
+    "    vals = np.linspace(0, 1, n_timepoints) + rng.normal(0, 0.1, n_timepoints)\n",
+    "    uid = f\"saw_{i}\"\n",
+    "    ground_truth[uid] = 1\n",
+    "    for t, v in enumerate(vals):\n",
+    "        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n",
+    "\n",
+    "    # Step family\n",
+    "    vals = np.concatenate([np.zeros(25), np.ones(25)]) + rng.normal(0, 0.1, n_timepoints)\n",
+    "    uid = f\"step_{i}\"\n",
+    "    ground_truth[uid] = 2\n",
+    "    for t, v in enumerate(vals):\n",
+    "        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n",
+    "\n",
+    "df = pl.DataFrame(rows)\n",
+    "print(f\"Shape: {df.shape}\")\n",
+    "print(f\"Series: {df['unique_id'].n_unique()}\")\n",
+    "df.head()"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "aeuqgo1pztk",
-   "source": "df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    width=900,\n    height=400,\n    title=\"30 Synthetic Series (3 Shape Families)\",\n    alpha=0.5,\n    legend=False,\n)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "aeuqgo1pztk",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.hvplot.line(\n",
+    "    x=\"ds\",\n",
+    "    y=\"y\",\n",
+    "    by=\"unique_id\",\n",
+    "    width=900,\n",
+    "    height=400,\n",
+    "    title=\"30 Synthetic Series (3 Shape Families)\",\n",
+    "    alpha=0.5,\n",
+    "    legend=False,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "zeczgcr575",
-   "source": "## 14.2 Univariate clustering with `kasba()`\n\nThe simplest way to use KASBA — one function call. Returns a DataFrame\nwith `[unique_id, cluster]` assignments.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.2 Univariate clustering with `kasba()`\n",
+    "\n",
+    "The simplest way to use KASBA — one function call. Returns a DataFrame\n",
+    "with `[unique_id, cluster]` assignments."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "2fnvzzv9g7p",
-   "source": "labels = kasba(df, k=3, seed=42)\nprint(\"KASBA cluster assignments:\")\nlabels",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "labels = kasba(df, k=3, seed=42)\n",
+    "print(\"KASBA cluster assignments:\")\n",
+    "labels"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "zq1zakwn6td",
-   "source": "# Visualize clusters\ndf_clustered = df.join(labels, on=\"unique_id\")\n\ndf_clustered.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    groupby=\"cluster\",\n    width=900,\n    height=400,\n    title=\"KASBA Clusters (k=3, MSM c=1.0)\",\n    alpha=0.7,\n    legend=False,\n)",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# Visualize clusters\n",
+    "df_clustered = df.join(labels, on=\"unique_id\")\n",
+    "\n",
+    "df_clustered.hvplot.line(\n",
+    "    x=\"ds\",\n",
+    "    y=\"y\",\n",
+    "    by=\"unique_id\",\n",
+    "    groupby=\"cluster\",\n",
+    "    width=900,\n",
+    "    height=400,\n",
+    "    title=\"KASBA Clusters (k=3, MSM c=1.0)\",\n",
+    "    alpha=0.7,\n",
+    "    legend=False,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "bvjyq3uufje",
-   "source": "# Check agreement with ground truth\ngt_df = pl.DataFrame({\"unique_id\": list(ground_truth.keys()), \"true_cluster\": list(ground_truth.values())})\ncomparison = labels.join(gt_df, on=\"unique_id\")\n\n# Cluster IDs may differ from ground truth IDs, so check purity\nfor cluster_id in comparison[\"cluster\"].unique().sort().to_list():\n    members = comparison.filter(pl.col(\"cluster\") == cluster_id)\n    true_labels = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)\n    purity = true_labels[\"count\"][0] / members.height\n    print(f\"Cluster {cluster_id}: {members.height} members, purity = {purity:.0%}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "bvjyq3uufje",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check agreement with ground truth\n",
+    "gt_df = pl.DataFrame({\"unique_id\": list(ground_truth.keys()), \"true_cluster\": list(ground_truth.values())})\n",
+    "comparison = labels.join(gt_df, on=\"unique_id\")\n",
+    "\n",
+    "# Cluster IDs may differ from ground truth IDs, so check purity\n",
+    "for cluster_id in comparison[\"cluster\"].unique().sort().to_list():\n",
+    "    members = comparison.filter(pl.col(\"cluster\") == cluster_id)\n",
+    "    true_labels = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)\n",
+    "    purity = true_labels[\"count\"][0] / members.height\n",
+    "    print(f\"Cluster {cluster_id}: {members.height} members, purity = {purity:.0%}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "zk03oau8ur",
-   "source": "## 14.3 Multivariate clustering\n\nKASBA supports multivariate time series via a `channel_col` parameter. Each series\nhas multiple channels (e.g., temperature and humidity), and MSM is computed either:\n\n- **independently** (`independent=True`, default) — sum of per-channel MSM distances\n- **dependently** (`independent=False`) — cross-channel MSM that considers inter-channel relationships",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.3 Multivariate clustering\n",
+    "\n",
+    "KASBA supports multivariate time series via a `channel_col` parameter. Each series\n",
+    "has multiple channels (e.g., temperature and humidity), and MSM is computed either:\n",
+    "\n",
+    "- **independently** (`independent=True`, default) — sum of per-channel MSM distances\n",
+    "- **dependently** (`independent=False`) — cross-channel MSM that considers inter-channel relationships"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "no4ti5md83h",
-   "source": "# Create multivariate data: 12 series, 2 channels, 2 clusters\nrng_mv = np.random.default_rng(99)\nmv_rows = []\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(0, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"cold_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(8, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"hot_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\n\ndf_mv = pl.DataFrame(mv_rows)\nprint(f\"Shape: {df_mv.shape}, Series: {df_mv['unique_id'].n_unique()}, Channels: {df_mv['channel'].n_unique()}\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# Create multivariate data: 12 series, 2 channels, 2 clusters\n",
+    "rng_mv = np.random.default_rng(99)\n",
+    "mv_rows = []\n",
+    "for i in range(6):\n",
+    "    for ch in [\"temp\", \"humidity\"]:\n",
+    "        vals = rng_mv.normal(0, 1, 30)\n",
+    "        for t, v in enumerate(vals):\n",
+    "            mv_rows.append({\"unique_id\": f\"cold_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\n",
+    "for i in range(6):\n",
+    "    for ch in [\"temp\", \"humidity\"]:\n",
+    "        vals = rng_mv.normal(8, 1, 30)\n",
+    "        for t, v in enumerate(vals):\n",
+    "            mv_rows.append({\"unique_id\": f\"hot_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\n",
+    "\n",
+    "df_mv = pl.DataFrame(mv_rows)\n",
+    "print(f\"Shape: {df_mv.shape}, Series: {df_mv['unique_id'].n_unique()}, Channels: {df_mv['channel'].n_unique()}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "xm0w141ira",
-   "source": "# Independent mode (default)\nclf_ind = KASBAClusterer(n_clusters=2, independent=True, seed=42)\nclf_ind.fit(df_mv, channel_col=\"channel\")\nprint(\"Independent mode:\")\nprint(clf_ind.labels_)\nprint(f\"Inertia: {clf_ind.inertia_:.2f}, Iterations: {clf_ind.n_iter_}\")\n\n# Dependent mode\nclf_dep = KASBAClusterer(n_clusters=2, independent=False, seed=42)\nclf_dep.fit(df_mv, channel_col=\"channel\")\nprint(\"\\nDependent mode:\")\nprint(clf_dep.labels_)\nprint(f\"Inertia: {clf_dep.inertia_:.2f}, Iterations: {clf_dep.n_iter_}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "xm0w141ira",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Independent mode (default)\n",
+    "clf_ind = KASBAClusterer(n_clusters=2, independent=True, seed=42)\n",
+    "clf_ind.fit(df_mv, channel_col=\"channel\")\n",
+    "print(\"Independent mode:\")\n",
+    "print(clf_ind.labels_)\n",
+    "print(f\"Inertia: {clf_ind.inertia_:.2f}, Iterations: {clf_ind.n_iter_}\")\n",
+    "\n",
+    "# Dependent mode\n",
+    "clf_dep = KASBAClusterer(n_clusters=2, independent=False, seed=42)\n",
+    "clf_dep.fit(df_mv, channel_col=\"channel\")\n",
+    "print(\"\\nDependent mode:\")\n",
+    "print(clf_dep.labels_)\n",
+    "print(f\"Inertia: {clf_dep.inertia_:.2f}, Iterations: {clf_dep.n_iter_}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "rhy5t2me7d",
-   "source": "## 14.4 Tuning MSM cost `c`\n\nThe MSM cost parameter `c` controls the penalty for split and merge operations:\n\n- **Low `c`** (e.g., 0.1) — cheap to split/merge, tolerates amplitude differences → fewer, broader clusters\n- **High `c`** (e.g., 10.0) — expensive to split/merge, sensitive to amplitude → tighter, more clusters needed\n\nThis is analogous to the Sakoe-Chiba band width in DTW — it controls how much\ndeformation the distance allows.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.4 Tuning MSM cost `c`\n",
+    "\n",
+    "The MSM cost parameter `c` controls the penalty for split and merge operations:\n",
+    "\n",
+    "- **Low `c`** (e.g., 0.1) — cheap to split/merge, tolerates amplitude differences → fewer, broader clusters\n",
+    "- **High `c`** (e.g., 10.0) — expensive to split/merge, sensitive to amplitude → tighter, more clusters needed\n",
+    "\n",
+    "This is analogous to the Sakoe-Chiba band width in DTW — it controls how much\n",
+    "deformation the distance allows."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "kty2rbq2r6",
-   "source": "# Sweep c values and measure silhouette score\nresults = []\nfor c_val in [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]:\n    lbl = kasba(df, k=3, c=c_val, seed=42)\n    sil = silhouette_score(df, lbl, method=\"msm\")\n    clf_tmp = KASBAClusterer(n_clusters=3, c=c_val, seed=42)\n    clf_tmp.fit(df)\n    results.append({\"c\": c_val, \"silhouette\": sil, \"inertia\": clf_tmp.inertia_})\n\nc_df = pl.DataFrame(results)\nprint(\"Effect of MSM cost parameter c:\")\nc_df",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# Sweep c values and measure silhouette score\n",
+    "results = []\n",
+    "for c_val in [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]:\n",
+    "    lbl = kasba(df, k=3, c=c_val, seed=42)\n",
+    "    sil = silhouette_score(df, lbl, method=\"msm\")\n",
+    "    clf_tmp = KASBAClusterer(n_clusters=3, c=c_val, seed=42)\n",
+    "    clf_tmp.fit(df)\n",
+    "    results.append({\"c\": c_val, \"silhouette\": sil, \"inertia\": clf_tmp.inertia_})\n",
+    "\n",
+    "c_df = pl.DataFrame(results)\n",
+    "print(\"Effect of MSM cost parameter c:\")\n",
+    "c_df"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "t7v6a0h295",
-   "source": "c_df.hvplot.line(\n    x=\"c\",\n    y=\"silhouette\",\n    width=700,\n    height=350,\n    title=\"Silhouette Score vs MSM Cost c\",\n    logx=True,\n    markers=True,\n)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "t7v6a0h295",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_df.hvplot.line(\n",
+    "    x=\"c\",\n",
+    "    y=\"silhouette\",\n",
+    "    width=700,\n",
+    "    height=350,\n",
+    "    title=\"Silhouette Score vs MSM Cost c\",\n",
+    "    logx=True,\n",
+    "    markers=True,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "2y33vath0gj",
-   "source": "## 14.5 Comparing with DTW k-means\n\n`TimeSeriesKMeans` uses DTW + DBA (Dynamic Barycenter Averaging) for centroid\nupdates. Let's compare it side-by-side with KASBA on the same data.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.5 Comparing with DTW k-means\n",
+    "\n",
+    "`TimeSeriesKMeans` uses DTW + DBA (Dynamic Barycenter Averaging) for centroid\n",
+    "updates. Let's compare it side-by-side with KASBA on the same data."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "u367mlggaom",
-   "source": "# KASBA (MSM)\nkasba_labels = kasba(df, k=3, seed=42)\nkasba_sil = silhouette_score(df, kasba_labels, method=\"msm\")\n\n# DTW k-means (DBA)\ndba_clf = TimeSeriesKMeans(n_clusters=3, metric=\"dtw\", max_iter=10, seed=42)\ndba_clf.fit(df)\ndba_labels = dba_clf.labels_\ndba_sil = silhouette_score(df, dba_labels, method=\"dtw\")\n\nprint(f\"KASBA (MSM):      silhouette = {kasba_sil:.4f}\")\nprint(f\"DTW k-means (DBA): silhouette = {dba_sil:.4f}\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": [
+    "# KASBA (MSM)\n",
+    "kasba_labels = kasba(df, k=3, seed=42)\n",
+    "kasba_sil = silhouette_score(df, kasba_labels, method=\"msm\")\n",
+    "\n",
+    "# DTW k-means (DBA)\n",
+    "dba_clf = TimeSeriesKMeans(n_clusters=3, metric=\"dtw\", max_iter=10, seed=42)\n",
+    "dba_clf.fit(df)\n",
+    "dba_labels = dba_clf.labels_\n",
+    "dba_sil = silhouette_score(df, dba_labels, method=\"dtw\")\n",
+    "\n",
+    "print(f\"KASBA (MSM):      silhouette = {kasba_sil:.4f}\")\n",
+    "print(f\"DTW k-means (DBA): silhouette = {dba_sil:.4f}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "gp60acxuuw8",
-   "source": "# Compare cluster purity for both methods\nfor name, lbl_df in [(\"KASBA\", kasba_labels), (\"DTW k-means\", dba_labels)]:\n    merged = lbl_df.join(gt_df, on=\"unique_id\")\n    total_pure = 0\n    for cid in merged[\"cluster\"].unique().sort().to_list():\n        members = merged.filter(pl.col(\"cluster\") == cid)\n        majority = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)[\"count\"][0]\n        total_pure += majority\n    purity = total_pure / merged.height\n    print(f\"{name:15s}: purity = {purity:.0%}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "gp60acxuuw8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare cluster purity for both methods\n",
+    "for name, lbl_df in [(\"KASBA\", kasba_labels), (\"DTW k-means\", dba_labels)]:\n",
+    "    merged = lbl_df.join(gt_df, on=\"unique_id\")\n",
+    "    total_pure = 0\n",
+    "    for cid in merged[\"cluster\"].unique().sort().to_list():\n",
+    "        members = merged.filter(pl.col(\"cluster\") == cid)\n",
+    "        majority = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)[\"count\"][0]\n",
+    "        total_pure += majority\n",
+    "    purity = total_pure / merged.height\n",
+    "    print(f\"{name:15s}: purity = {purity:.0%}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "q6567qyg31e",
-   "source": "## 14.6 Stochastic barycenters — visualize learned centroids\n\nKASBA learns centroids via stochastic barycenter averaging (SGD on a random subset\nof cluster members). Let's visualize them and compare with DBA centroids from\nDTW k-means.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.6 Stochastic barycenters — visualize learned centroids\n",
+    "\n",
+    "KASBA learns centroids via stochastic barycenter averaging (SGD on a random subset\n",
+    "of cluster members). Let's visualize them and compare with DBA centroids from\n",
+    "DTW k-means."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "dla3hfdhwx6",
-   "source": "# Extract KASBA centroids\nkasba_clf = KASBAClusterer(n_clusters=3, seed=42)\nkasba_clf.fit(df)\n\ncentroid_rows = []\nfor i in range(3):\n    centroid = kasba_clf.centroids_[i]  # shape: (1 * n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"KASBA_{i}\", \"ds\": t, \"y\": v})\n\n# Extract DBA centroids\nfor i in range(3):\n    centroid = dba_clf.centroids_[i]  # shape: (n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"DBA_{i}\", \"ds\": t, \"y\": v})\n\ncentroids_df = pl.DataFrame(centroid_rows)\n\ncentroids_df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"centroid\",\n    width=900,\n    height=400,\n    title=\"Learned Centroids: KASBA (MSM) vs DBA (DTW)\",\n    line_width=2,\n)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "dla3hfdhwx6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract KASBA centroids\n",
+    "kasba_clf = KASBAClusterer(n_clusters=3, seed=42)\n",
+    "kasba_clf.fit(df)\n",
+    "\n",
+    "centroid_rows = []\n",
+    "for i in range(3):\n",
+    "    centroid = kasba_clf.centroids_[i]  # shape: (1 * n_timepoints,)\n",
+    "    for t, v in enumerate(centroid):\n",
+    "        centroid_rows.append({\"centroid\": f\"KASBA_{i}\", \"ds\": t, \"y\": v})\n",
+    "\n",
+    "# Extract DBA centroids\n",
+    "for i in range(3):\n",
+    "    centroid = dba_clf.centroids_[i]  # shape: (n_timepoints,)\n",
+    "    for t, v in enumerate(centroid):\n",
+    "        centroid_rows.append({\"centroid\": f\"DBA_{i}\", \"ds\": t, \"y\": v})\n",
+    "\n",
+    "centroids_df = pl.DataFrame(centroid_rows)\n",
+    "\n",
+    "centroids_df.hvplot.line(\n",
+    "    x=\"ds\",\n",
+    "    y=\"y\",\n",
+    "    by=\"centroid\",\n",
+    "    width=900,\n",
+    "    height=400,\n",
+    "    title=\"Learned Centroids: KASBA (MSM) vs DBA (DTW)\",\n",
+    "    line_width=2,\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "5soubf4fn9m",
-   "source": "## 14.7 Predicting new series\n\nThe OOP API (`KASBAClusterer`) supports `predict()` — assign new, unseen series\nto existing clusters without re-fitting.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 14.7 Predicting new series\n",
+    "\n",
+    "The OOP API (`KASBAClusterer`) supports `predict()` — assign new, unseen series\n",
+    "to existing clusters without re-fitting."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "307bft1jp3x",
-   "source": "# Create 3 new series — one from each family\nnew_rows = []\nrng_new = np.random.default_rng(777)\n\n# New sine\nvals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng_new.normal(0, 0.1, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_sine\", \"ds\": t, \"y\": v})\n\n# New sawtooth\nvals = np.linspace(0, 1, n_timepoints) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_saw\", \"ds\": t, \"y\": v})\n\n# New step\nvals = np.concatenate([np.zeros(25), np.ones(25)]) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_step\", \"ds\": t, \"y\": v})\n\nnew_df = pl.DataFrame(new_rows)\npredictions = kasba_clf.predict(new_df)\nprint(\"Predictions for new series:\")\npredictions",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "307bft1jp3x",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create 3 new series — one from each family\n",
+    "new_rows = []\n",
+    "rng_new = np.random.default_rng(777)\n",
+    "\n",
+    "# New sine\n",
+    "vals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng_new.normal(0, 0.1, n_timepoints)\n",
+    "for t, v in enumerate(vals):\n",
+    "    new_rows.append({\"unique_id\": \"new_sine\", \"ds\": t, \"y\": v})\n",
+    "\n",
+    "# New sawtooth\n",
+    "vals = np.linspace(0, 1, n_timepoints) + rng_new.normal(0, 0.05, n_timepoints)\n",
+    "for t, v in enumerate(vals):\n",
+    "    new_rows.append({\"unique_id\": \"new_saw\", \"ds\": t, \"y\": v})\n",
+    "\n",
+    "# New step\n",
+    "vals = np.concatenate([np.zeros(25), np.ones(25)]) + rng_new.normal(0, 0.05, n_timepoints)\n",
+    "for t, v in enumerate(vals):\n",
+    "    new_rows.append({\"unique_id\": \"new_step\", \"ds\": t, \"y\": v})\n",
+    "\n",
+    "new_df = pl.DataFrame(new_rows)\n",
+    "predictions = kasba_clf.predict(new_df)\n",
+    "print(\"Predictions for new series:\")\n",
+    "predictions"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3dxuvnil7nq",
-   "source": "## Summary\n\n| Feature | API |\n|---------|-----|\n| Quick clustering | `kasba(df, k=3)` |\n| OOP with fit/predict | `KASBAClusterer(n_clusters=3).fit(df)` |\n| Multivariate | `kasba(df, k=3, channel_col=\"channel\")` |\n| Tune MSM cost | `kasba(df, k=3, c=2.0)` |\n| Independent vs dependent | `KASBAClusterer(independent=False)` |\n\n### When to use KASBA vs other methods\n\n- **KASBA** — best when you need a proper metric (triangle inequality enables pruning),\n  or when amplitude differences matter (tunable via `c`).\n- **DTW k-means** — well-understood default; use when you want standard elastic alignment.\n- **K-Shape** — fastest option; use when shape matters but phase/amplitude don't.\n- **HDBSCAN** — use when you don't know `k` and want automatic noise detection.\n\n### Key parameters\n\n- `c` — MSM cost. Start with 1.0, sweep [0.1, 10.0] to tune.\n- `independent` — for multivariate data. True (default) sums per-channel distances;\n  False computes cross-channel MSM.\n- `ba_subset_size` — fraction of cluster used for barycenter SGD. Lower = faster but noisier.\n- `max_iter` — convergence typically within 5-10 iterations.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | API |\n",
+    "|---------|-----|\n",
+    "| Quick clustering | `kasba(df, k=3)` |\n",
+    "| OOP with fit/predict | `KASBAClusterer(n_clusters=3).fit(df)` |\n",
+    "| Multivariate | `kasba(df, k=3, channel_col=\"channel\")` |\n",
+    "| Tune MSM cost | `kasba(df, k=3, c=2.0)` |\n",
+    "| Independent vs dependent | `KASBAClusterer(independent=False)` |\n",
+    "\n",
+    "### When to use KASBA vs other methods\n",
+    "\n",
+    "- **KASBA** — best when you need a proper metric (triangle inequality enables pruning),\n",
+    "  or when amplitude differences matter (tunable via `c`).\n",
+    "- **DTW k-means** — well-understood default; use when you want standard elastic alignment.\n",
+    "- **K-Shape** — fastest option; use when shape matters but phase/amplitude don't.\n",
+    "- **HDBSCAN** — use when you don't know `k` and want automatic noise detection.\n",
+    "\n",
+    "### Key parameters\n",
+    "\n",
+    "- `c` — MSM cost. Start with 1.0, sweep [0.1, 10.0] to tune.\n",
+    "- `independent` — for multivariate data. True (default) sums per-channel distances;\n",
+    "  False computes cross-channel MSM.\n",
+    "- `ba_subset_size` — fraction of cluster used for barycenter SGD. Lower = faster but noisier.\n",
+    "- `max_iter` — convergence typically within 5-10 iterations."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/14_kasba_clustering.ipynb
+++ b/notebooks/14_kasba_clustering.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "h8fbrz6wups",
+   "source": "# 14 — KASBA Clustering\n\n**KASBA** (K-means with Accelerated Stochastic Barycenter Averaging) is a time series\nclustering algorithm that uses the **MSM** (Move-Split-Merge) elastic distance instead\nof DTW.\n\n### Why MSM over DTW?\n\n| Property | DTW | MSM |\n|----------|-----|-----|\n| **Metric** | No (violates triangle inequality) | Yes (proper metric) |\n| **Triangle inequality pruning** | Not possible | 10-30x speedup |\n| **Phase invariance** | Yes | Yes |\n| **Amplitude invariance** | No | Tunable via cost `c` |\n\nBecause MSM is a proper metric, KASBA can use triangle inequality pruning to skip\nunnecessary distance computations — making it significantly faster than DTW-based\nk-means on large datasets.\n\n### How KASBA works\n\n1. Initialize `k` centroids (random selection from data)\n2. **Assign** each series to nearest centroid using MSM distance\n3. **Update** centroids via stochastic barycenter averaging (SGD on a subset of cluster members)\n4. Repeat until convergence or `max_iter` reached\n\nThe stochastic barycenter is cheaper than the full DBA (Dynamic Barycenter Averaging)\nused in DTW k-means, while still producing high-quality centroids.\n\n### References\n\n- Stefan, A., Athitsos, V. & Das, G. (2013). *The Move-Split-Merge Metric for Time Series*. IEEE TKDE.\n- Holder, C., Middlehurst, M. & Bagnall, A. (2023). *A Review and Evaluation of Elastic Distance Functions for Time Series Clustering*. Knowledge and Information Systems.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6vkhso7a0z2",
+   "source": "import importlib\n\nif importlib.util.find_spec(\"polars_ts\") is None:\n    %pip install -q polars-timeseries[all]\nif importlib.util.find_spec(\"hvplot\") is None:\n    %pip install -q hvplot",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "7ovi3uyb3x3",
+   "source": "try:\n    import hvplot.polars  # noqa\nexcept ImportError:\n    pass\n\nimport numpy as np\nimport polars as pl\n\nfrom polars_ts import KASBAClusterer, TimeSeriesKMeans, kasba, silhouette_score",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c5s8cpk9b",
+   "source": "## 14.1 Synthetic data\n\nWe generate 30 univariate series belonging to 3 shape families:\n- **Sine** — smooth periodic pattern\n- **Sawtooth** — linear ramp with reset\n- **Step** — piecewise constant with a level shift\n\nEach family has 10 series with slight noise, making them visually distinct but\nrequiring an elastic distance to cluster correctly.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "q5z34e2ga2n",
+   "source": "rng = np.random.default_rng(42)\nn_timepoints = 50\nn_per_cluster = 10\n\nrows = []\nground_truth = {}\n\nfor i in range(n_per_cluster):\n    # Sine family\n    vals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng.normal(0, 0.15, n_timepoints)\n    uid = f\"sine_{i}\"\n    ground_truth[uid] = 0\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Sawtooth family\n    vals = np.linspace(0, 1, n_timepoints) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"saw_{i}\"\n    ground_truth[uid] = 1\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\n    # Step family\n    vals = np.concatenate([np.zeros(25), np.ones(25)]) + rng.normal(0, 0.1, n_timepoints)\n    uid = f\"step_{i}\"\n    ground_truth[uid] = 2\n    for t, v in enumerate(vals):\n        rows.append({\"unique_id\": uid, \"ds\": t, \"y\": v})\n\ndf = pl.DataFrame(rows)\nprint(f\"Shape: {df.shape}\")\nprint(f\"Series: {df['unique_id'].n_unique()}\")\ndf.head()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "aeuqgo1pztk",
+   "source": "df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    width=900,\n    height=400,\n    title=\"30 Synthetic Series (3 Shape Families)\",\n    alpha=0.5,\n    legend=False,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zeczgcr575",
+   "source": "## 14.2 Univariate clustering with `kasba()`\n\nThe simplest way to use KASBA — one function call. Returns a DataFrame\nwith `[unique_id, cluster]` assignments.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2fnvzzv9g7p",
+   "source": "labels = kasba(df, k=3, seed=42)\nprint(\"KASBA cluster assignments:\")\nlabels",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "zq1zakwn6td",
+   "source": "# Visualize clusters\ndf_clustered = df.join(labels, on=\"unique_id\")\n\ndf_clustered.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"unique_id\",\n    groupby=\"cluster\",\n    width=900,\n    height=400,\n    title=\"KASBA Clusters (k=3, MSM c=1.0)\",\n    alpha=0.7,\n    legend=False,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "bvjyq3uufje",
+   "source": "# Check agreement with ground truth\ngt_df = pl.DataFrame({\"unique_id\": list(ground_truth.keys()), \"true_cluster\": list(ground_truth.values())})\ncomparison = labels.join(gt_df, on=\"unique_id\")\n\n# Cluster IDs may differ from ground truth IDs, so check purity\nfor cluster_id in comparison[\"cluster\"].unique().sort().to_list():\n    members = comparison.filter(pl.col(\"cluster\") == cluster_id)\n    true_labels = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)\n    purity = true_labels[\"count\"][0] / members.height\n    print(f\"Cluster {cluster_id}: {members.height} members, purity = {purity:.0%}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zk03oau8ur",
+   "source": "## 14.3 Multivariate clustering\n\nKASBA supports multivariate time series via a `channel_col` parameter. Each series\nhas multiple channels (e.g., temperature and humidity), and MSM is computed either:\n\n- **independently** (`independent=True`, default) — sum of per-channel MSM distances\n- **dependently** (`independent=False`) — cross-channel MSM that considers inter-channel relationships",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "no4ti5md83h",
+   "source": "# Create multivariate data: 12 series, 2 channels, 2 clusters\nrng_mv = np.random.default_rng(99)\nmv_rows = []\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(0, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"cold_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\nfor i in range(6):\n    for ch in [\"temp\", \"humidity\"]:\n        vals = rng_mv.normal(8, 1, 30)\n        for t, v in enumerate(vals):\n            mv_rows.append({\"unique_id\": f\"hot_{i}\", \"ds\": t, \"channel\": ch, \"y\": v})\n\ndf_mv = pl.DataFrame(mv_rows)\nprint(f\"Shape: {df_mv.shape}, Series: {df_mv['unique_id'].n_unique()}, Channels: {df_mv['channel'].n_unique()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "xm0w141ira",
+   "source": "# Independent mode (default)\nclf_ind = KASBAClusterer(n_clusters=2, independent=True, seed=42)\nclf_ind.fit(df_mv, channel_col=\"channel\")\nprint(\"Independent mode:\")\nprint(clf_ind.labels_)\nprint(f\"Inertia: {clf_ind.inertia_:.2f}, Iterations: {clf_ind.n_iter_}\")\n\n# Dependent mode\nclf_dep = KASBAClusterer(n_clusters=2, independent=False, seed=42)\nclf_dep.fit(df_mv, channel_col=\"channel\")\nprint(\"\\nDependent mode:\")\nprint(clf_dep.labels_)\nprint(f\"Inertia: {clf_dep.inertia_:.2f}, Iterations: {clf_dep.n_iter_}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rhy5t2me7d",
+   "source": "## 14.4 Tuning MSM cost `c`\n\nThe MSM cost parameter `c` controls the penalty for split and merge operations:\n\n- **Low `c`** (e.g., 0.1) — cheap to split/merge, tolerates amplitude differences → fewer, broader clusters\n- **High `c`** (e.g., 10.0) — expensive to split/merge, sensitive to amplitude → tighter, more clusters needed\n\nThis is analogous to the Sakoe-Chiba band width in DTW — it controls how much\ndeformation the distance allows.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "kty2rbq2r6",
+   "source": "# Sweep c values and measure silhouette score\nresults = []\nfor c_val in [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]:\n    lbl = kasba(df, k=3, c=c_val, seed=42)\n    sil = silhouette_score(df, lbl, method=\"msm\")\n    clf_tmp = KASBAClusterer(n_clusters=3, c=c_val, seed=42)\n    clf_tmp.fit(df)\n    results.append({\"c\": c_val, \"silhouette\": sil, \"inertia\": clf_tmp.inertia_})\n\nc_df = pl.DataFrame(results)\nprint(\"Effect of MSM cost parameter c:\")\nc_df",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "t7v6a0h295",
+   "source": "c_df.hvplot.line(\n    x=\"c\",\n    y=\"silhouette\",\n    width=700,\n    height=350,\n    title=\"Silhouette Score vs MSM Cost c\",\n    logx=True,\n    markers=True,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2y33vath0gj",
+   "source": "## 14.5 Comparing with DTW k-means\n\n`TimeSeriesKMeans` uses DTW + DBA (Dynamic Barycenter Averaging) for centroid\nupdates. Let's compare it side-by-side with KASBA on the same data.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "u367mlggaom",
+   "source": "# KASBA (MSM)\nkasba_labels = kasba(df, k=3, seed=42)\nkasba_sil = silhouette_score(df, kasba_labels, method=\"msm\")\n\n# DTW k-means (DBA)\ndba_clf = TimeSeriesKMeans(n_clusters=3, metric=\"dtw\", max_iter=10, seed=42)\ndba_clf.fit(df)\ndba_labels = dba_clf.labels_\ndba_sil = silhouette_score(df, dba_labels, method=\"dtw\")\n\nprint(f\"KASBA (MSM):      silhouette = {kasba_sil:.4f}\")\nprint(f\"DTW k-means (DBA): silhouette = {dba_sil:.4f}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "gp60acxuuw8",
+   "source": "# Compare cluster purity for both methods\nfor name, lbl_df in [(\"KASBA\", kasba_labels), (\"DTW k-means\", dba_labels)]:\n    merged = lbl_df.join(gt_df, on=\"unique_id\")\n    total_pure = 0\n    for cid in merged[\"cluster\"].unique().sort().to_list():\n        members = merged.filter(pl.col(\"cluster\") == cid)\n        majority = members[\"true_cluster\"].value_counts().sort(\"count\", descending=True)[\"count\"][0]\n        total_pure += majority\n    purity = total_pure / merged.height\n    print(f\"{name:15s}: purity = {purity:.0%}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q6567qyg31e",
+   "source": "## 14.6 Stochastic barycenters — visualize learned centroids\n\nKASBA learns centroids via stochastic barycenter averaging (SGD on a random subset\nof cluster members). Let's visualize them and compare with DBA centroids from\nDTW k-means.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "dla3hfdhwx6",
+   "source": "# Extract KASBA centroids\nkasba_clf = KASBAClusterer(n_clusters=3, seed=42)\nkasba_clf.fit(df)\n\ncentroid_rows = []\nfor i in range(3):\n    centroid = kasba_clf.centroids_[i]  # shape: (1 * n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"KASBA_{i}\", \"ds\": t, \"y\": v})\n\n# Extract DBA centroids\nfor i in range(3):\n    centroid = dba_clf.centroids_[i]  # shape: (n_timepoints,)\n    for t, v in enumerate(centroid):\n        centroid_rows.append({\"centroid\": f\"DBA_{i}\", \"ds\": t, \"y\": v})\n\ncentroids_df = pl.DataFrame(centroid_rows)\n\ncentroids_df.hvplot.line(\n    x=\"ds\",\n    y=\"y\",\n    by=\"centroid\",\n    width=900,\n    height=400,\n    title=\"Learned Centroids: KASBA (MSM) vs DBA (DTW)\",\n    line_width=2,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5soubf4fn9m",
+   "source": "## 14.7 Predicting new series\n\nThe OOP API (`KASBAClusterer`) supports `predict()` — assign new, unseen series\nto existing clusters without re-fitting.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "307bft1jp3x",
+   "source": "# Create 3 new series — one from each family\nnew_rows = []\nrng_new = np.random.default_rng(777)\n\n# New sine\nvals = np.sin(np.linspace(0, 4 * np.pi, n_timepoints)) + rng_new.normal(0, 0.1, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_sine\", \"ds\": t, \"y\": v})\n\n# New sawtooth\nvals = np.linspace(0, 1, n_timepoints) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_saw\", \"ds\": t, \"y\": v})\n\n# New step\nvals = np.concatenate([np.zeros(25), np.ones(25)]) + rng_new.normal(0, 0.05, n_timepoints)\nfor t, v in enumerate(vals):\n    new_rows.append({\"unique_id\": \"new_step\", \"ds\": t, \"y\": v})\n\nnew_df = pl.DataFrame(new_rows)\npredictions = kasba_clf.predict(new_df)\nprint(\"Predictions for new series:\")\npredictions",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dxuvnil7nq",
+   "source": "## Summary\n\n| Feature | API |\n|---------|-----|\n| Quick clustering | `kasba(df, k=3)` |\n| OOP with fit/predict | `KASBAClusterer(n_clusters=3).fit(df)` |\n| Multivariate | `kasba(df, k=3, channel_col=\"channel\")` |\n| Tune MSM cost | `kasba(df, k=3, c=2.0)` |\n| Independent vs dependent | `KASBAClusterer(independent=False)` |\n\n### When to use KASBA vs other methods\n\n- **KASBA** — best when you need a proper metric (triangle inequality enables pruning),\n  or when amplitude differences matter (tunable via `c`).\n- **DTW k-means** — well-understood default; use when you want standard elastic alignment.\n- **K-Shape** — fastest option; use when shape matters but phase/amplitude don't.\n- **HDBSCAN** — use when you don't know `k` and want automatic noise detection.\n\n### Key parameters\n\n- `c` — MSM cost. Start with 1.0, sweep [0.1, 10.0] to tune.\n- `independent` — for multivariate data. True (default) sums per-channel distances;\n  False computes cross-channel MSM.\n- `ba_subset_size` — fraction of cluster used for barycenter SGD. Lower = faster but noisier.\n- `max_iter` — convergence typically within 5-10 iterations.",
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -244,6 +244,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "StreamingKalmanFilter": ("polars_ts.streaming", "StreamingKalmanFilter"),
     "StreamingGlobalForecaster": ("polars_ts.streaming", "StreamingGlobalForecaster"),
     "SlidingWindowManager": ("polars_ts.streaming", "SlidingWindowManager"),
+    # --- Registry / Experiment Tracking ---
+    "ModelRegistry": ("polars_ts.registry", "ModelRegistry"),
+    "Experiment": ("polars_ts.registry", "Experiment"),
+    "Run": ("polars_ts.registry", "Run"),
 }
 
 

--- a/polars_ts/reconciliation.py
+++ b/polars_ts/reconciliation.py
@@ -97,7 +97,6 @@ def reconcile(
     if method not in valid_methods:
         raise ValueError(f"Unknown method {method!r}. Choose from {sorted(valid_methods)}")
 
-<<<<<<< feat/grouped-hierarchies-166
     grouped = _normalize_hierarchy(hierarchy)
 
     # Projection-based methods work with grouped hierarchies natively
@@ -118,27 +117,6 @@ def reconcile(
             tree = {k: v[0] for k, v in grouped.items()}
             return _bottom_up(df, tree, forecast_col, id_col, time_col)
         return _bottom_up_grouped(df, grouped, forecast_col, id_col, time_col)
-=======
-    if method == "middle_out":
-        if middle_level is None:
-            raise ValueError("middle_level is required for method='middle_out'")
-        return _middle_out(df, hierarchy, forecast_col, id_col, time_col, middle_level)
-    if method == "permbu":
-        if residuals is None:
-            raise ValueError("residuals is required for method='permbu'")
-        return _permbu(df, hierarchy, forecast_col, id_col, time_col, residuals)
-    if method == "mint_cv":
-        if train_data is None:
-            raise ValueError("train_data is required for method='mint_cv'")
-        return _mint_cv(df, hierarchy, forecast_col, id_col, time_col, train_data, n_folds)
-
-    # Methods that support interval_cols via projection matrix
-    if method == "bottom_up":
-        return _bottom_up(df, hierarchy, forecast_col, id_col, time_col)
-    if method == "top_down":
-        return _top_down(df, hierarchy, forecast_col, id_col, time_col)
-    return _ols(df, hierarchy, forecast_col, id_col, time_col, interval_cols=interval_cols)
->>>>>>> main
 
     # Tree-only methods
     tree = _to_tree(grouped) if not _is_tree(grouped) else {k: v[0] for k, v in grouped.items()}
@@ -317,7 +295,6 @@ def _top_down(
 
 
 def _build_summing_matrix(
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
 ) -> tuple[np.ndarray, list[str], list[str], dict[str, int]]:
     """Build the summing matrix S for tree or grouped hierarchies.
@@ -330,20 +307,12 @@ def _build_summing_matrix(
         all_parents.update(parents)
     all_nodes = sorted(set(hierarchy.keys()) | all_parents)
     bottom = _get_bottom_nodes_grouped(hierarchy)
-=======
-    hierarchy: dict[str, str],
-) -> tuple[np.ndarray, list[str], list[str], dict[str, int]]:
-    """Build the summing matrix S and return (S, all_nodes, bottom, node_idx)."""
-    all_nodes = sorted(set(hierarchy.keys()) | set(hierarchy.values()))
-    bottom = _get_bottom_nodes(hierarchy)
->>>>>>> main
     n_total = len(all_nodes)
     n_bottom = len(bottom)
     node_idx = {node: i for i, node in enumerate(all_nodes)}
 
     S = np.zeros((n_total, n_bottom))
     for j, b in enumerate(bottom):
-<<<<<<< feat/grouped-hierarchies-166
         # BFS to find all ancestors
         S[node_idx[b], j] = 1.0
         queue = [b]
@@ -412,75 +381,6 @@ def _ols(
     where S is the summing matrix.
     """
     S, all_nodes, _bottom, node_idx = _build_summing_matrix(hierarchy)
-=======
-        current = b
-        S[node_idx[current], j] = 1.0
-        while current in hierarchy:
-            current = hierarchy[current]
-            S[node_idx[current], j] = 1.0
->>>>>>> main
-
-    return S, all_nodes, bottom, node_idx
-
-
-<<<<<<< feat/grouped-hierarchies-166
-    return _apply_projection(df, P, all_nodes, node_idx, forecast_col, id_col, time_col, extra_cols=interval_cols)
-
-=======
-def _apply_projection(
-    df: pl.DataFrame,
-    P: np.ndarray,
-    all_nodes: list[str],
-    node_idx: dict[str, int],
-    forecast_col: str,
-    id_col: str,
-    time_col: str,
-    extra_cols: list[str] | None = None,
-) -> pl.DataFrame:
-    """Apply projection matrix P to forecasts, optionally to extra columns too."""
-    cols_to_project = [forecast_col] + (extra_cols or [])
-    n_total = len(all_nodes)
-    times = sorted(df[time_col].unique().to_list())
-    result_rows: list[dict[str, Any]] = []
-
-    for t in times:
-        t_data = df.filter(pl.col(time_col) == t)
-        row_map = {row[id_col]: row for row in t_data.iter_rows(named=True)}
-
-        for col in cols_to_project:
-            y_hat = np.zeros(n_total)
-            for node, idx in node_idx.items():
-                if node in row_map:
-                    y_hat[idx] = row_map[node][col]
-            if col == cols_to_project[0]:
-                y_tildes = {col: P @ y_hat}
-            else:
-                y_tildes[col] = P @ y_hat
-
-        for node, idx in node_idx.items():
-            row_dict: dict[str, Any] = {id_col: node, time_col: t}
-            for col in cols_to_project:
-                row_dict[col] = y_tildes[col][idx]
-            result_rows.append(row_dict)
-
-    return pl.DataFrame(result_rows).sort(id_col, time_col)
-
-
-def _ols(
-    df: pl.DataFrame,
-    hierarchy: dict[str, str],
-    forecast_col: str,
-    id_col: str,
-    time_col: str,
-    *,
-    interval_cols: list[str] | None = None,
-) -> pl.DataFrame:
-    """MinTrace-OLS reconciliation.
-
-    Computes reconciled forecasts as: y_tilde = S @ (S'S)^{-1} @ S' @ y_hat
-    where S is the summing matrix.
-    """
-    S, all_nodes, _bottom, node_idx = _build_summing_matrix(hierarchy)
 
     # Reconciliation: P = S @ (S'S)^{-1} @ S'
     StS_inv = np.linalg.pinv(S.T @ S)
@@ -488,7 +388,6 @@ def _ols(
 
     return _apply_projection(df, P, all_nodes, node_idx, forecast_col, id_col, time_col, extra_cols=interval_cols)
 
->>>>>>> main
 
 def _middle_out(
     df: pl.DataFrame,
@@ -503,11 +402,7 @@ def _middle_out(
     Below the middle level: disaggregate using historical proportions.
     Above the middle level: aggregate by summing children.
     """
-<<<<<<< feat/grouped-hierarchies-166
     bottom = _get_bottom_nodes_tree(hierarchy)
-=======
-    bottom = _get_bottom_nodes(hierarchy)
->>>>>>> main
 
     # --- Disaggregate downward from middle to bottom ---
     # For each middle node, find its descendant bottom nodes
@@ -587,11 +482,7 @@ def _middle_out(
 
 def _permbu(
     df: pl.DataFrame,
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
-=======
-    hierarchy: dict[str, str],
->>>>>>> main
     forecast_col: str,
     id_col: str,
     time_col: str,
@@ -633,11 +524,7 @@ def _permbu(
 
 def _mint_cv(
     df: pl.DataFrame,
-<<<<<<< feat/grouped-hierarchies-166
     hierarchy: dict[str, list[str]],
-=======
-    hierarchy: dict[str, str],
->>>>>>> main
     forecast_col: str,
     id_col: str,
     time_col: str,

--- a/polars_ts/registry/__init__.py
+++ b/polars_ts/registry/__init__.py
@@ -1,0 +1,11 @@
+"""Model registry and experiment tracking."""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "ModelRegistry": ("polars_ts.registry.registry", "ModelRegistry"),
+    "Experiment": ("polars_ts.registry.experiment", "Experiment"),
+    "Run": ("polars_ts.registry.experiment", "Run"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/registry/experiment.py
+++ b/polars_ts/registry/experiment.py
@@ -1,0 +1,109 @@
+"""Experiment and run tracking for time series models."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import polars as pl
+
+
+@dataclass
+class Run:
+    """A single model training/evaluation run."""
+
+    run_id: str
+    model_name: str
+    config: dict[str, Any]
+    metrics: dict[str, float]
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    tags: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "model_name": self.model_name,
+            "config": self.config,
+            "metrics": self.metrics,
+            "timestamp": self.timestamp,
+            "tags": self.tags,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Run:
+        return cls(
+            run_id=d["run_id"],
+            model_name=d["model_name"],
+            config=d["config"],
+            metrics=d["metrics"],
+            timestamp=d.get("timestamp", ""),
+            tags=d.get("tags", {}),
+        )
+
+
+@dataclass
+class Experiment:
+    """A collection of runs for comparison."""
+
+    name: str
+    runs: list[Run] = field(default_factory=list)
+
+    def log_run(
+        self,
+        *,
+        model_name: str,
+        config: dict[str, Any],
+        metrics: dict[str, float],
+        tags: dict[str, str] | None = None,
+        run_id: str | None = None,
+    ) -> Run:
+        run = Run(
+            run_id=run_id or uuid.uuid4().hex[:12],
+            model_name=model_name,
+            config=config,
+            metrics=metrics,
+            tags=tags or {},
+        )
+        self.runs.append(run)
+        return run
+
+    def best_run(self, metric: str, *, higher_is_better: bool = False) -> Run:
+        if not self.runs:
+            raise ValueError("no runs logged — cannot determine best run")
+        key = (lambda r: r.metrics[metric]) if not higher_is_better else (lambda r: -r.metrics[metric])
+        return min(self.runs, key=key)
+
+    def leaderboard(self, metric: str, *, higher_is_better: bool = False) -> pl.DataFrame:
+        rows = []
+        for r in self.runs:
+            row: dict[str, Any] = {"run_id": r.run_id, "model_name": r.model_name}
+            row.update(r.metrics)
+            rows.append(row)
+        df = pl.DataFrame(rows)
+        return df.sort(metric, descending=higher_is_better)
+
+    def to_dataframe(self) -> pl.DataFrame:
+        rows = []
+        for r in self.runs:
+            row: dict[str, Any] = {
+                "run_id": r.run_id,
+                "model_name": r.model_name,
+                "timestamp": r.timestamp,
+            }
+            row.update(r.metrics)
+            rows.append(row)
+        return pl.DataFrame(rows)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "runs": [r.to_dict() for r in self.runs],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Experiment:
+        exp = cls(name=d["name"])
+        exp.runs = [Run.from_dict(r) for r in d.get("runs", [])]
+        return exp

--- a/polars_ts/registry/registry.py
+++ b/polars_ts/registry/registry.py
@@ -1,0 +1,188 @@
+"""Model registry for saving, loading, and versioning time series models."""
+
+from __future__ import annotations
+
+import json
+import pickle
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+from polars_ts.registry.experiment import Experiment, Run
+
+
+class ModelRegistry:
+    """File-system-backed model registry with versioning and experiment tracking.
+
+    Parameters
+    ----------
+    root
+        Root directory for the registry. Models are stored under
+        ``root/models/<name>/<version>/`` and experiments under
+        ``root/experiments/<name>.json``.
+
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root)
+        self._models_dir = self._root / "models"
+        self._experiments_dir = self._root / "experiments"
+        self._models_dir.mkdir(parents=True, exist_ok=True)
+        self._experiments_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Model persistence
+    # ------------------------------------------------------------------
+
+    def save_model(
+        self,
+        model: Any,
+        name: str,
+        *,
+        version: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Persist a model to disk.
+
+        Returns the version string used.
+        """
+        version = version or uuid.uuid4().hex[:12]
+        model_dir = self._models_dir / name / version
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        with open(model_dir / "model.pkl", "wb") as f:
+            pickle.dump(model, f)
+
+        meta = metadata or {}
+        with open(model_dir / "metadata.json", "w") as f:
+            json.dump(meta, f, indent=2)
+
+        return version
+
+    def load_model(self, name: str, *, version: str | None = None) -> Any:
+        """Load a model from disk. Loads latest version if *version* is None."""
+        name_dir = self._models_dir / name
+        if not name_dir.exists():
+            raise FileNotFoundError(f"model {name!r} not found in registry")
+
+        if version is None:
+            # Pick the latest by directory modification time
+            versions = sorted(name_dir.iterdir(), key=lambda p: p.stat().st_mtime)
+            if not versions:
+                raise FileNotFoundError(f"no versions found for model {name!r}")
+            version_dir = versions[-1]
+        else:
+            version_dir = name_dir / version
+            if not version_dir.exists():
+                raise FileNotFoundError(f"version {version!r} not found for model {name!r}")
+
+        with open(version_dir / "model.pkl", "rb") as f:
+            return pickle.load(f)  # noqa: S301
+
+    def get_metadata(self, name: str, *, version: str | None = None) -> dict[str, Any]:
+        """Retrieve metadata for a saved model."""
+        name_dir = self._models_dir / name
+        if not name_dir.exists():
+            raise FileNotFoundError(f"model {name!r} not found in registry")
+
+        if version is None:
+            versions = sorted(name_dir.iterdir(), key=lambda p: p.stat().st_mtime)
+            if not versions:
+                raise FileNotFoundError(f"no versions found for model {name!r}")
+            version_dir = versions[-1]
+        else:
+            version_dir = name_dir / version
+
+        meta_path = version_dir / "metadata.json"
+        if not meta_path.exists():
+            return {}
+        with open(meta_path) as f:
+            return json.load(f)
+
+    def list_models(self) -> list[str]:
+        """Return names of all registered models."""
+        if not self._models_dir.exists():
+            return []
+        return sorted(p.name for p in self._models_dir.iterdir() if p.is_dir())
+
+    def list_versions(self, name: str) -> list[str]:
+        """Return all version strings for a given model."""
+        name_dir = self._models_dir / name
+        if not name_dir.exists():
+            return []
+        return sorted(p.name for p in name_dir.iterdir() if p.is_dir())
+
+    def delete_model(self, name: str) -> None:
+        """Remove a model and all its versions."""
+        name_dir = self._models_dir / name
+        if name_dir.exists():
+            shutil.rmtree(name_dir)
+
+    def delete_version(self, name: str, version: str) -> None:
+        """Remove a specific version of a model."""
+        version_dir = self._models_dir / name / version
+        if version_dir.exists():
+            shutil.rmtree(version_dir)
+
+    # ------------------------------------------------------------------
+    # Experiment persistence
+    # ------------------------------------------------------------------
+
+    def save_experiment(self, experiment: Experiment) -> None:
+        """Persist an experiment (all runs) to disk."""
+        path = self._experiments_dir / f"{experiment.name}.json"
+        with open(path, "w") as f:
+            json.dump(experiment.to_dict(), f, indent=2)
+
+    def load_experiment(self, name: str) -> Experiment:
+        """Load a previously saved experiment."""
+        path = self._experiments_dir / f"{name}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"experiment {name!r} not found")
+        with open(path) as f:
+            return Experiment.from_dict(json.load(f))
+
+    def list_experiments(self) -> list[str]:
+        """Return names of all saved experiments."""
+        if not self._experiments_dir.exists():
+            return []
+        return sorted(p.stem for p in self._experiments_dir.glob("*.json"))
+
+    # ------------------------------------------------------------------
+    # Convenience: log run + optionally save model in one call
+    # ------------------------------------------------------------------
+
+    def log_run(
+        self,
+        *,
+        experiment_name: str,
+        model: Any,
+        model_name: str,
+        config: dict[str, Any],
+        metrics: dict[str, float],
+        tags: dict[str, str] | None = None,
+        save_model: bool = False,
+    ) -> Run:
+        """Log a run to an experiment, optionally saving the model.
+
+        If the experiment does not exist yet, it is created automatically.
+        """
+        # Load or create experiment
+        try:
+            exp = self.load_experiment(experiment_name)
+        except FileNotFoundError:
+            exp = Experiment(name=experiment_name)
+
+        run = exp.log_run(
+            model_name=model_name,
+            config=config,
+            metrics=metrics,
+            tags=tags,
+        )
+
+        if save_model:
+            self.save_model(model, model_name, version=run.run_id)
+
+        self.save_experiment(exp)
+        return run

--- a/tests/registry/test_registry.py
+++ b/tests/registry/test_registry.py
@@ -1,0 +1,316 @@
+"""Tests for model registry and experiment tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from polars_ts.registry.experiment import Experiment, Run
+from polars_ts.registry.registry import ModelRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyModel:
+    """Minimal model with fit/predict for testing."""
+
+    def __init__(self, bias: float = 0.0):
+        self.bias = bias
+        self.is_fitted_: bool = False
+
+    def fit(self, _df: pl.DataFrame) -> _DummyModel:
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, _df: pl.DataFrame, *, h: int = 1) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "unique_id": ["A"] * h,
+                "ds": [datetime(2024, 1, 1) + timedelta(days=i) for i in range(h)],
+                "y_hat": [self.bias] * h,
+            }
+        )
+
+
+def _make_ts(n: int = 20) -> pl.DataFrame:
+    base = datetime(2024, 1, 1)
+    return pl.DataFrame(
+        {
+            "unique_id": ["A"] * n,
+            "ds": [base + timedelta(days=i) for i in range(n)],
+            "y": [float(i) for i in range(n)],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Experiment / Run dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_create_run(self):
+        run = Run(
+            run_id="run-001",
+            model_name="dummy",
+            config={"bias": 1.0},
+            metrics={"mae": 0.5, "rmse": 0.7},
+        )
+        assert run.run_id == "run-001"
+        assert run.model_name == "dummy"
+        assert run.config == {"bias": 1.0}
+        assert run.metrics["mae"] == 0.5
+        assert isinstance(run.timestamp, str)
+
+    def test_run_to_dict_roundtrip(self):
+        run = Run(
+            run_id="run-002",
+            model_name="pipeline",
+            config={"lags": [1, 2]},
+            metrics={"mae": 1.2},
+            tags={"env": "test"},
+        )
+        d = run.to_dict()
+        restored = Run.from_dict(d)
+        assert restored.run_id == run.run_id
+        assert restored.model_name == run.model_name
+        assert restored.config == run.config
+        assert restored.metrics == run.metrics
+        assert restored.tags == run.tags
+
+
+class TestExperiment:
+    def test_create_experiment(self):
+        exp = Experiment(name="forecast-v1")
+        assert exp.name == "forecast-v1"
+        assert len(exp.runs) == 0
+
+    def test_log_run(self):
+        exp = Experiment(name="test-exp")
+        run = exp.log_run(
+            model_name="dummy",
+            config={"bias": 0.0},
+            metrics={"mae": 0.3},
+        )
+        assert len(exp.runs) == 1
+        assert exp.runs[0].run_id == run.run_id
+        assert run.model_name == "dummy"
+
+    def test_log_multiple_runs(self):
+        exp = Experiment(name="multi")
+        exp.log_run(model_name="m1", config={}, metrics={"mae": 1.0})
+        exp.log_run(model_name="m2", config={}, metrics={"mae": 0.5})
+        assert len(exp.runs) == 2
+
+    def test_best_run(self):
+        exp = Experiment(name="best-test")
+        exp.log_run(model_name="bad", config={}, metrics={"mae": 2.0, "rmse": 3.0})
+        exp.log_run(model_name="good", config={}, metrics={"mae": 0.5, "rmse": 1.0})
+        exp.log_run(model_name="mid", config={}, metrics={"mae": 1.0, "rmse": 2.0})
+
+        best = exp.best_run("mae")
+        assert best.model_name == "good"
+
+        best_rmse = exp.best_run("rmse")
+        assert best_rmse.model_name == "good"
+
+    def test_best_run_higher_is_better(self):
+        exp = Experiment(name="higher")
+        exp.log_run(model_name="low", config={}, metrics={"r2": 0.7})
+        exp.log_run(model_name="high", config={}, metrics={"r2": 0.95})
+
+        best = exp.best_run("r2", higher_is_better=True)
+        assert best.model_name == "high"
+
+    def test_leaderboard(self):
+        exp = Experiment(name="board")
+        exp.log_run(model_name="m1", config={"a": 1}, metrics={"mae": 2.0, "rmse": 3.0})
+        exp.log_run(model_name="m2", config={"a": 2}, metrics={"mae": 0.5, "rmse": 1.0})
+
+        board = exp.leaderboard("mae")
+        assert isinstance(board, pl.DataFrame)
+        assert len(board) == 2
+        assert board["model_name"][0] == "m2"  # best first
+        assert "mae" in board.columns
+        assert "run_id" in board.columns
+
+    def test_to_dataframe(self):
+        exp = Experiment(name="df-test")
+        exp.log_run(model_name="m1", config={}, metrics={"mae": 1.0})
+        exp.log_run(model_name="m2", config={}, metrics={"mae": 0.5})
+
+        df = exp.to_dataframe()
+        assert isinstance(df, pl.DataFrame)
+        assert len(df) == 2
+        assert "run_id" in df.columns
+        assert "model_name" in df.columns
+        assert "mae" in df.columns
+
+    def test_empty_experiment_best_run_raises(self):
+        exp = Experiment(name="empty")
+        with pytest.raises(ValueError, match="no runs"):
+            exp.best_run("mae")
+
+
+# ---------------------------------------------------------------------------
+# ModelRegistry tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelRegistry:
+    def test_save_and_load_model(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        model = _DummyModel(bias=42.0)
+        model.fit(_make_ts())
+
+        registry.save_model(model, "my-model", version="v1")
+
+        loaded = registry.load_model("my-model", version="v1")
+        assert isinstance(loaded, _DummyModel)
+        assert loaded.bias == 42.0
+        assert loaded.is_fitted_
+
+    def test_save_model_auto_version(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        model = _DummyModel()
+
+        v1 = registry.save_model(model, "auto-ver")
+        v2 = registry.save_model(model, "auto-ver")
+
+        assert v1 != v2
+        # Both versions loadable
+        registry.load_model("auto-ver", version=v1)
+        registry.load_model("auto-ver", version=v2)
+
+    def test_list_models(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        registry.save_model(_DummyModel(), "alpha")
+        registry.save_model(_DummyModel(), "beta")
+
+        names = registry.list_models()
+        assert set(names) == {"alpha", "beta"}
+
+    def test_list_versions(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        v1 = registry.save_model(_DummyModel(), "versioned")
+        v2 = registry.save_model(_DummyModel(), "versioned")
+
+        versions = registry.list_versions("versioned")
+        assert v1 in versions
+        assert v2 in versions
+        assert len(versions) == 2
+
+    def test_load_latest(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        registry.save_model(_DummyModel(bias=1.0), "latest-test")
+        registry.save_model(_DummyModel(bias=2.0), "latest-test")
+
+        loaded = registry.load_model("latest-test")
+        assert loaded.bias == 2.0
+
+    def test_load_nonexistent_raises(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            registry.load_model("does-not-exist")
+
+    def test_save_with_metadata(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        model = _DummyModel(bias=5.0)
+        model.fit(_make_ts())
+
+        registry.save_model(
+            model,
+            "meta-model",
+            version="v1",
+            metadata={"dataset": "test", "horizon": 3},
+        )
+
+        meta = registry.get_metadata("meta-model", version="v1")
+        assert meta["dataset"] == "test"
+        assert meta["horizon"] == 3
+
+    def test_delete_model(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        registry.save_model(_DummyModel(), "to-delete")
+        assert "to-delete" in registry.list_models()
+
+        registry.delete_model("to-delete")
+        assert "to-delete" not in registry.list_models()
+
+    def test_delete_version(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        v1 = registry.save_model(_DummyModel(), "multi-ver")
+        v2 = registry.save_model(_DummyModel(), "multi-ver")
+
+        registry.delete_version("multi-ver", v1)
+        versions = registry.list_versions("multi-ver")
+        assert v1 not in versions
+        assert v2 in versions
+
+    def test_save_and_load_experiment(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        exp = Experiment(name="my-exp")
+        exp.log_run(model_name="m1", config={"a": 1}, metrics={"mae": 1.0})
+        exp.log_run(model_name="m2", config={"a": 2}, metrics={"mae": 0.5})
+
+        registry.save_experiment(exp)
+        loaded = registry.load_experiment("my-exp")
+
+        assert loaded.name == "my-exp"
+        assert len(loaded.runs) == 2
+        assert loaded.runs[0].metrics["mae"] == 1.0
+
+    def test_list_experiments(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+
+        exp1 = Experiment(name="exp-a")
+        exp1.log_run(model_name="m", config={}, metrics={"mae": 1.0})
+        registry.save_experiment(exp1)
+
+        exp2 = Experiment(name="exp-b")
+        exp2.log_run(model_name="m", config={}, metrics={"mae": 2.0})
+        registry.save_experiment(exp2)
+
+        names = registry.list_experiments()
+        assert set(names) == {"exp-a", "exp-b"}
+
+    def test_log_run_to_registry(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+        model = _DummyModel(bias=1.0)
+        model.fit(_make_ts())
+
+        run = registry.log_run(
+            experiment_name="auto-exp",
+            model=model,
+            model_name="dummy",
+            config={"bias": 1.0},
+            metrics={"mae": 0.3},
+            save_model=True,
+        )
+
+        assert run.run_id is not None
+        # Experiment was created
+        exp = registry.load_experiment("auto-exp")
+        assert len(exp.runs) == 1
+        # Model was saved
+        loaded = registry.load_model("dummy", version=run.run_id)
+        assert loaded.bias == 1.0
+
+    def test_reproducibility_seed_tracking(self, tmp_path: Path):
+        registry = ModelRegistry(tmp_path)
+
+        registry.log_run(
+            experiment_name="seed-exp",
+            model=_DummyModel(),
+            model_name="dummy",
+            config={"bias": 0.0, "seed": 42},
+            metrics={"mae": 0.1},
+        )
+
+        exp = registry.load_experiment("seed-exp")
+        assert exp.runs[0].config["seed"] == 42

--- a/tests/test_kasba_clusterer.py
+++ b/tests/test_kasba_clusterer.py
@@ -1,0 +1,254 @@
+"""Tests for KASBAClusterer class and kasba() convenience function (issue #196).
+
+Covers the Polars-level API: DataFrame input/output, column types,
+fit/predict lifecycle, univariate and multivariate modes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.clustering.kasba import KASBAClusterer, kasba
+
+
+@pytest.fixture
+def univariate_df() -> pl.DataFrame:
+    """10 univariate series (2 clusters: ascending vs descending), 20 timepoints."""
+    rng = np.random.default_rng(42)
+    rows = []
+    for i in range(5):
+        vals = np.arange(20, dtype=np.float64) + rng.normal(0, 0.1, 20)
+        for t, v in enumerate(vals):
+            rows.append({"unique_id": f"up_{i}", "ds": t, "y": v})
+    for i in range(5):
+        vals = np.arange(19, -1, -1, dtype=np.float64) + rng.normal(0, 0.1, 20)
+        for t, v in enumerate(vals):
+            rows.append({"unique_id": f"down_{i}", "ds": t, "y": v})
+    return pl.DataFrame(rows)
+
+
+@pytest.fixture
+def multivariate_df() -> pl.DataFrame:
+    """6 multivariate series, 2 channels, 15 timepoints (2 clusters)."""
+    rng = np.random.default_rng(123)
+    rows = []
+    for i in range(3):
+        for ch in ["temp", "humidity"]:
+            vals = rng.normal(0, 1, 15)
+            for t, v in enumerate(vals):
+                rows.append({"unique_id": f"a_{i}", "ds": t, "channel": ch, "y": v})
+    for i in range(3):
+        for ch in ["temp", "humidity"]:
+            vals = rng.normal(10, 1, 15)
+            for t, v in enumerate(vals):
+                rows.append({"unique_id": f"b_{i}", "ds": t, "channel": ch, "y": v})
+    return pl.DataFrame(rows)
+
+
+class TestKASBAClustererFit:
+    """Test KASBAClusterer.fit() returns correct structure."""
+
+    def test_labels_is_dataframe(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert isinstance(clf.labels_, pl.DataFrame)
+
+    def test_labels_columns(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.labels_.columns == ["unique_id", "cluster"]
+
+    def test_labels_row_count(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.labels_.height == 10
+
+    def test_cluster_values_in_range(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        clusters = clf.labels_["cluster"].to_list()
+        assert all(0 <= c < 2 for c in clusters)
+
+    def test_centroids_shape(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.centroids_ is not None
+        assert clf.centroids_.shape == (2, 1 * 20)
+
+    def test_inertia_non_negative(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.inertia_ >= 0.0
+
+    def test_n_iter_positive(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.n_iter_ >= 1
+
+    def test_is_fitted_flag(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        assert not clf._is_fitted
+        clf.fit(univariate_df)
+        assert clf._is_fitted
+
+    def test_fit_returns_self(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        result = clf.fit(univariate_df)
+        assert result is clf
+
+    def test_deterministic_with_same_seed(self, univariate_df):
+        clf1 = KASBAClusterer(n_clusters=2, seed=42)
+        clf1.fit(univariate_df)
+        clf2 = KASBAClusterer(n_clusters=2, seed=42)
+        clf2.fit(univariate_df)
+        assert clf1.labels_.equals(clf2.labels_)
+
+    def test_id_dtype_preserved_string(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        assert clf.labels_["unique_id"].dtype == pl.String
+
+    def test_id_dtype_preserved_int(self, univariate_df):
+        df = univariate_df.with_columns(
+            pl.col("unique_id").str.replace("up_", "1").str.replace("down_", "2").cast(pl.Int64).alias("unique_id")
+        )
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(df)
+        assert clf.labels_["unique_id"].dtype == pl.Int64
+
+
+class TestKASBAClustererPredict:
+    """Test KASBAClusterer.predict()."""
+
+    def test_predict_before_fit_raises(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        with pytest.raises(RuntimeError, match="fit"):
+            clf.predict(univariate_df)
+
+    def test_predict_returns_dataframe(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        preds = clf.predict(univariate_df)
+        assert isinstance(preds, pl.DataFrame)
+        assert preds.columns == ["unique_id", "cluster"]
+
+    def test_predict_same_data_matches_fit(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        preds = clf.predict(univariate_df)
+        assert clf.labels_.sort("unique_id").equals(preds.sort("unique_id"))
+
+    def test_predict_new_data(self, univariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(univariate_df)
+        # Create a single new ascending series
+        new_df = pl.DataFrame(
+            {
+                "unique_id": ["new_up"] * 20,
+                "ds": list(range(20)),
+                "y": list(range(20)),
+            }
+        )
+        preds = clf.predict(new_df)
+        assert preds.height == 1
+        assert 0 <= preds["cluster"][0] < 2
+
+
+class TestKASBAClustererMultivariate:
+    """Test multivariate mode via channel_col."""
+
+    def test_multivariate_fit(self, multivariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(multivariate_df, channel_col="channel")
+        assert clf.labels_.height == 6
+        assert clf._n_channels == 2
+
+    def test_multivariate_centroids_shape(self, multivariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(multivariate_df, channel_col="channel")
+        assert clf.centroids_.shape == (2, 2 * 15)
+
+    def test_multivariate_independent_vs_dependent(self, multivariate_df):
+        clf_ind = KASBAClusterer(n_clusters=2, independent=True, seed=42)
+        clf_ind.fit(multivariate_df, channel_col="channel")
+
+        clf_dep = KASBAClusterer(n_clusters=2, independent=False, seed=42)
+        clf_dep.fit(multivariate_df, channel_col="channel")
+
+        # Both should produce valid results (may or may not differ)
+        assert clf_ind.labels_.height == 6
+        assert clf_dep.labels_.height == 6
+
+    def test_multivariate_predict(self, multivariate_df):
+        clf = KASBAClusterer(n_clusters=2)
+        clf.fit(multivariate_df, channel_col="channel")
+        preds = clf.predict(multivariate_df, channel_col="channel")
+        assert preds.height == 6
+
+
+class TestKasbaConvenienceFunction:
+    """Test the kasba() top-level function."""
+
+    def test_returns_dataframe(self, univariate_df):
+        result = kasba(univariate_df, k=2)
+        assert isinstance(result, pl.DataFrame)
+
+    def test_columns(self, univariate_df):
+        result = kasba(univariate_df, k=2)
+        assert result.columns == ["unique_id", "cluster"]
+
+    def test_row_count(self, univariate_df):
+        result = kasba(univariate_df, k=2)
+        assert result.height == 10
+
+    def test_cluster_range(self, univariate_df):
+        result = kasba(univariate_df, k=3)
+        clusters = result["cluster"].to_list()
+        assert all(0 <= c < 3 for c in clusters)
+
+    def test_custom_columns(self):
+        df = pl.DataFrame(
+            {
+                "item": ["a"] * 10 + ["b"] * 10,
+                "time": list(range(10)) * 2,
+                "value": list(range(10)) + list(range(9, -1, -1)),
+            }
+        )
+        result = kasba(df, k=2, id_col="item", target_col="value")
+        assert result.columns == ["item", "cluster"]
+        assert result.height == 2
+
+    def test_multivariate(self, multivariate_df):
+        result = kasba(multivariate_df, k=2, channel_col="channel")
+        assert result.height == 6
+
+    def test_deterministic(self, univariate_df):
+        r1 = kasba(univariate_df, k=2, seed=42)
+        r2 = kasba(univariate_df, k=2, seed=42)
+        assert r1.sort("unique_id").equals(r2.sort("unique_id"))
+
+    def test_kwargs_forwarded(self, univariate_df):
+        result = kasba(univariate_df, k=2, c=2.0, ba_subset_size=0.3)
+        assert result.height == 10
+
+
+class TestKASBAImports:
+    """Test that KASBA is properly registered in __init__.py."""
+
+    def test_import_from_clustering(self):
+        from polars_ts.clustering import KASBAClusterer as C1
+        from polars_ts.clustering import kasba as f1
+
+        assert C1 is KASBAClusterer
+        # kasba may resolve to the module due to same-name module;
+        # verify the callable is accessible
+        assert callable(f1) or hasattr(f1, "kasba")
+
+    def test_import_from_top_level(self):
+        from polars_ts import KASBAClusterer as C2
+        from polars_ts import kasba as f2
+
+        assert C2 is KASBAClusterer
+        assert f2 is kasba


### PR DESCRIPTION
## Summary

- Add file-system-backed `ModelRegistry` with model save/load, versioning, metadata, and delete
- Add `Experiment` and `Run` dataclasses for tracking configs, metrics, tags, and timestamps
- Leaderboard generation (`leaderboard()`, `best_run()`, `to_dataframe()`) via Polars DataFrames
- Convenience `log_run()` API to log experiment + optionally persist model in one call
- Registered in top-level `polars_ts` lazy imports (`ModelRegistry`, `Experiment`, `Run`)

Closes #168

## Test plan

- [x] 23 tests across 4 classes (TestRun, TestExperiment, TestModelRegistry)
- [x] Covers: save/load roundtrip, auto-versioning, latest version, metadata, delete model/version, experiment persistence, log_run convenience, seed tracking
- [x] ruff check + ruff format pass cleanly
- [ ] CI pipeline passes