### PR TITLE
refactor: standardize lazy import pattern across all submodules (#217)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -248,6 +248,18 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ModelRegistry": ("polars_ts.registry", "ModelRegistry"),
     "Experiment": ("polars_ts.registry", "Experiment"),
     "Run": ("polars_ts.registry", "Run"),
+    # --- Bayesian ---
+    "KalmanFilter": ("polars_ts.bayesian", "KalmanFilter"),
+    "kalman_filter": ("polars_ts.bayesian", "kalman_filter"),
+    "UnscentedKalmanFilter": ("polars_ts.bayesian", "UnscentedKalmanFilter"),
+    "EnsembleKalmanFilter": ("polars_ts.bayesian", "EnsembleKalmanFilter"),
+    "BSTS": ("polars_ts.bayesian", "BSTS"),
+    "bsts_fit": ("polars_ts.bayesian", "bsts_fit"),
+    "bsts_forecast": ("polars_ts.bayesian", "bsts_forecast"),
+    "GaussianProcessTS": ("polars_ts.bayesian", "GaussianProcessTS"),
+    "gp_forecast": ("polars_ts.bayesian", "gp_forecast"),
+    "MCMCForecaster": ("polars_ts.bayesian", "MCMCForecaster"),
+    "mcmc_forecast": ("polars_ts.bayesian", "mcmc_forecast"),
 }
 
 
@@ -258,22 +270,6 @@ def __getattr__(name: str) -> Any:
         mod_path, attr = _LAZY_IMPORTS[name]
         mod = importlib.import_module(mod_path)
         return getattr(mod, attr)
-    if name in {
-        "KalmanFilter",
-        "kalman_filter",
-        "UnscentedKalmanFilter",
-        "EnsembleKalmanFilter",
-        "BSTS",
-        "bsts_fit",
-        "bsts_forecast",
-        "GaussianProcessTS",
-        "gp_forecast",
-        "MCMCForecaster",
-        "mcmc_forecast",
-    }:
-        from polars_ts import bayesian as _bayes
-
-        return getattr(_bayes, name)
     raise AttributeError(f"module 'polars_ts' has no attribute {name!r}")
 
 

--- a/polars_ts/metrics/__init__.py
+++ b/polars_ts/metrics/__init__.py
@@ -1,3 +1,6 @@
+# NOTE: This module intentionally uses eager imports (not make_getattr) because
+# the @pl.api.register_dataframe_namespace("pts") decorator must execute at
+# import time to register the Polars DataFrame namespace.
 from collections.abc import Generator
 from dataclasses import dataclass
 

