### PR TITLE
refactor: audit __all__ exports, drop private names from public API (#219)

### DIFF
--- a/polars_ts/bayesian_var/__init__.py
+++ b/polars_ts/bayesian_var/__init__.py
@@ -4,15 +4,19 @@ from polars_ts.bayesian_var.model import (
     BayesianVAR,
     InferenceMethod,
     PriorType,
-    _build_var_matrices,
     bayesian_var,
 )
+
+# Internal helpers re-exported for backward compatibility with the pre-split
+# single-module import paths. They are intentionally kept out of __all__ since
+# they are private API; import them directly from the submodules instead.
+from polars_ts.bayesian_var.model import _build_var_matrices as _build_var_matrices
 from polars_ts.bayesian_var.priors import (
     MinnesotaPrior,
     NormalWishartPrior,
-    _estimate_sigma_from_ar,
-    _minnesota_prior_precision,
 )
+from polars_ts.bayesian_var.priors import _estimate_sigma_from_ar as _estimate_sigma_from_ar
+from polars_ts.bayesian_var.priors import _minnesota_prior_precision as _minnesota_prior_precision
 from polars_ts.bayesian_var.results import BayesianVARResult
 
 __all__ = [
@@ -22,8 +26,5 @@ __all__ = [
     "MinnesotaPrior",
     "NormalWishartPrior",
     "PriorType",
-    "_build_var_matrices",
-    "_estimate_sigma_from_ar",
-    "_minnesota_prior_precision",
     "bayesian_var",
 ]

--- a/polars_ts/metrics/__init__.py
+++ b/polars_ts/metrics/__init__.py
@@ -20,6 +20,16 @@ try:
 except ImportError:
     _StatsForecast = None
 
+__all__ = [
+    "Metrics",
+    "crps",
+    "mae",
+    "mape",
+    "mase",
+    "rmse",
+    "smape",
+]
+
 
 @dataclass
 @pl.api.register_dataframe_namespace("pts")

--- a/polars_ts/models/bayesian_ets/__init__.py
+++ b/polars_ts/models/bayesian_ets/__init__.py
@@ -1,16 +1,17 @@
 """Bayesian Exponential Smoothing (Bayesian ETS)."""
 
-from polars_ts.models.bayesian_ets.inference import (
-    _forecast_from_params,
-    _holt_loglik,
-    _hw_loglik,
-    _log_posterior,
-    _map_estimate,
-    _mcmc_sample,
-    _pack_params,
-    _ses_loglik,
-    _unpack_params,
-)
+# Internal helpers re-exported for backward compatibility with the pre-split
+# single-module import paths. They are intentionally kept out of __all__ since
+# they are private API; import them directly from the submodule instead.
+from polars_ts.models.bayesian_ets.inference import _forecast_from_params as _forecast_from_params
+from polars_ts.models.bayesian_ets.inference import _holt_loglik as _holt_loglik
+from polars_ts.models.bayesian_ets.inference import _hw_loglik as _hw_loglik
+from polars_ts.models.bayesian_ets.inference import _log_posterior as _log_posterior
+from polars_ts.models.bayesian_ets.inference import _map_estimate as _map_estimate
+from polars_ts.models.bayesian_ets.inference import _mcmc_sample as _mcmc_sample
+from polars_ts.models.bayesian_ets.inference import _pack_params as _pack_params
+from polars_ts.models.bayesian_ets.inference import _ses_loglik as _ses_loglik
+from polars_ts.models.bayesian_ets.inference import _unpack_params as _unpack_params
 from polars_ts.models.bayesian_ets.model import BayesianETS, BayesianETSResult, bayesian_ets
 from polars_ts.models.bayesian_ets.priors import ETSPriors, InferenceMethod, ModelType
 
@@ -20,14 +21,5 @@ __all__ = [
     "ETSPriors",
     "InferenceMethod",
     "ModelType",
-    "_forecast_from_params",
-    "_holt_loglik",
-    "_hw_loglik",
-    "_log_posterior",
-    "_map_estimate",
-    "_mcmc_sample",
-    "_pack_params",
-    "_ses_loglik",
-    "_unpack_params",
     "bayesian_ets",
 ]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -42,7 +42,7 @@
 - [ ] T7.6: Run registry + dataset + embedding tests
 
 ## Phase 8: Public API & Export Consistency
-- [ ] T8.1: Remove private `_` functions from `__all__` in `bayesian_var/` and `bayesian_ets/`
+- [x] T8.1: Remove private `_` functions from `__all__` in `bayesian_var/` and `bayesian_ets/` (kept as backward-compat re-exports)
 - [ ] T8.2: Add missing classes to root `_LAZY_IMPORTS` (MCMCResult, Kaboudan, DL forecasters, etc.)
-- [ ] T8.3: Audit `__all__` exports across all modules
-- [ ] T8.4: Run `test_lazy_imports.py`
+- [x] T8.3: Audit `__all__` exports across all modules (added `__all__` to `metrics/`; regression test `TestAllExportHygiene`)
+- [x] T8.4: Run `test_lazy_imports.py`

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -76,9 +76,9 @@ class TestBayesianLazyImports:
     @pytest.mark.parametrize("name", BAYESIAN_NAMES)
     def test_bayesian_in_lazy_imports(self, name):
         """Every bayesian name should be registered in _LAZY_IMPORTS."""
-        assert name in polars_ts._LAZY_IMPORTS, (
-            f"{name!r} is not in polars_ts._LAZY_IMPORTS — " f"it may still be in a special-case if-block"
-        )
+        assert (
+            name in polars_ts._LAZY_IMPORTS
+        ), f"{name!r} is not in polars_ts._LAZY_IMPORTS — it may still be in a special-case if-block"
 
     @pytest.mark.parametrize("name", BAYESIAN_NAMES)
     def test_bayesian_resolves_from_top_level(self, name):
@@ -91,9 +91,9 @@ class TestBayesianLazyImports:
         import inspect
 
         source = inspect.getsource(polars_ts.__getattr__)
-        assert "KalmanFilter" not in source, (
-            "__getattr__ still contains hardcoded 'KalmanFilter' — " "bayesian names should be in _LAZY_IMPORTS"
-        )
+        assert (
+            "KalmanFilter" not in source
+        ), "__getattr__ still contains hardcoded 'KalmanFilter' — bayesian names should be in _LAZY_IMPORTS"
 
     def test_bayesian_in_all(self):
         """All bayesian names should appear in __all__."""
@@ -199,3 +199,42 @@ class TestMetricsIntentionalEager:
             "metrics/__init__.py should use @pl.api.register_dataframe_namespace — "
             "it needs eager imports, not make_getattr"
         )
+
+
+class TestAllExportHygiene:
+    """T5.2 (#219): __all__ across every package must declare only public API."""
+
+    @staticmethod
+    def _iter_init_alls():
+        """Yield (module_name, __all__) for every package __init__ that defines __all__."""
+        import pathlib
+
+        root = pathlib.Path(polars_ts.__file__).parent
+        for init in sorted(root.rglob("__init__.py")):
+            rel = init.relative_to(root.parent).with_suffix("")
+            modname = ".".join(rel.parts)
+            if modname.endswith(".__init__"):
+                modname = modname[: -len(".__init__")]
+            mod = importlib.import_module(modname)
+            names = getattr(mod, "__all__", None)
+            if names is not None:
+                yield modname, list(names)
+
+    def test_no_private_names_in_all(self):
+        """No __all__ may advertise a private (underscore-prefixed) name as public API."""
+        offenders = {modname: [n for n in names if n.startswith("_")] for modname, names in self._iter_init_alls()}
+        offenders = {m: p for m, p in offenders.items() if p}
+        assert not offenders, f"Private names leaked into __all__: {offenders}"
+
+    def test_all_entries_are_strings_and_unique(self):
+        """Each __all__ must be a list of unique string identifiers."""
+        for modname, names in self._iter_init_alls():
+            assert all(isinstance(n, str) for n in names), f"{modname}.__all__ has non-string entries"
+            assert len(names) == len(set(names)), f"{modname}.__all__ has duplicates"
+
+    def test_metrics_declares_all(self):
+        """metrics/__init__.py must declare __all__ (eager namespace module, previously missing)."""
+        import polars_ts.metrics as metrics_mod
+
+        assert hasattr(metrics_mod, "__all__"), "polars_ts.metrics is missing __all__"
+        assert "Metrics" in metrics_mod.__all__


### PR DESCRIPTION
## Summary

Completes **Phase 5 / T5.2** of the tech-debt plan (#214): audit `__all__` across every package so each declares only its public API. With T5.1 (the dedicated `_distance_dispatch` test) already landed, this closes out Phase 5.

Closes #219.

## Changes

- **`polars_ts/metrics/__init__.py`** — added the missing `__all__` (`Metrics` + the 6 public metric functions). This was the only `__init__.py` with no `__all__`.
- **`polars_ts/bayesian_var/__init__.py`** & **`models/bayesian_ets/__init__.py`** — removed 12 private `_`-prefixed names from `__all__`. They remain importable from the package as explicit `_x as _x` backward-compat re-exports, so pre-split import paths (and `test_backward_compat_import_from_package`) still work — `__all__` just no longer advertises private API as public.
- **`tests/test_lazy_imports.py`** — added `TestAllExportHygiene` regression guard: no private names in any `__all__`, unique string entries, and `metrics` declares `__all__`.
- **`tasks/todo.md`** — ticked T8.1/T8.3/T8.4.

## Verification

- Runtime audit: no private names in any of the 25 `__init__.py` `__all__` lists; all `__all__` names resolve (remaining unresolved hits are the known optional-dep torch/statsforecast venv failures, not dangling names).
- `ruff check` + `ruff format` clean.
- Tests: **185 passed** across `test_lazy_imports`, `test_bayesian_var`, `test_bayesian_ets` (229 passed / 11 skipped including `tests/metrics`).

Single commit, rebased on current `main`.