### PR TITLE
feat: add industrial IoT predictive maintenance agents (#161)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -232,6 +232,14 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RollingStdAgent": ("polars_ts.anomaly_agents", "RollingStdAgent"),
     "MADAgent": ("polars_ts.anomaly_agents", "MADAgent"),
     "ConsensusAgent": ("polars_ts.anomaly_agents", "ConsensusAgent"),
+    # --- Industrial IoT predictive maintenance agents ---
+    "MachineEnv": ("polars_ts.iiot_agents", "MachineEnv"),
+    "MaintenanceOrchestrator": ("polars_ts.iiot_agents", "MaintenanceOrchestrator"),
+    "MaintenanceResult": ("polars_ts.iiot_agents", "MaintenanceResult"),
+    "SpectralFeatureAgent": ("polars_ts.iiot_agents", "SpectralFeatureAgent"),
+    "HealthIndexAgent": ("polars_ts.iiot_agents", "HealthIndexAgent"),
+    "RULEstimator": ("polars_ts.iiot_agents", "RULEstimator"),
+    "MaintenanceSchedulerAgent": ("polars_ts.iiot_agents", "MaintenanceSchedulerAgent"),
     # --- Multi-agent RL ---
     "PortfolioEnv": ("polars_ts.marl", "PortfolioEnv"),
     "MARLOrchestrator": ("polars_ts.marl", "MARLOrchestrator"),

--- a/polars_ts/iiot_agents/__init__.py
+++ b/polars_ts/iiot_agents/__init__.py
@@ -1,0 +1,21 @@
+"""Industrial IoT predictive-maintenance agents.
+
+Combines vibration/sensor spectral analysis, multi-sensor health-index fusion,
+Remaining Useful Life (RUL) estimation, and a reinforcement-learning
+maintenance scheduler that learns optimal intervention timing (minimising
+downtime and maintenance cost). Closes #161.
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "MachineEnv": ("polars_ts.iiot_agents.env", "MachineEnv"),
+    "SpectralFeatureAgent": ("polars_ts.iiot_agents.agents", "SpectralFeatureAgent"),
+    "HealthIndexAgent": ("polars_ts.iiot_agents.agents", "HealthIndexAgent"),
+    "RULEstimator": ("polars_ts.iiot_agents.agents", "RULEstimator"),
+    "MaintenanceSchedulerAgent": ("polars_ts.iiot_agents.agents", "MaintenanceSchedulerAgent"),
+    "MaintenanceOrchestrator": ("polars_ts.iiot_agents.orchestrator", "MaintenanceOrchestrator"),
+    "MaintenanceResult": ("polars_ts.iiot_agents.orchestrator", "MaintenanceResult"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/iiot_agents/agents.py
+++ b/polars_ts/iiot_agents/agents.py
@@ -1,0 +1,193 @@
+"""Predictive-maintenance agents: spectral features, health, RUL, scheduling.
+
+The agents form a pipeline: :class:`SpectralFeatureAgent` extracts vibration
+band energies, :class:`HealthIndexAgent` fuses multi-sensor signals into a
+health index, :class:`RULEstimator` projects Remaining Useful Life, and the
+reinforcement-learning :class:`MaintenanceSchedulerAgent` decides when to
+operate, inspect, or maintain.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from polars_ts.iiot_agents.env import MAINTAIN, OPERATE
+
+
+class SpectralFeatureAgent:
+    """Extract vibration band-energy features from a sensor window via FFT.
+
+    A dependency-free complement to the imaging module's ``to_spectrogram`` /
+    ``to_scalogram``: computes RMS amplitude and the fraction of spectral
+    energy in low/mid/high frequency bands, which shift as bearings and gears
+    degrade.
+
+    Parameters
+    ----------
+    n_bands
+        Number of equal-width frequency bands to summarise energy over.
+
+    """
+
+    def __init__(self, n_bands: int = 3) -> None:
+        if n_bands < 1:
+            raise ValueError("n_bands must be >= 1")
+        self.n_bands = n_bands
+
+    def extract(self, window: np.ndarray) -> np.ndarray:
+        """Return ``[rms, band_0_frac, …, band_{n_bands-1}_frac]`` for a 1D window."""
+        window = np.asarray(window, dtype=np.float64)
+        rms = float(np.sqrt(np.mean(window**2)))
+        centered = window - window.mean()
+        spectrum = np.abs(np.fft.rfft(centered)) ** 2
+        total = float(spectrum.sum()) + 1e-12
+        bands = np.array_split(spectrum, self.n_bands)
+        fracs = [float(b.sum()) / total for b in bands]
+        return np.array([rms, *fracs], dtype=np.float64)
+
+
+class HealthIndexAgent:
+    """Fuse multi-sensor readings into a health index in ``[0, 1]``.
+
+    Degradation is modelled as growth in each sensor's RMS amplitude relative
+    to a healthy baseline; per-sensor degradation scores are fused by weighted
+    mean and mapped to a health index (1 = healthy, 0 = failed).
+
+    Parameters
+    ----------
+    baseline
+        Per-sensor healthy RMS baseline. Inferred from the first ``warmup``
+        steps when omitted.
+    warmup
+        Number of initial steps used to infer ``baseline`` when not supplied.
+    fail_ratio
+        RMS ratio (current / baseline) at which health reaches 0.
+    weights
+        Optional per-sensor fusion weights (defaults to equal weighting).
+
+    """
+
+    def __init__(
+        self,
+        baseline: np.ndarray | None = None,
+        warmup: int = 5,
+        fail_ratio: float = 3.0,
+        weights: np.ndarray | None = None,
+    ) -> None:
+        self.baseline = None if baseline is None else np.asarray(baseline, dtype=np.float64)
+        self.warmup = warmup
+        self.fail_ratio = fail_ratio
+        self.weights = None if weights is None else np.asarray(weights, dtype=np.float64)
+
+    def fit_baseline(self, sensors: np.ndarray) -> None:
+        """Infer the healthy per-sensor RMS baseline from initial observations."""
+        head = np.asarray(sensors, dtype=np.float64)[: self.warmup]
+        self.baseline = np.sqrt(np.mean(head**2, axis=0)) + 1e-12
+
+    def score(self, window: np.ndarray) -> float:
+        """Return a fused health index in ``[0, 1]`` for a multi-sensor window.
+
+        ``window`` is ``(w, n_sensors)`` or a single ``(n_sensors,)`` row.
+        """
+        window = np.atleast_2d(np.asarray(window, dtype=np.float64))
+        rms = np.sqrt(np.mean(window**2, axis=0)) + 1e-12
+        if self.baseline is None:
+            self.baseline = rms
+        ratio = rms / self.baseline
+        # Per-sensor degradation in [0, 1]: 0 at baseline, 1 at fail_ratio.
+        degradation = np.clip((ratio - 1.0) / (self.fail_ratio - 1.0), 0.0, 1.0)
+        w = self.weights if self.weights is not None else np.ones(degradation.shape[0])
+        fused = float(np.average(degradation, weights=w))
+        return float(np.clip(1.0 - fused, 0.0, 1.0))
+
+
+class RULEstimator:
+    """Estimate Remaining Useful Life by extrapolating the health trend.
+
+    Fits a linear trend to the recent health-index history and projects the
+    number of steps until it reaches ``failure_threshold``.
+
+    Parameters
+    ----------
+    failure_threshold
+        Health level defining failure.
+    min_history
+        Minimum number of points before a finite RUL is returned.
+
+    """
+
+    def __init__(self, failure_threshold: float = 0.2, min_history: int = 3) -> None:
+        self.failure_threshold = failure_threshold
+        self.min_history = min_history
+
+    def estimate(self, health_history: list[float] | np.ndarray) -> float:
+        """Return estimated steps until failure (``inf`` if not yet declining)."""
+        h = np.asarray(health_history, dtype=np.float64)
+        if h.size < self.min_history:
+            return float("inf")
+        x = np.arange(h.size, dtype=np.float64)
+        slope, intercept = np.polyfit(x, h, 1)
+        current = float(intercept + slope * (h.size - 1))
+        if current <= self.failure_threshold:
+            return 0.0
+        if slope >= -1e-9:  # stable or improving
+            return float("inf")
+        return float((current - self.failure_threshold) / (-slope))
+
+
+class MaintenanceSchedulerAgent:
+    """Tabular Q-learning agent that schedules maintenance from health state.
+
+    The health index is discretised into ``n_states`` buckets; the agent learns
+    a Q-value for each ``(health_bucket, action)`` pair from environment reward,
+    balancing uptime against maintenance cost and failure risk.
+
+    Parameters
+    ----------
+    n_states
+        Number of health buckets (finer = more granular timing).
+    n_actions
+        Size of the maintenance action set.
+    alpha, gamma, epsilon
+        Learning rate, discount factor, and epsilon-greedy exploration rate.
+    seed
+        Seed for the exploration RNG.
+
+    """
+
+    def __init__(
+        self,
+        n_states: int = 10,
+        n_actions: int = 3,
+        alpha: float = 0.1,
+        gamma: float = 0.9,
+        epsilon: float = 0.1,
+        seed: int = 0,
+    ) -> None:
+        self.n_states = n_states
+        self.n_actions = n_actions
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self._rng = np.random.default_rng(seed)
+        self.q = np.zeros((n_states, n_actions), dtype=np.float64)
+        # Optimistic prior: prefer operating while healthy, maintaining while degraded.
+        self.q[-1, OPERATE] = 0.1
+        self.q[0, MAINTAIN] = 0.1
+
+    def bucket(self, health: float) -> int:
+        """Map a health index in ``[0, 1]`` to a discrete state bucket."""
+        b = int(np.clip(health, 0.0, 1.0) * (self.n_states - 1) + 0.5)
+        return int(min(max(b, 0), self.n_states - 1))
+
+    def act(self, state: int, explore: bool = False) -> int:
+        """Return an action for ``state`` (epsilon-greedy when ``explore``)."""
+        if explore and float(self._rng.random()) < self.epsilon:
+            return int(self._rng.integers(self.n_actions))
+        return int(np.argmax(self.q[state]))
+
+    def update(self, state: int, action: int, reward: float, next_state: int) -> None:
+        """Apply a Q-learning temporal-difference update."""
+        best_next = float(np.max(self.q[next_state]))
+        td_target = reward + self.gamma * best_next
+        self.q[state, action] += self.alpha * (td_target - self.q[state, action])

--- a/polars_ts/iiot_agents/env.py
+++ b/polars_ts/iiot_agents/env.py
@@ -1,0 +1,152 @@
+"""Predictive-maintenance environment for industrial IoT sensor streams.
+
+Models a machine degrading toward failure as a multi-sensor time series. At
+each step a maintenance agent chooses to operate, inspect, or maintain; the
+reward trades machine uptime against inspection/maintenance cost and a large
+penalty for running a degraded machine to failure.
+
+The environment plays back a fixed degradation trajectory (actions do not
+mutate the sensor stream); the learning signal is the *timing* of maintenance
+relative to the true failure point.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# Discrete maintenance actions.
+OPERATE, INSPECT, MAINTAIN = 0, 1, 2
+ACTIONS: tuple[str, ...] = ("operate", "inspect", "maintain")
+
+
+class MachineEnv:
+    """Environment over a machine's multi-sensor degradation trajectory.
+
+    Parameters
+    ----------
+    sensors
+        2D array ``(n_steps, n_sensors)`` of sensor readings (e.g. vibration
+        amplitude, temperature, current). May contain ``NaN`` for dropped
+        samples (carried forward).
+    failure_step
+        Index at which the machine fails. If omitted it is inferred from
+        ``health`` crossing ``failure_threshold`` (or the last step if never).
+    health
+        Optional ground-truth health trajectory in ``[0, 1]`` (1 = healthy).
+        When omitted, downstream agents estimate health from ``sensors``.
+    failure_threshold
+        Health level at or below which the machine is considered failed.
+    maintenance_cost, inspect_cost, failure_penalty, uptime_reward
+        Reward components (see :meth:`step`).
+
+    """
+
+    n_actions: int = 3
+
+    def __init__(
+        self,
+        sensors: np.ndarray,
+        failure_step: int | None = None,
+        health: np.ndarray | None = None,
+        failure_threshold: float = 0.2,
+        maintenance_cost: float = 1.0,
+        inspect_cost: float = 0.1,
+        failure_penalty: float = 10.0,
+        uptime_reward: float = 1.0,
+    ) -> None:
+        sensors = np.asarray(sensors, dtype=np.float64)
+        if sensors.ndim != 2:
+            raise ValueError("sensors must be a 2D array of shape (n_steps, n_sensors)")
+        self.n_steps, self.n_sensors = sensors.shape
+        if self.n_steps < 2:
+            raise ValueError("sensors must contain at least two observations")
+        self.sensors = _forward_fill(sensors)
+
+        self.health = np.asarray(health, dtype=np.float64) if health is not None else None
+        if self.health is not None and self.health.shape != (self.n_steps,):
+            raise ValueError("health must be 1D with one entry per step")
+
+        self.failure_threshold = failure_threshold
+        self.maintenance_cost = maintenance_cost
+        self.inspect_cost = inspect_cost
+        self.failure_penalty = failure_penalty
+        self.uptime_reward = uptime_reward
+
+        self.failure_step = self._resolve_failure_step(failure_step)
+        self._step = 0
+
+    def _resolve_failure_step(self, failure_step: int | None) -> int:
+        if failure_step is not None:
+            return int(failure_step)
+        if self.health is not None:
+            below = np.nonzero(self.health <= self.failure_threshold)[0]
+            return int(below[0]) if below.size else self.n_steps - 1
+        return self.n_steps - 1
+
+    def reset(self) -> np.ndarray:
+        """Reset to the first observation and return it."""
+        self._step = 0
+        return self.sensors[0].copy()
+
+    def step(self, action: int) -> tuple[np.ndarray, float, bool, dict[str, Any]]:
+        """Advance one observation given a maintenance ``action``.
+
+        Reward logic:
+
+        - ``MAINTAIN`` — pay ``maintenance_cost`` but gain a timeliness bonus
+          that peaks just before ``failure_step`` (rewards well-timed
+          preventive maintenance; penalises maintaining a healthy machine).
+        - ``INSPECT`` — pay a small ``inspect_cost``.
+        - ``OPERATE`` — earn ``uptime_reward`` before failure; incur
+          ``failure_penalty`` if operated at/after ``failure_step``.
+
+        Returns
+        -------
+        tuple
+            ``(observation, reward, done, info)``.
+
+        """
+        if not 0 <= action < self.n_actions:
+            raise ValueError(f"action must be in [0, {self.n_actions}), got {action}")
+        idx = self._step
+        failed = idx >= self.failure_step
+
+        if action == MAINTAIN:
+            # Timeliness in [0, 1]: 1 just before failure, decaying earlier.
+            timeliness = max(0.0, 1.0 - (self.failure_step - idx) / max(self.failure_step, 1))
+            reward = self.failure_penalty * timeliness - self.maintenance_cost
+        elif action == INSPECT:
+            reward = -self.inspect_cost
+        else:  # OPERATE
+            reward = -self.failure_penalty if failed else self.uptime_reward
+
+        self._step += 1
+        done = self._step >= self.n_steps
+        obs = self.sensors[self._step].copy() if not done else np.zeros(self.n_sensors)
+        info = {
+            "step": idx,
+            "action": action,
+            "failed": bool(failed),
+            "health": float(self.health[idx]) if self.health is not None else None,
+        }
+        return obs, reward, done, info
+
+
+def _forward_fill(arr: np.ndarray) -> np.ndarray:
+    """Carry the last valid reading forward per sensor; back-fill leading NaNs."""
+    out = arr.copy()
+    for c in range(out.shape[1]):
+        col = out[:, c]
+        last = np.nan
+        for i in range(col.shape[0]):
+            if np.isnan(col[i]):
+                col[i] = last
+            else:
+                last = col[i]
+        if np.isnan(col[0]):
+            valid = col[~np.isnan(col)]
+            col[np.isnan(col)] = valid[0] if valid.size else 0.0
+        out[:, c] = col
+    return out

--- a/polars_ts/iiot_agents/orchestrator.py
+++ b/polars_ts/iiot_agents/orchestrator.py
@@ -1,0 +1,177 @@
+"""MaintenanceOrchestrator: trains and evaluates maintenance agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from polars_ts.iiot_agents.agents import (
+    HealthIndexAgent,
+    MaintenanceSchedulerAgent,
+    RULEstimator,
+)
+from polars_ts.iiot_agents.env import MAINTAIN, MachineEnv
+
+
+@dataclass
+class MaintenanceResult:
+    """Output of a :class:`MaintenanceOrchestrator` run.
+
+    Attributes
+    ----------
+    actions
+        Per-step maintenance action id from the final greedy policy.
+    health_index
+        Per-step fused health index.
+    rul
+        Per-step Remaining Useful Life estimate (steps).
+    first_maintenance_step
+        Index of the first ``MAINTAIN`` action, or ``-1`` if never.
+    total_reward
+        Total environment reward of the final greedy evaluation pass.
+    history
+        Per-step diagnostic records.
+
+    """
+
+    actions: np.ndarray
+    health_index: np.ndarray
+    rul: np.ndarray
+    first_maintenance_step: int = -1
+    total_reward: float = 0.0
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+
+class MaintenanceOrchestrator:
+    """Coordinate predictive-maintenance agents over a machine trajectory.
+
+    The scheduler is trained over ``n_episodes`` replays of the trajectory,
+    then evaluated once greedily to produce the reported schedule.
+
+    Parameters
+    ----------
+    n_episodes
+        Number of Q-learning training episodes over the trajectory.
+    window
+        Sliding-window length for spectral/health feature extraction.
+    failure_threshold
+        Health level defining failure (shared by env, health, and RUL).
+    seed
+        Seed for the scheduler's RNG.
+
+    """
+
+    def __init__(
+        self,
+        n_episodes: int = 50,
+        window: int = 5,
+        failure_threshold: float = 0.2,
+        seed: int = 0,
+    ) -> None:
+        self.n_episodes = n_episodes
+        self.window = window
+        self.failure_threshold = failure_threshold
+        self.seed = seed
+
+    def _health_series(self, sensors: np.ndarray, health: np.ndarray | None) -> np.ndarray:
+        """Per-step fused health index (uses ground truth when provided)."""
+        if health is not None:
+            return np.asarray(health, dtype=np.float64)
+        agent = HealthIndexAgent(warmup=self.window)
+        agent.fit_baseline(sensors)
+        n = len(sensors)
+        out = np.empty(n, dtype=np.float64)
+        for i in range(n):
+            lo = max(0, i - self.window + 1)
+            out[i] = agent.score(sensors[lo : i + 1])
+        return out
+
+    def run(
+        self,
+        sensors: np.ndarray,
+        health: np.ndarray | None = None,
+        failure_step: int | None = None,
+    ) -> MaintenanceResult:
+        """Train the scheduler then return its greedy maintenance schedule.
+
+        Parameters
+        ----------
+        sensors
+            2D array ``(n_steps, n_sensors)`` of sensor readings.
+        health
+            Optional ground-truth health trajectory.
+        failure_step
+            Optional explicit failure index.
+
+        Returns
+        -------
+        MaintenanceResult
+
+        """
+        health_series = self._health_series(sensors, health)
+        scheduler = MaintenanceSchedulerAgent(n_actions=MachineEnv.n_actions, seed=self.seed)
+        rul_estimator = RULEstimator(failure_threshold=self.failure_threshold)
+
+        def make_env() -> MachineEnv:
+            return MachineEnv(
+                sensors,
+                failure_step=failure_step,
+                health=health_series,
+                failure_threshold=self.failure_threshold,
+            )
+
+        # --- Training: replay the trajectory, learning Q-values. ---
+        for _ in range(self.n_episodes):
+            env = make_env()
+            env.reset()
+            state = scheduler.bucket(float(health_series[0]))
+            done = False
+            while not done:
+                action = scheduler.act(state, explore=True)
+                _, reward, done, info = env.step(action)
+                nxt = info["step"] + 1
+                next_state = scheduler.bucket(float(health_series[min(nxt, len(health_series) - 1)]))
+                scheduler.update(state, action, reward, next_state)
+                state = next_state
+
+        # --- Evaluation: single greedy pass. ---
+        env = make_env()
+        env.reset()
+        actions: list[int] = []
+        rul: list[float] = []
+        history: list[dict[str, Any]] = []
+        total_reward = 0.0
+        first_maint = -1
+        done = False
+        idx = 0
+        while not done:
+            hb = scheduler.bucket(float(health_series[idx]))
+            action = scheduler.act(hb, explore=False)
+            rul_est = rul_estimator.estimate(health_series[: idx + 1])
+            _, reward, done, info = env.step(action)
+            total_reward += reward
+            actions.append(action)
+            rul.append(rul_est)
+            if action == MAINTAIN and first_maint < 0:
+                first_maint = idx
+            history.append(
+                {
+                    "step": idx,
+                    "health": float(health_series[idx]),
+                    "rul": rul_est,
+                    "action": action,
+                    "reward": reward,
+                }
+            )
+            idx += 1
+
+        return MaintenanceResult(
+            actions=np.array(actions, dtype=np.int64),
+            health_index=health_series.copy(),
+            rul=np.array(rul, dtype=np.float64),
+            first_maintenance_step=first_maint,
+            total_reward=total_reward,
+            history=history,
+        )

--- a/tests/test_iiot_agents.py
+++ b/tests/test_iiot_agents.py
@@ -1,0 +1,343 @@
+"""Tests for industrial IoT predictive-maintenance agents (#161).
+
+Defines the expected API for MachineEnv, the spectral/health/RUL agents, the
+Q-learning maintenance scheduler, and the MaintenanceOrchestrator.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def degrading_machine() -> tuple[np.ndarray, np.ndarray]:
+    """Build a 2-sensor run whose vibration RMS grows toward failure, with health."""
+    rng = np.random.default_rng(0)
+    n = 60
+    # Vibration amplitude ramps up over time (degradation); temperature drifts.
+    t = np.linspace(0, 1, n)
+    amp = 1.0 + 5.0 * t**2
+    vibration = rng.normal(0, 1, n) * amp
+    temperature = 40.0 + 20.0 * t + rng.normal(0, 0.5, n)
+    sensors = np.column_stack([vibration, temperature])
+    health = np.clip(1.0 - t**2, 0.0, 1.0)
+    return sensors, health
+
+
+@pytest.fixture
+def healthy_machine() -> np.ndarray:
+    """Build a stable 2-sensor run with no degradation."""
+    rng = np.random.default_rng(1)
+    n = 40
+    sensors = np.column_stack([rng.normal(0, 1, n), 40.0 + rng.normal(0, 0.5, n)])
+    return sensors
+
+
+# ---------------------------------------------------------------------------
+# MachineEnv
+# ---------------------------------------------------------------------------
+
+
+class TestMachineEnv:
+    def test_creation(self, degrading_machine):
+        from polars_ts.iiot_agents import MachineEnv
+
+        sensors, health = degrading_machine
+        env = MachineEnv(sensors, health=health)
+        assert env.n_steps == 60
+        assert env.n_sensors == 2
+
+    def test_rejects_1d(self):
+        from polars_ts.iiot_agents import MachineEnv
+
+        with pytest.raises(ValueError, match="2D"):
+            MachineEnv(np.zeros(10))
+
+    def test_failure_step_inferred_from_health(self, degrading_machine):
+        from polars_ts.iiot_agents import MachineEnv
+
+        sensors, health = degrading_machine
+        env = MachineEnv(sensors, health=health, failure_threshold=0.2)
+        expected = int(np.nonzero(health <= 0.2)[0][0])
+        assert env.failure_step == expected
+
+    def test_invalid_action_raises(self, degrading_machine):
+        from polars_ts.iiot_agents import MachineEnv
+
+        sensors, health = degrading_machine
+        env = MachineEnv(sensors, health=health)
+        env.reset()
+        with pytest.raises(ValueError, match="action"):
+            env.step(7)
+
+    def test_operate_penalized_after_failure(self, degrading_machine):
+        from polars_ts.iiot_agents import MachineEnv
+        from polars_ts.iiot_agents.env import OPERATE
+
+        sensors, health = degrading_machine
+        env = MachineEnv(sensors, health=health, failure_penalty=10.0)
+        env.reset()
+        rewards = []
+        done = False
+        while not done:
+            _, r, done, _ = env.step(OPERATE)
+            rewards.append(r)
+        # Running to failure incurs a large negative reward at some point.
+        assert min(rewards) <= -10.0 + 1e-9
+
+    def test_timely_maintenance_beats_early(self, degrading_machine):
+        from polars_ts.iiot_agents import MachineEnv
+        from polars_ts.iiot_agents.env import MAINTAIN
+
+        sensors, health = degrading_machine
+        env = MachineEnv(sensors, health=health)
+        fs = env.failure_step
+        env.reset()
+        rewards = {}
+        idx = 0
+        done = False
+        while not done:
+            _, r, done, info = env.step(MAINTAIN)
+            rewards[idx] = r
+            idx += 1
+        # Maintaining just before failure is worth more than maintaining at t=0.
+        assert rewards[fs - 1] > rewards[0]
+
+    def test_episode_terminates(self, healthy_machine):
+        from polars_ts.iiot_agents import MachineEnv
+        from polars_ts.iiot_agents.env import OPERATE
+
+        env = MachineEnv(healthy_machine)
+        env.reset()
+        steps, done = 0, False
+        while not done:
+            _, _, done, _ = env.step(OPERATE)
+            steps += 1
+            assert steps <= len(healthy_machine)
+        assert steps == len(healthy_machine)
+
+    def test_nan_forward_filled(self):
+        from polars_ts.iiot_agents import MachineEnv
+
+        sensors = np.array([[1.0, 2.0], [np.nan, 2.0], [3.0, 2.0]])
+        env = MachineEnv(sensors)
+        assert not np.isnan(env.sensors).any()
+        assert env.sensors[1, 0] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# SpectralFeatureAgent
+# ---------------------------------------------------------------------------
+
+
+class TestSpectralFeatureAgent:
+    def test_feature_length(self):
+        from polars_ts.iiot_agents import SpectralFeatureAgent
+
+        feats = SpectralFeatureAgent(n_bands=3).extract(np.random.default_rng(0).normal(0, 1, 64))
+        assert feats.shape == (4,)  # rms + 3 band fractions
+
+    def test_band_fractions_sum_to_one(self):
+        from polars_ts.iiot_agents import SpectralFeatureAgent
+
+        feats = SpectralFeatureAgent(n_bands=4).extract(np.random.default_rng(0).normal(0, 1, 128))
+        assert feats[1:].sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_rms_grows_with_amplitude(self):
+        from polars_ts.iiot_agents import SpectralFeatureAgent
+
+        agent = SpectralFeatureAgent()
+        rng = np.random.default_rng(0)
+        low = agent.extract(rng.normal(0, 1, 64))[0]
+        high = agent.extract(rng.normal(0, 5, 64))[0]
+        assert high > low
+
+    def test_invalid_n_bands(self):
+        from polars_ts.iiot_agents import SpectralFeatureAgent
+
+        with pytest.raises(ValueError, match="n_bands"):
+            SpectralFeatureAgent(n_bands=0)
+
+
+# ---------------------------------------------------------------------------
+# HealthIndexAgent
+# ---------------------------------------------------------------------------
+
+
+class TestHealthIndexAgent:
+    def test_healthy_near_one(self, healthy_machine):
+        from polars_ts.iiot_agents import HealthIndexAgent
+
+        agent = HealthIndexAgent(warmup=5)
+        agent.fit_baseline(healthy_machine)
+        h = agent.score(healthy_machine[:5])
+        assert h > 0.8
+
+    def test_degradation_lowers_health(self, degrading_machine):
+        from polars_ts.iiot_agents import HealthIndexAgent
+
+        sensors, _ = degrading_machine
+        agent = HealthIndexAgent(warmup=5)
+        agent.fit_baseline(sensors)
+        early = agent.score(sensors[:5])
+        late = agent.score(sensors[-5:])
+        assert late < early
+
+    def test_bounded_zero_one(self, degrading_machine):
+        from polars_ts.iiot_agents import HealthIndexAgent
+
+        sensors, _ = degrading_machine
+        agent = HealthIndexAgent(warmup=5)
+        agent.fit_baseline(sensors)
+        for i in range(len(sensors)):
+            h = agent.score(sensors[max(0, i - 4) : i + 1])
+            assert 0.0 <= h <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# RULEstimator
+# ---------------------------------------------------------------------------
+
+
+class TestRULEstimator:
+    def test_infinite_when_stable(self):
+        from polars_ts.iiot_agents import RULEstimator
+
+        rul = RULEstimator().estimate([1.0, 1.0, 1.0, 1.0])
+        assert rul == float("inf")
+
+    def test_finite_when_declining(self):
+        from polars_ts.iiot_agents import RULEstimator
+
+        history = list(np.linspace(1.0, 0.5, 10))
+        rul = RULEstimator(failure_threshold=0.2).estimate(history)
+        assert 0.0 < rul < float("inf")
+
+    def test_zero_when_below_threshold(self):
+        from polars_ts.iiot_agents import RULEstimator
+
+        rul = RULEstimator(failure_threshold=0.2).estimate([0.5, 0.3, 0.1])
+        assert rul == 0.0
+
+    def test_insufficient_history(self):
+        from polars_ts.iiot_agents import RULEstimator
+
+        assert RULEstimator(min_history=3).estimate([0.9, 0.8]) == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# MaintenanceSchedulerAgent
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceSchedulerAgent:
+    def test_bucketing_bounds(self):
+        from polars_ts.iiot_agents import MaintenanceSchedulerAgent
+
+        agent = MaintenanceSchedulerAgent(n_states=10)
+        assert agent.bucket(1.0) == 9
+        assert agent.bucket(0.0) == 0
+        assert 0 <= agent.bucket(0.5) <= 9
+
+    def test_act_returns_valid_action(self):
+        from polars_ts.iiot_agents import MaintenanceSchedulerAgent
+
+        agent = MaintenanceSchedulerAgent()
+        assert 0 <= agent.act(3) < agent.n_actions
+
+    def test_q_update_moves_value(self):
+        from polars_ts.iiot_agents import MaintenanceSchedulerAgent
+
+        agent = MaintenanceSchedulerAgent()
+        before = agent.q[2, 1]
+        agent.update(2, 1, reward=5.0, next_state=2)
+        assert agent.q[2, 1] > before
+
+    def test_learns_to_maintain_when_degraded(self):
+        from polars_ts.iiot_agents import MaintenanceSchedulerAgent
+        from polars_ts.iiot_agents.env import MAINTAIN
+
+        agent = MaintenanceSchedulerAgent(n_states=5)
+        # Repeatedly reward maintaining in the most-degraded bucket.
+        for _ in range(200):
+            agent.update(0, MAINTAIN, reward=1.0, next_state=0)
+        assert agent.act(0) == MAINTAIN
+
+
+# ---------------------------------------------------------------------------
+# MaintenanceOrchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestMaintenanceOrchestrator:
+    def test_run_returns_result(self, degrading_machine):
+        from polars_ts.iiot_agents import MaintenanceOrchestrator, MaintenanceResult
+
+        sensors, health = degrading_machine
+        result = MaintenanceOrchestrator(n_episodes=30).run(sensors, health=health)
+        assert isinstance(result, MaintenanceResult)
+
+    def test_result_shapes(self, degrading_machine):
+        from polars_ts.iiot_agents import MaintenanceOrchestrator
+
+        sensors, health = degrading_machine
+        result = MaintenanceOrchestrator(n_episodes=30).run(sensors, health=health)
+        n = len(sensors)
+        assert result.actions.shape == (n,)
+        assert result.health_index.shape == (n,)
+        assert result.rul.shape == (n,)
+        assert len(result.history) == n
+
+    def test_schedules_maintenance_before_failure(self, degrading_machine):
+        from polars_ts.iiot_agents import MaintenanceOrchestrator
+        from polars_ts.iiot_agents.env import MachineEnv
+
+        sensors, health = degrading_machine
+        result = MaintenanceOrchestrator(n_episodes=80, seed=0).run(sensors, health=health)
+        fs = MachineEnv(sensors, health=health).failure_step
+        # The learned policy should schedule maintenance, and do so before failure.
+        assert result.first_maintenance_step >= 0
+        assert result.first_maintenance_step <= fs
+
+    def test_health_estimated_without_ground_truth(self, degrading_machine):
+        from polars_ts.iiot_agents import MaintenanceOrchestrator
+
+        sensors, _ = degrading_machine
+        result = MaintenanceOrchestrator(n_episodes=20).run(sensors)
+        # Estimated health should decline from start to end for a degrading machine.
+        assert result.health_index[-5:].mean() < result.health_index[:5].mean()
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    NAMES = [
+        "MachineEnv",
+        "SpectralFeatureAgent",
+        "HealthIndexAgent",
+        "RULEstimator",
+        "MaintenanceSchedulerAgent",
+        "MaintenanceOrchestrator",
+        "MaintenanceResult",
+    ]
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_module(self, name):
+        import polars_ts.iiot_agents as mod
+
+        assert getattr(mod, name) is not None
+        assert name in mod.__all__
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_top_level(self, name):
+        import polars_ts
+
+        assert getattr(polars_ts, name) is not None


### PR DESCRIPTION
## Summary

Implements **Phase 4 / T3-3** of the roadmap (#148): a predictive-maintenance agent module for multi-sensor industrial IoT streams. Follows the established `anomaly_agents` / `healthcare_agents` structure (env + agents + orchestrator + lazy `__init__`).

Closes #161.

## Scope (per #161)

| Requirement | Delivered |
|-------------|-----------|
| Vibration spectrogram analysis | `SpectralFeatureAgent` — FFT band-energy + RMS features (dependency-free complement to `imaging.to_spectrogram` / `to_scalogram`) |
| Remaining Useful Life (RUL) estimation | `RULEstimator` — linear health-trend extrapolation to failure threshold |
| RL agent for maintenance scheduling | `MaintenanceSchedulerAgent` — tabular Q-learning over discretized health states; minimises downtime + maintenance cost |
| Multi-sensor fusion | `HealthIndexAgent` — weighted RMS-growth fusion into a `[0, 1]` health index |

## Module `polars_ts.iiot_agents`

- **`MachineEnv`** — plays back a machine's multi-sensor degradation trajectory. Actions (`operate` / `inspect` / `maintain`) earn uptime, pay inspection/maintenance cost, and incur a failure penalty for running a degraded machine to failure. Reward is **timing-sensitive**: maintenance value peaks just before the true failure step, giving a learnable signal for *when* to intervene.
- **`SpectralFeatureAgent`**, **`HealthIndexAgent`**, **`RULEstimator`**, **`MaintenanceSchedulerAgent`**.
- **`MaintenanceOrchestrator` / `MaintenanceResult`** — trains the Q-scheduler over N episodes, then emits a greedy schedule with per-step health-index and RUL timelines and the first scheduled maintenance step.

All names wired into the root `_LAZY_IMPORTS` registry.

## Tests & verification

- **41 new tests** (`tests/test_iiot_agents.py`): env reward logic (failure penalty, maintenance timeliness), spectral features, health-index degradation, RUL behaviour (stable/declining/below-threshold), Q-learning updates, orchestrator end-to-end (schedules maintenance before failure; estimates health without ground truth), and lazy imports.
- `ruff check` + `ruff format` clean (run with the CI-pinned **ruff 0.8.4**).
- Single commit, based on current `main`.

## Notes

- Health estimation works with or without a ground-truth health trajectory (falls back to sensor-derived RMS-growth).
- Remaining Phase 4 domain agents after this: T3-4 (#162), T3-5 (#163).