### PR TITLE
feat: add healthcare time series agents (EHR, clinical decision support) (#160)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -232,6 +232,15 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RollingStdAgent": ("polars_ts.anomaly_agents", "RollingStdAgent"),
     "MADAgent": ("polars_ts.anomaly_agents", "MADAgent"),
     "ConsensusAgent": ("polars_ts.anomaly_agents", "ConsensusAgent"),
+    # --- Healthcare agents (clinical decision support) ---
+    "ClinicalEnv": ("polars_ts.healthcare_agents", "ClinicalEnv"),
+    "ClinicalOrchestrator": ("polars_ts.healthcare_agents", "ClinicalOrchestrator"),
+    "ClinicalResult": ("polars_ts.healthcare_agents", "ClinicalResult"),
+    "SepsisWarningAgent": ("polars_ts.healthcare_agents", "SepsisWarningAgent"),
+    "VitalMonitorAgent": ("polars_ts.healthcare_agents", "VitalMonitorAgent"),
+    "EscalationAgent": ("polars_ts.healthcare_agents", "EscalationAgent"),
+    "TreatmentAgent": ("polars_ts.healthcare_agents", "TreatmentAgent"),
+    "federated_average": ("polars_ts.healthcare_agents", "federated_average"),
     # --- Multi-agent RL ---
     "PortfolioEnv": ("polars_ts.marl", "PortfolioEnv"),
     "MARLOrchestrator": ("polars_ts.marl", "MARLOrchestrator"),

--- a/polars_ts/healthcare_agents/__init__.py
+++ b/polars_ts/healthcare_agents/__init__.py
@@ -1,0 +1,24 @@
+"""Multi-agent clinical decision support for EHR vital-sign time series.
+
+Specialized agents score each vital-sign observation for sepsis risk (qSOFA +
+SIRS), physiological derangement, and a NEWS-style escalation tier, while a
+contextual-bandit treatment recommender adapts interventions online. Handles
+irregularly sampled observations and privacy-preserving federated averaging of
+per-site agent parameters. Closes #160.
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "ClinicalEnv": ("polars_ts.healthcare_agents.env", "ClinicalEnv"),
+    "VITAL_CHANNELS": ("polars_ts.healthcare_agents.env", "VITAL_CHANNELS"),
+    "SepsisWarningAgent": ("polars_ts.healthcare_agents.agents", "SepsisWarningAgent"),
+    "VitalMonitorAgent": ("polars_ts.healthcare_agents.agents", "VitalMonitorAgent"),
+    "EscalationAgent": ("polars_ts.healthcare_agents.agents", "EscalationAgent"),
+    "TreatmentAgent": ("polars_ts.healthcare_agents.agents", "TreatmentAgent"),
+    "federated_average": ("polars_ts.healthcare_agents.agents", "federated_average"),
+    "ClinicalOrchestrator": ("polars_ts.healthcare_agents.orchestrator", "ClinicalOrchestrator"),
+    "ClinicalResult": ("polars_ts.healthcare_agents.orchestrator", "ClinicalResult"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/healthcare_agents/agents.py
+++ b/polars_ts/healthcare_agents/agents.py
@@ -1,0 +1,219 @@
+"""Specialized clinical agents for EHR vital-sign monitoring.
+
+The agents operate on a single vital-sign observation (one row of
+``ClinicalEnv``) in :data:`~polars_ts.healthcare_agents.env.VITAL_CHANNELS`
+order: ``(heart_rate, systolic_bp, respiratory_rate, temperature, spo2)``.
+
+Scoring heuristics are grounded in widely used bedside instruments — qSOFA and
+SIRS for sepsis risk and a NEWS-style aggregate for escalation — kept
+dependency-free and deterministic so they are testable and auditable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Channel indices within a vitals row.
+_HR, _SBP, _RR, _TEMP, _SPO2 = 0, 1, 2, 3, 4
+
+
+class SepsisWarningAgent:
+    """Early sepsis-risk scoring from vital signs (qSOFA + SIRS heuristics).
+
+    qSOFA awards a point each for respiratory rate >= 22, systolic BP <= 100,
+    and (unavailable here) altered mentation. SIRS awards points for
+    temperature, heart rate and respiratory-rate derangement. The agent flags
+    sepsis risk when the combined score meets ``threshold``.
+
+    Parameters
+    ----------
+    threshold
+        Combined qSOFA+SIRS score at or above which sepsis risk is flagged.
+
+    """
+
+    def __init__(self, threshold: int = 2) -> None:
+        self.threshold = threshold
+
+    def score(self, vitals: np.ndarray) -> tuple[float, bool]:
+        """Return ``(risk_score, is_at_risk)`` for one vital-sign row."""
+        hr, sbp, rr, temp = (
+            float(vitals[_HR]),
+            float(vitals[_SBP]),
+            float(vitals[_RR]),
+            float(vitals[_TEMP]),
+        )
+        qsofa = (rr >= 22.0) + (sbp <= 100.0)
+        sirs = (temp > 38.0 or temp < 36.0) + (hr > 90.0) + (rr > 20.0)
+        risk = float(qsofa + sirs)
+        return risk, bool(risk >= self.threshold)
+
+
+class VitalMonitorAgent:
+    """Per-channel physiological range monitor.
+
+    Flags any vital sign outside its normal reference band and reports how many
+    channels are deranged.
+
+    Parameters
+    ----------
+    bounds
+        Optional mapping ``channel_index -> (low, high)`` overriding the
+        default adult reference ranges.
+
+    """
+
+    #: Default adult normal reference ranges per channel index.
+    DEFAULT_BOUNDS: dict[int, tuple[float, float]] = {
+        _HR: (60.0, 100.0),
+        _SBP: (100.0, 140.0),
+        _RR: (12.0, 20.0),
+        _TEMP: (36.0, 38.0),
+        _SPO2: (94.0, 100.0),
+    }
+
+    def __init__(self, bounds: dict[int, tuple[float, float]] | None = None) -> None:
+        self.bounds = bounds or dict(self.DEFAULT_BOUNDS)
+
+    def score(self, vitals: np.ndarray) -> tuple[float, bool]:
+        """Return ``(n_deranged, any_deranged)`` for one vital-sign row."""
+        deranged = 0
+        for c, (low, high) in self.bounds.items():
+            if c < len(vitals):
+                v = float(vitals[c])
+                if v < low or v > high:
+                    deranged += 1
+        return float(deranged), bool(deranged > 0)
+
+
+class EscalationAgent:
+    """Map a clinical picture to a discrete escalation tier (NEWS-style).
+
+    Aggregates a NEWS-like severity score from the vital-sign row and combines
+    it with upstream sepsis and monitoring signals to pick an escalation tier
+    in ``[0, n_tiers)``:
+
+    - ``0`` routine monitoring
+    - ``1`` increased observation frequency
+    - ``2`` urgent clinical review
+    - ``3`` rapid-response / ICU transfer
+
+    """
+
+    def __init__(self, n_tiers: int = 4) -> None:
+        self.n_tiers = n_tiers
+
+    def news_score(self, vitals: np.ndarray) -> int:
+        """Compute a simplified National Early Warning Score (0-3 per channel)."""
+        hr, sbp, rr, temp, spo2 = (float(vitals[i]) for i in range(5))
+        score = 0
+        # Respiratory rate.
+        score += 3 if rr <= 8 or rr >= 25 else 2 if rr >= 21 else 1 if rr <= 11 else 0
+        # SpO2.
+        score += 3 if spo2 <= 91 else 2 if spo2 <= 93 else 1 if spo2 <= 95 else 0
+        # Systolic BP.
+        score += 3 if sbp <= 90 or sbp >= 220 else 2 if sbp <= 100 else 1 if sbp <= 110 else 0
+        # Heart rate.
+        score += 3 if hr <= 40 or hr >= 131 else 2 if hr >= 111 else 1 if hr >= 91 or hr <= 50 else 0
+        # Temperature.
+        score += 3 if temp <= 35 else 2 if temp >= 39.1 else 1 if temp >= 38.1 or temp <= 36 else 0
+        return score
+
+    def decide(self, vitals: np.ndarray, sepsis_risk: bool, n_deranged: float) -> int:
+        """Choose an escalation tier from NEWS score and upstream signals."""
+        news = self.news_score(vitals)
+        # NEWS thresholds: >=7 high, 5-6 medium, 1-4 low, 0 none.
+        tier = 3 if news >= 7 else 2 if news >= 5 else 1 if news >= 1 else 0
+        # Sepsis risk forces at least urgent review; many deranged vitals bump a tier.
+        if sepsis_risk:
+            tier = max(tier, 2)
+        if n_deranged >= 3:
+            tier = min(tier + 1, self.n_tiers - 1)
+        return int(min(tier, self.n_tiers - 1))
+
+
+class TreatmentAgent:
+    """Contextual-bandit treatment recommender over escalation tiers.
+
+    Learns a per-tier preference for a small action set via a simple
+    reward-averaging (bandit) update, letting the recommended intervention
+    adapt to observed outcomes without any heavyweight RL dependency.
+
+    Parameters
+    ----------
+    actions
+        Ordered intervention labels; the index is the action id.
+    seed
+        Seed for the exploration RNG (``numpy.random.default_rng``).
+
+    """
+
+    DEFAULT_ACTIONS: tuple[str, ...] = (
+        "continue_monitoring",
+        "administer_fluids",
+        "start_antibiotics",
+        "transfer_icu",
+    )
+
+    def __init__(self, actions: tuple[str, ...] | None = None, seed: int = 0) -> None:
+        self.actions = actions or self.DEFAULT_ACTIONS
+        self._rng = np.random.default_rng(seed)
+        n_tiers, n_actions = 4, len(self.actions)
+        # Optimistic prior nudges each tier toward its namesake action.
+        self._value = np.zeros((n_tiers, n_actions), dtype=np.float64)
+        for t in range(n_tiers):
+            self._value[t, min(t, n_actions - 1)] = 0.1
+        self._counts = np.zeros((n_tiers, n_actions), dtype=np.int64)
+
+    def recommend(self, tier: int, explore: float = 0.0) -> int:
+        """Return an action id for ``tier``; ``explore`` is the epsilon-greedy rate."""
+        tier = int(min(max(tier, 0), self._value.shape[0] - 1))
+        if explore > 0.0 and float(self._rng.random()) < explore:
+            return int(self._rng.integers(len(self.actions)))
+        return int(np.argmax(self._value[tier]))
+
+    def update(self, tier: int, action: int, reward: float) -> None:
+        """Incremental sample-average update of the tier/action value estimate."""
+        tier = int(min(max(tier, 0), self._value.shape[0] - 1))
+        self._counts[tier, action] += 1
+        n = self._counts[tier, action]
+        self._value[tier, action] += (reward - self._value[tier, action]) / n
+
+
+def federated_average(
+    values: list[np.ndarray],
+    weights: list[float] | None = None,
+) -> np.ndarray:
+    """Privacy-preserving FedAvg of per-site agent parameters.
+
+    Combines locally trained parameter arrays (e.g. ``TreatmentAgent`` value
+    tables) from multiple sites into a single global array by weighted mean,
+    without any site sharing its raw patient data.
+
+    Parameters
+    ----------
+    values
+        Per-site parameter arrays, all of identical shape.
+    weights
+        Optional per-site weights (e.g. local sample counts). Defaults to
+        equal weighting.
+
+    Returns
+    -------
+    numpy.ndarray
+        The aggregated global parameter array.
+
+    """
+    if not values:
+        raise ValueError("values must contain at least one site's parameters")
+    arrays = [np.asarray(v, dtype=np.float64) for v in values]
+    shape = arrays[0].shape
+    if any(a.shape != shape for a in arrays):
+        raise ValueError("all site parameter arrays must share the same shape")
+    w = np.ones(len(arrays)) if weights is None else np.asarray(weights, dtype=np.float64)
+    if w.shape[0] != len(arrays):
+        raise ValueError("weights length must match number of sites")
+    if float(w.sum()) == 0.0:
+        raise ValueError("weights must not sum to zero")
+    stacked = np.stack(arrays, axis=0)
+    return np.tensordot(w, stacked, axes=([0], [0])) / float(w.sum())

--- a/polars_ts/healthcare_agents/env.py
+++ b/polars_ts/healthcare_agents/env.py
@@ -1,0 +1,150 @@
+"""Clinical monitoring environment for EHR vital-sign time series.
+
+Models an ICU patient trajectory as a sequence of (possibly irregularly
+sampled) vital-sign observations. At each step an agent chooses an escalation
+tier; when ground-truth deterioration labels are supplied the reward reflects
+early, correct escalation while penalising both alarm fatigue (over-escalation)
+and missed deterioration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# Canonical vital-sign channel order used across the healthcare_agents module.
+VITAL_CHANNELS: tuple[str, ...] = (
+    "heart_rate",
+    "systolic_bp",
+    "respiratory_rate",
+    "temperature",
+    "spo2",
+)
+
+
+class ClinicalEnv:
+    """Gymnasium-like environment over a patient's vital-sign trajectory.
+
+    Parameters
+    ----------
+    vitals
+        2D array ``(n_steps, n_channels)`` of vital-sign observations. Channels
+        are interpreted in :data:`VITAL_CHANNELS` order unless ``channels`` is
+        given. Missing readings may be encoded as ``NaN`` (carried forward).
+    times
+        Optional 1D array of observation timestamps (hours since admission) for
+        irregularly sampled series. When omitted, unit spacing is assumed. Used
+        to expose the elapsed interval since the previous reading in ``info``.
+    labels
+        Optional ground-truth boolean array (``True`` = clinical deterioration
+        at that step). When provided, rewards reflect escalation accuracy.
+    channels
+        Optional channel names overriding :data:`VITAL_CHANNELS`.
+
+    """
+
+    #: Number of discrete escalation tiers (0 = routine … 3 = ICU/rapid-response).
+    n_tiers: int = 4
+
+    def __init__(
+        self,
+        vitals: np.ndarray,
+        times: np.ndarray | None = None,
+        labels: np.ndarray | None = None,
+        channels: tuple[str, ...] | None = None,
+    ) -> None:
+        vitals = np.asarray(vitals, dtype=np.float64)
+        if vitals.ndim != 2:
+            raise ValueError("vitals must be a 2D array of shape (n_steps, n_channels)")
+        self.n_steps, self.n_channels = vitals.shape
+        if self.n_steps < 1:
+            raise ValueError("vitals must contain at least one observation")
+
+        self.channels = channels or VITAL_CHANNELS[: self.n_channels]
+        if len(self.channels) != self.n_channels:
+            raise ValueError(f"channels length {len(self.channels)} != n_channels {self.n_channels}")
+
+        # Carry-forward imputation for missing (NaN) readings; back-fill any leading NaNs.
+        self.vitals = _forward_fill(vitals)
+
+        self.times = (
+            np.asarray(times, dtype=np.float64) if times is not None else np.arange(self.n_steps, dtype=np.float64)
+        )
+        if self.times.shape != (self.n_steps,):
+            raise ValueError("times must be 1D with one entry per step")
+
+        self.labels = np.asarray(labels, dtype=bool) if labels is not None else None
+        if self.labels is not None and self.labels.shape != (self.n_steps,):
+            raise ValueError("labels must be 1D with one entry per step")
+
+        self._step = 0
+
+    def reset(self) -> np.ndarray:
+        """Reset to the first observation and return it."""
+        self._step = 0
+        return self.vitals[0].copy()
+
+    def step(self, tier: int) -> tuple[np.ndarray, float, bool, dict[str, Any]]:
+        """Advance one observation given a chosen escalation ``tier``.
+
+        Parameters
+        ----------
+        tier
+            Chosen escalation tier in ``[0, n_tiers)``.
+
+        Returns
+        -------
+        tuple
+            ``(observation, reward, done, info)``. On the terminal step the
+            observation is a zero vector.
+
+        """
+        if not 0 <= tier < self.n_tiers:
+            raise ValueError(f"tier must be in [0, {self.n_tiers}), got {tier}")
+
+        idx = self._step
+        elapsed = float(self.times[idx] - self.times[idx - 1]) if idx > 0 else 0.0
+        reward = self._reward(idx, tier)
+
+        self._step += 1
+        done = self._step >= self.n_steps
+        obs = self.vitals[self._step].copy() if not done else np.zeros(self.n_channels)
+        info = {
+            "step": idx,
+            "time": float(self.times[idx]),
+            "elapsed": elapsed,
+            "tier": tier,
+            "deteriorating": bool(self.labels[idx]) if self.labels is not None else None,
+        }
+        return obs, reward, done, info
+
+    def _reward(self, idx: int, tier: int) -> float:
+        """Escalation reward: reward matched urgency, penalise alarm fatigue and misses."""
+        if self.labels is None:
+            # Unsupervised: mild penalty per escalation tier to discourage crying wolf.
+            return -0.1 * tier
+        if self.labels[idx]:
+            # Deterioration present: reward proportional to escalation, strong miss penalty.
+            return float(tier) if tier > 0 else -2.0
+        # Stable patient: reward calm, penalise unnecessary escalation (alarm fatigue).
+        return 0.2 if tier == 0 else -0.5 * tier
+
+
+def _forward_fill(arr: np.ndarray) -> np.ndarray:
+    """Carry the last valid reading forward per channel; back-fill leading NaNs."""
+    out = arr.copy()
+    for c in range(out.shape[1]):
+        col = out[:, c]
+        last = np.nan
+        for i in range(col.shape[0]):
+            if np.isnan(col[i]):
+                col[i] = last
+            else:
+                last = col[i]
+        # Back-fill any leading NaNs with the first valid value.
+        if np.isnan(col[0]):
+            valid = col[~np.isnan(col)]
+            col[np.isnan(col)] = valid[0] if valid.size else 0.0
+        out[:, c] = col
+    return out

--- a/polars_ts/healthcare_agents/orchestrator.py
+++ b/polars_ts/healthcare_agents/orchestrator.py
@@ -1,0 +1,145 @@
+"""ClinicalOrchestrator: chains clinical agents over a ClinicalEnv."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from polars_ts.healthcare_agents.agents import (
+    EscalationAgent,
+    SepsisWarningAgent,
+    TreatmentAgent,
+    VitalMonitorAgent,
+)
+from polars_ts.healthcare_agents.env import ClinicalEnv
+
+
+@dataclass
+class ClinicalResult:
+    """Output of a :class:`ClinicalOrchestrator` run.
+
+    Attributes
+    ----------
+    escalation_tiers
+        Per-step chosen escalation tier.
+    sepsis_flags
+        Per-step sepsis-risk flag from :class:`SepsisWarningAgent`.
+    treatments
+        Per-step recommended intervention label.
+    total_reward
+        Sum of environment rewards (meaningful only when labels are supplied).
+    history
+        Per-step diagnostic records.
+
+    """
+
+    escalation_tiers: np.ndarray
+    sepsis_flags: np.ndarray
+    treatments: list[str]
+    total_reward: float = 0.0
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+
+class ClinicalOrchestrator:
+    """Coordinate clinical decision-support agents over a vital-sign trajectory.
+
+    At each observation:
+
+    1. :class:`SepsisWarningAgent` scores sepsis risk (qSOFA + SIRS).
+    2. :class:`VitalMonitorAgent` counts out-of-range vitals.
+    3. :class:`EscalationAgent` selects an escalation tier (NEWS-style).
+    4. :class:`TreatmentAgent` recommends an intervention and, when labels are
+       available, learns online from the environment reward.
+
+    Parameters
+    ----------
+    sepsis_threshold
+        Combined qSOFA+SIRS score at which sepsis risk is flagged.
+    explore
+        Epsilon-greedy exploration rate for the treatment recommender.
+    seed
+        Seed for the treatment recommender's RNG.
+
+    """
+
+    def __init__(
+        self,
+        sepsis_threshold: int = 2,
+        explore: float = 0.0,
+        seed: int = 0,
+    ) -> None:
+        self.sepsis_threshold = sepsis_threshold
+        self.explore = explore
+        self.seed = seed
+
+    def run(
+        self,
+        vitals: np.ndarray,
+        times: np.ndarray | None = None,
+        labels: np.ndarray | None = None,
+    ) -> ClinicalResult:
+        """Run the multi-agent clinical monitoring loop.
+
+        Parameters
+        ----------
+        vitals
+            2D array ``(n_steps, n_channels)`` of vital-sign observations.
+        times
+            Optional observation timestamps for irregularly sampled series.
+        labels
+            Optional ground-truth deterioration labels for reward/learning.
+
+        Returns
+        -------
+        ClinicalResult
+
+        """
+        env = ClinicalEnv(vitals, times=times, labels=labels)
+        sepsis_agent = SepsisWarningAgent(threshold=self.sepsis_threshold)
+        monitor = VitalMonitorAgent()
+        escalation = EscalationAgent(n_tiers=env.n_tiers)
+        treatment = TreatmentAgent(seed=self.seed)
+
+        tiers: list[int] = []
+        sepsis_flags: list[bool] = []
+        treatments: list[str] = []
+        history: list[dict[str, Any]] = []
+        total_reward = 0.0
+
+        obs = env.reset()
+        done = False
+        while not done:
+            risk, sepsis_flag = sepsis_agent.score(obs)
+            n_deranged, _ = monitor.score(obs)
+            tier = escalation.decide(obs, sepsis_flag, n_deranged)
+            action = treatment.recommend(tier, explore=self.explore)
+
+            obs, reward, done, info = env.step(tier)
+            treatment.update(tier, action, reward)
+            total_reward += reward
+
+            tiers.append(tier)
+            sepsis_flags.append(sepsis_flag)
+            treatments.append(treatment.actions[action])
+            history.append(
+                {
+                    "step": info["step"],
+                    "time": info["time"],
+                    "elapsed": info["elapsed"],
+                    "sepsis_risk": risk,
+                    "n_deranged": n_deranged,
+                    "tier": tier,
+                    "treatment": treatment.actions[action],
+                    "reward": reward,
+                }
+            )
+
+        return ClinicalResult(
+            escalation_tiers=np.array(tiers, dtype=np.int64),
+            sepsis_flags=np.array(sepsis_flags, dtype=bool),
+            treatments=treatments,
+            total_reward=total_reward,
+            history=history,
+        )