--- a/polars_ts/streaming/__init__.py
+++ b/polars_ts/streaming/__init__.py
@@ -7,14 +7,13 @@ Provides incremental model updates for streaming time series data:
 - SlidingWindowManager: Memory-efficient windowed state management
 """
 
-from polars_ts.streaming.ets import StreamingETS
-from polars_ts.streaming.global_model import StreamingGlobalForecaster
-from polars_ts.streaming.kalman import StreamingKalmanFilter
-from polars_ts.streaming.window import SlidingWindowManager
+from polars_ts._lazy import make_getattr
 
-__all__ = [
-    "StreamingETS",
-    "StreamingKalmanFilter",
-    "StreamingGlobalForecaster",
-    "SlidingWindowManager",
-]
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "StreamingETS": ("polars_ts.streaming.ets", "StreamingETS"),
+    "StreamingKalmanFilter": ("polars_ts.streaming.kalman", "StreamingKalmanFilter"),
+    "StreamingGlobalForecaster": ("polars_ts.streaming.global_model", "StreamingGlobalForecaster"),
+    "SlidingWindowManager": ("polars_ts.streaming.window", "SlidingWindowManager"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,5 +1,9 @@
 """Tests for lazy-loaded module imports via polars_ts.__getattr__."""
 
+import ast
+import importlib
+import sys
+
 import pytest
 
 import polars_ts
@@ -50,3 +54,148 @@ class TestLazyImports:
 
     def test_cusum_is_callable(self):
         assert callable(polars_ts.cusum)
+
+
+class TestBayesianLazyImports:
+    """T3.2: Bayesian names must be in _LAZY_IMPORTS, not a special-case if-block."""
+
+    BAYESIAN_NAMES = [
+        "KalmanFilter",
+        "kalman_filter",
+        "UnscentedKalmanFilter",
+        "EnsembleKalmanFilter",
+        "BSTS",
+        "bsts_fit",
+        "bsts_forecast",
+        "GaussianProcessTS",
+        "gp_forecast",
+        "MCMCForecaster",
+        "mcmc_forecast",
+    ]
+
+    @pytest.mark.parametrize("name", BAYESIAN_NAMES)
+    def test_bayesian_in_lazy_imports(self, name):
+        """Every bayesian name should be registered in _LAZY_IMPORTS."""
+        assert name in polars_ts._LAZY_IMPORTS, (
+            f"{name!r} is not in polars_ts._LAZY_IMPORTS — " f"it may still be in a special-case if-block"
+        )
+
+    @pytest.mark.parametrize("name", BAYESIAN_NAMES)
+    def test_bayesian_resolves_from_top_level(self, name):
+        """Bayesian names must resolve via polars_ts.<name>."""
+        obj = getattr(polars_ts, name)
+        assert obj is not None
+
+    def test_no_special_case_if_block_in_getattr(self):
+        """The __getattr__ in __init__.py must not contain hardcoded name sets."""
+        import inspect
+
+        source = inspect.getsource(polars_ts.__getattr__)
+        assert "KalmanFilter" not in source, (
+            "__getattr__ still contains hardcoded 'KalmanFilter' — " "bayesian names should be in _LAZY_IMPORTS"
+        )
+
+    def test_bayesian_in_all(self):
+        """All bayesian names should appear in __all__."""
+        for name in self.BAYESIAN_NAMES:
+            assert name in polars_ts.__all__, f"{name!r} missing from polars_ts.__all__"
+
+
+class TestStreamingLazyImports:
+    """T3.1: streaming/__init__.py must use make_getattr, not eager imports."""
+
+    STREAMING_NAMES = [
+        "StreamingETS",
+        "StreamingKalmanFilter",
+        "StreamingGlobalForecaster",
+        "SlidingWindowManager",
+    ]
+
+    def test_streaming_uses_make_getattr(self):
+        """streaming/__init__.py must define __getattr__ via make_getattr."""
+        import polars_ts.streaming as streaming_mod
+
+        source_path = streaming_mod.__file__
+        with open(source_path) as f:
+            tree = ast.parse(f.read())
+
+        # Should NOT have top-level "from polars_ts.streaming.X import Y" statements
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("polars_ts.streaming."):
+                pytest.fail(
+                    f"streaming/__init__.py has eager import: 'from {node.module} import ...'. "
+                    f"Should use make_getattr pattern instead."
+                )
+
+    def test_streaming_has_getattr_from_make_getattr(self):
+        """Streaming module should have __getattr__ defined by make_getattr."""
+        import polars_ts.streaming as streaming_mod
+
+        assert hasattr(streaming_mod, "__getattr__"), "streaming module missing __getattr__"
+        assert callable(streaming_mod.__getattr__)
+
+    @pytest.mark.parametrize("name", STREAMING_NAMES)
+    def test_streaming_names_resolve(self, name):
+        """All streaming names must still resolve after conversion."""
+        import polars_ts.streaming as streaming_mod
+
+        obj = getattr(streaming_mod, name)
+        assert obj is not None
+
+    @pytest.mark.parametrize("name", STREAMING_NAMES)
+    def test_streaming_names_in_submodule_all(self, name):
+        """All streaming names should appear in streaming.__all__."""
+        import polars_ts.streaming as streaming_mod
+
+        assert name in streaming_mod.__all__, f"{name!r} missing from streaming.__all__"
+
+    def test_streaming_lazy_import_no_submodule_loaded_at_import_time(self):
+        """Importing polars_ts.streaming should not eagerly load submodules."""
+        # Remove streaming submodules from sys.modules to test fresh import
+        streaming_submodules = [k for k in sys.modules if k.startswith("polars_ts.streaming.")]
+        saved = {k: sys.modules.pop(k) for k in streaming_submodules}
+        # Also remove streaming itself
+        if "polars_ts.streaming" in sys.modules:
+            saved["polars_ts.streaming"] = sys.modules.pop("polars_ts.streaming")
+
+        try:
+            importlib.import_module("polars_ts.streaming")
+            loaded = [k for k in sys.modules if k.startswith("polars_ts.streaming.")]
+            assert loaded == [], f"Importing polars_ts.streaming eagerly loaded submodules: {loaded}"
+        finally:
+            # Restore original modules
+            sys.modules.update(saved)
+
+
+class TestMetricsIntentionalEager:
+    """T3.3: metrics/__init__.py uses eager imports intentionally (Polars namespace)."""
+
+    def test_metrics_namespace_registers(self):
+        """The Polars .pts namespace must be available after importing polars_ts.metrics."""
+        import polars as pl
+
+        import polars_ts.metrics  # noqa: F401 — triggers @register_dataframe_namespace
+
+        df = pl.DataFrame({"y": [1.0, 2.0], "y_hat": [1.1, 2.1]})
+        assert hasattr(df, "pts"), "Polars .pts namespace not registered"
+        assert hasattr(df.pts, "mae"), "Polars .pts.mae not available"
+
+    def test_metrics_uses_eager_imports_intentionally(self):
+        """metrics/__init__.py must use eager imports for Polars namespace registration."""
+        import ast
+
+        import polars_ts.metrics as metrics_mod
+
+        source_path = metrics_mod.__file__
+        with open(source_path) as f:
+            tree = ast.parse(f.read())
+
+        has_register_decorator = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "register_dataframe_namespace":
+                has_register_decorator = True
+                break
+        assert has_register_decorator, (
+            "metrics/__init__.py should use @pl.api.register_dataframe_namespace — "
+            "it needs eager imports, not make_getattr"
+        )


### PR DESCRIPTION
## Summary

Phase 3 of the tech debt refactoring plan (#214). Standardizes lazy imports across all submodule `__init__.py` files.

- **T3.1**: Convert `streaming/__init__.py` from eager imports to `make_getattr` pattern — submodules are no longer loaded at import time
- **T3.2**: Move 11 bayesian names from special-case `if`-block in `__init__.py` into `_LAZY_IMPORTS` dict — eliminates the last hardcoded name set in `__getattr__`
- **T3.3**: Document `metrics/__init__.py` intentional eager imports (required for `@pl.api.register_dataframe_namespace`)

### Files changed
- `polars_ts/__init__.py` — bayesian names moved to `_LAZY_IMPORTS`, special-case block removed
- `polars_ts/streaming/__init__.py` — converted to `make_getattr`
- `polars_ts/metrics/__init__.py` — added rationale comment
- `tests/test_lazy_imports.py` — 37 new tests (50 total): registry checks, resolution, AST guards, lazy-load verification

## Test plan
- [x] 50 lazy import tests pass (`pytest tests/test_lazy_imports.py`)
- [x] 68 streaming tests pass (`pytest tests/test_streaming.py`)
- [x] 118 targeted tests pass with 0 regressions
- [x] `ruff check` + `ruff format` clean

Closes #217