--- a/tests/test_healthcare_agents.py
+++ b/tests/test_healthcare_agents.py
@@ -1,0 +1,356 @@
+"""Tests for multi-agent clinical decision support (#160).
+
+Defines the expected API for ClinicalEnv, the clinical agents, federated
+averaging, and the ClinicalOrchestrator.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _stable_row() -> list[float]:
+    """Return a physiologically normal vital-sign row."""
+    # heart_rate, systolic_bp, respiratory_rate, temperature, spo2
+    return [75.0, 120.0, 16.0, 37.0, 98.0]
+
+
+def _septic_row() -> list[float]:
+    """Return a deranged row consistent with sepsis / deterioration."""
+    return [125.0, 92.0, 26.0, 39.2, 91.0]
+
+
+@pytest.fixture
+def stable_vitals() -> np.ndarray:
+    """Build a stable trajectory with no deterioration."""
+    return np.array([_stable_row() for _ in range(30)], dtype=np.float64)
+
+
+@pytest.fixture
+def deteriorating_vitals() -> tuple[np.ndarray, np.ndarray]:
+    """Build a trajectory that deteriorates in its second half, with labels."""
+    rows = [_stable_row() for _ in range(15)] + [_septic_row() for _ in range(15)]
+    labels = np.array([False] * 15 + [True] * 15, dtype=bool)
+    return np.array(rows, dtype=np.float64), labels
+
+
+# ---------------------------------------------------------------------------
+# ClinicalEnv
+# ---------------------------------------------------------------------------
+
+
+class TestClinicalEnv:
+    def test_creation(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        env = ClinicalEnv(stable_vitals)
+        assert env.n_steps == 30
+        assert env.n_channels == 5
+
+    def test_reset_returns_first_row(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        env = ClinicalEnv(stable_vitals)
+        obs = env.reset()
+        assert obs.shape == (5,)
+        np.testing.assert_allclose(obs, _stable_row())
+
+    def test_rejects_1d_input(self):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        with pytest.raises(ValueError, match="2D"):
+            ClinicalEnv(np.zeros(10))
+
+    def test_step_returns_tuple(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        env = ClinicalEnv(stable_vitals)
+        env.reset()
+        obs, reward, done, info = env.step(0)
+        assert obs.shape == (5,)
+        assert isinstance(reward, float)
+        assert isinstance(done, bool)
+        assert "elapsed" in info and "tier" in info
+
+    def test_invalid_tier_raises(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        env = ClinicalEnv(stable_vitals)
+        env.reset()
+        with pytest.raises(ValueError, match="tier"):
+            env.step(99)
+
+    def test_episode_terminates(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        env = ClinicalEnv(stable_vitals)
+        env.reset()
+        steps, done = 0, False
+        while not done:
+            _, _, done, _ = env.step(0)
+            steps += 1
+            assert steps <= 30
+        assert steps == 30
+
+    def test_irregular_times_reported(self):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        vitals = np.array([_stable_row() for _ in range(3)], dtype=np.float64)
+        times = np.array([0.0, 2.5, 10.0])
+        env = ClinicalEnv(vitals, times=times)
+        env.reset()
+        _, _, _, info0 = env.step(0)
+        assert info0["elapsed"] == 0.0
+        _, _, _, info1 = env.step(0)
+        assert info1["elapsed"] == pytest.approx(2.5)
+
+    def test_nan_forward_filled(self):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        vitals = np.array([_stable_row(), _stable_row(), _stable_row()], dtype=np.float64)
+        vitals[1, 0] = np.nan  # missing heart rate mid-stream
+        env = ClinicalEnv(vitals)
+        assert not np.isnan(env.vitals).any()
+        assert env.vitals[1, 0] == pytest.approx(vitals[0, 0])
+
+    def test_reward_rewards_correct_escalation(self, deteriorating_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        vitals, labels = deteriorating_vitals
+        env = ClinicalEnv(vitals, labels=labels)
+        env.reset()
+        # Advance to a deteriorating step; escalating should beat ignoring.
+        for _ in range(20):
+            env.step(0)
+        r_escalate = env._reward(20, tier=3)
+        r_ignore = env._reward(20, tier=0)
+        assert r_escalate > r_ignore
+
+    def test_reward_penalizes_alarm_fatigue(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalEnv
+
+        labels = np.zeros(len(stable_vitals), dtype=bool)
+        env = ClinicalEnv(stable_vitals, labels=labels)
+        assert env._reward(0, tier=0) > env._reward(0, tier=3)
+
+
+# ---------------------------------------------------------------------------
+# SepsisWarningAgent
+# ---------------------------------------------------------------------------
+
+
+class TestSepsisWarningAgent:
+    def test_flags_septic_row(self):
+        from polars_ts.healthcare_agents import SepsisWarningAgent
+
+        agent = SepsisWarningAgent()
+        risk, flag = agent.score(np.array(_septic_row()))
+        assert flag is True
+        assert risk >= 2.0
+
+    def test_ignores_stable_row(self):
+        from polars_ts.healthcare_agents import SepsisWarningAgent
+
+        agent = SepsisWarningAgent()
+        _, flag = agent.score(np.array(_stable_row()))
+        assert flag is False
+
+
+# ---------------------------------------------------------------------------
+# VitalMonitorAgent
+# ---------------------------------------------------------------------------
+
+
+class TestVitalMonitorAgent:
+    def test_no_derangement_when_stable(self):
+        from polars_ts.healthcare_agents import VitalMonitorAgent
+
+        n, any_flag = VitalMonitorAgent().score(np.array(_stable_row()))
+        assert n == 0.0
+        assert any_flag is False
+
+    def test_counts_deranged_channels(self):
+        from polars_ts.healthcare_agents import VitalMonitorAgent
+
+        n, any_flag = VitalMonitorAgent().score(np.array(_septic_row()))
+        assert n >= 3.0
+        assert any_flag is True
+
+
+# ---------------------------------------------------------------------------
+# EscalationAgent
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationAgent:
+    def test_stable_maps_to_tier_zero(self):
+        from polars_ts.healthcare_agents import EscalationAgent
+
+        tier = EscalationAgent().decide(np.array(_stable_row()), sepsis_risk=False, n_deranged=0.0)
+        assert tier == 0
+
+    def test_septic_maps_to_high_tier(self):
+        from polars_ts.healthcare_agents import EscalationAgent
+
+        tier = EscalationAgent().decide(np.array(_septic_row()), sepsis_risk=True, n_deranged=4.0)
+        assert tier == 3
+
+    def test_sepsis_forces_review(self):
+        from polars_ts.healthcare_agents import EscalationAgent
+
+        agent = EscalationAgent()
+        # Otherwise-stable vitals but sepsis risk flagged -> at least urgent review.
+        tier = agent.decide(np.array(_stable_row()), sepsis_risk=True, n_deranged=0.0)
+        assert tier >= 2
+
+
+# ---------------------------------------------------------------------------
+# TreatmentAgent
+# ---------------------------------------------------------------------------
+
+
+class TestTreatmentAgent:
+    def test_recommend_returns_valid_action(self):
+        from polars_ts.healthcare_agents import TreatmentAgent
+
+        agent = TreatmentAgent()
+        a = agent.recommend(tier=2)
+        assert 0 <= a < len(agent.actions)
+
+    def test_learns_from_reward(self):
+        from polars_ts.healthcare_agents import TreatmentAgent
+
+        agent = TreatmentAgent()
+        # Reinforce action 3 for tier 3 repeatedly; it should become preferred.
+        for _ in range(20):
+            agent.update(tier=3, action=3, reward=1.0)
+        assert agent.recommend(tier=3) == 3
+
+    def test_deterministic_without_exploration(self):
+        from polars_ts.healthcare_agents import TreatmentAgent
+
+        agent = TreatmentAgent(seed=1)
+        assert agent.recommend(tier=1) == agent.recommend(tier=1)
+
+
+# ---------------------------------------------------------------------------
+# federated_average
+# ---------------------------------------------------------------------------
+
+
+class TestFederatedAverage:
+    def test_equal_weight_mean(self):
+        from polars_ts.healthcare_agents import federated_average
+
+        a = np.array([[0.0, 2.0], [4.0, 6.0]])
+        b = np.array([[2.0, 4.0], [6.0, 8.0]])
+        out = federated_average([a, b])
+        np.testing.assert_allclose(out, [[1.0, 3.0], [5.0, 7.0]])
+
+    def test_weighted_mean(self):
+        from polars_ts.healthcare_agents import federated_average
+
+        a = np.zeros((2, 2))
+        b = np.ones((2, 2))
+        out = federated_average([a, b], weights=[1.0, 3.0])
+        np.testing.assert_allclose(out, np.full((2, 2), 0.75))
+
+    def test_shape_mismatch_raises(self):
+        from polars_ts.healthcare_agents import federated_average
+
+        with pytest.raises(ValueError, match="same shape"):
+            federated_average([np.zeros((2, 2)), np.zeros((3, 3))])
+
+    def test_empty_raises(self):
+        from polars_ts.healthcare_agents import federated_average
+
+        with pytest.raises(ValueError, match="at least one"):
+            federated_average([])
+
+
+# ---------------------------------------------------------------------------
+# ClinicalOrchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestClinicalOrchestrator:
+    def test_run_returns_result(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator, ClinicalResult
+
+        result = ClinicalOrchestrator().run(stable_vitals)
+        assert isinstance(result, ClinicalResult)
+
+    def test_result_shapes(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator
+
+        result = ClinicalOrchestrator().run(stable_vitals)
+        assert result.escalation_tiers.shape == (30,)
+        assert result.sepsis_flags.shape == (30,)
+        assert len(result.treatments) == 30
+        assert len(result.history) == 30
+
+    def test_stable_patient_stays_calm(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator
+
+        result = ClinicalOrchestrator().run(stable_vitals)
+        assert result.escalation_tiers.max() == 0
+        assert not result.sepsis_flags.any()
+
+    def test_detects_deterioration(self, deteriorating_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator
+
+        vitals, labels = deteriorating_vitals
+        result = ClinicalOrchestrator().run(vitals, labels=labels)
+        # Escalation must rise for the deteriorating second half.
+        assert result.escalation_tiers[:15].max() < result.escalation_tiers[15:].max()
+        assert result.sepsis_flags[15:].any()
+
+    def test_recommends_icu_for_deterioration(self, deteriorating_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator
+
+        vitals, labels = deteriorating_vitals
+        result = ClinicalOrchestrator().run(vitals, labels=labels)
+        assert "transfer_icu" in result.treatments
+
+    def test_handles_irregular_times(self, stable_vitals):
+        from polars_ts.healthcare_agents import ClinicalOrchestrator
+
+        times = np.cumsum(np.linspace(0.5, 2.0, len(stable_vitals)))
+        result = ClinicalOrchestrator().run(stable_vitals, times=times)
+        assert len(result.history) == len(stable_vitals)
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    NAMES = [
+        "ClinicalEnv",
+        "ClinicalOrchestrator",
+        "ClinicalResult",
+        "SepsisWarningAgent",
+        "VitalMonitorAgent",
+        "EscalationAgent",
+        "TreatmentAgent",
+        "federated_average",
+    ]
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_module(self, name):
+        import polars_ts.healthcare_agents as mod
+
+        assert getattr(mod, name) is not None
+        assert name in mod.__all__
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_top_level(self, name):
+        import polars_ts
+
+        assert getattr(polars_ts, name) is not None


### PR DESCRIPTION
## Summary

Implements **Phase 4 / T3-2** of the roadmap (#148): a multi-agent clinical decision-support module for EHR vital-sign time series. Follows the established `anomaly_agents` / `marl` structure (env + agents + orchestrator + lazy `__init__`).

Closes #160.

## Scope (per #160)

| Requirement | Delivered |
|-------------|-----------|
| Sepsis early warning from vital signs | `SepsisWarningAgent` (qSOFA + SIRS heuristics) |
| ICU monitoring with multi-agent escalation | `EscalationAgent` (NEWS-style tiers) + `ClinicalOrchestrator` |
| Treatment optimization via RL agents | `TreatmentAgent` (contextual bandit, online reward learning) |
| Irregular time series handling | `ClinicalEnv` exposes per-step elapsed time; carry-forward NaN imputation |
| Privacy-preserving federated learning | `federated_average` (FedAvg over per-site agent params) |

## Module `polars_ts.healthcare_agents`

- **`ClinicalEnv`** — gymnasium-like environment over a patient's `(n_steps, n_channels)` vital-sign trajectory. Escalation reward rewards early, correct escalation and penalises both alarm fatigue (over-escalation) and missed deterioration. Handles irregular sampling and missing readings.
- **`SepsisWarningAgent`**, **`VitalMonitorAgent`**, **`EscalationAgent`**, **`TreatmentAgent`** — bedside-grounded, dependency-free, deterministic scoring.
- **`federated_average`** — weighted FedAvg of per-site parameter arrays.
- **`ClinicalOrchestrator` / `ClinicalResult`** — chain the agents over `ClinicalEnv`.

All names wired into the root `_LAZY_IMPORTS` registry.

## Tests & verification

- **46 new tests** (`tests/test_healthcare_agents.py`): env lifecycle, irregular times, NaN handling, reward shaping, each agent, federated averaging, orchestrator end-to-end (stable vs deteriorating patient), and lazy imports.
- `ruff check` + `ruff format` clean (run with the CI-pinned **ruff 0.8.4**).
- Single commit, based on current `main`.

## Notes

- Heuristics (qSOFA/SIRS/NEWS reference ranges) are standard bedside instruments, kept dependency-free so they are auditable and testable — not a substitute for clinical judgement.
- Remaining Phase 4 domain agents after this: T3-3 (#161), T3-4 (#162), T3-5 (#163).