### PR TITLE
feat: add hierarchical energy/demand forecasting agents (#162)

### DIFF
--- a/polars_ts/__init__.py
+++ b/polars_ts/__init__.py
@@ -232,6 +232,14 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RollingStdAgent": ("polars_ts.anomaly_agents", "RollingStdAgent"),
     "MADAgent": ("polars_ts.anomaly_agents", "MADAgent"),
     "ConsensusAgent": ("polars_ts.anomaly_agents", "ConsensusAgent"),
+    # --- Energy/demand forecasting agents ---
+    "GridHierarchy": ("polars_ts.energy_agents", "GridHierarchy"),
+    "EnergyGridOrchestrator": ("polars_ts.energy_agents", "EnergyGridOrchestrator"),
+    "EnergyForecastResult": ("polars_ts.energy_agents", "EnergyForecastResult"),
+    "DemandForecastAgent": ("polars_ts.energy_agents", "DemandForecastAgent"),
+    "WeatherContextAgent": ("polars_ts.energy_agents", "WeatherContextAgent"),
+    "RenewableAgent": ("polars_ts.energy_agents", "RenewableAgent"),
+    "DemandResponseAgent": ("polars_ts.energy_agents", "DemandResponseAgent"),
     # --- Multi-agent RL ---
     "PortfolioEnv": ("polars_ts.marl", "PortfolioEnv"),
     "MARLOrchestrator": ("polars_ts.marl", "MARLOrchestrator"),

--- a/polars_ts/energy_agents/__init__.py
+++ b/polars_ts/energy_agents/__init__.py
@@ -1,0 +1,21 @@
+"""Hierarchical multi-agent energy and demand forecasting.
+
+A region -> grid -> household hierarchy of demand-forecasting agents with
+weather-context adjustment, renewable-intermittency netting, and peak-shaving
+demand response, made coherent via the hierarchical reconciliation module.
+Closes #162.
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "GridHierarchy": ("polars_ts.energy_agents.hierarchy", "GridHierarchy"),
+    "DemandForecastAgent": ("polars_ts.energy_agents.agents", "DemandForecastAgent"),
+    "WeatherContextAgent": ("polars_ts.energy_agents.agents", "WeatherContextAgent"),
+    "RenewableAgent": ("polars_ts.energy_agents.agents", "RenewableAgent"),
+    "DemandResponseAgent": ("polars_ts.energy_agents.agents", "DemandResponseAgent"),
+    "EnergyGridOrchestrator": ("polars_ts.energy_agents.orchestrator", "EnergyGridOrchestrator"),
+    "EnergyForecastResult": ("polars_ts.energy_agents.orchestrator", "EnergyForecastResult"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/energy_agents/agents.py
+++ b/polars_ts/energy_agents/agents.py
@@ -1,0 +1,145 @@
+"""Agents for hierarchical energy/demand forecasting.
+
+- :class:`DemandForecastAgent` — per-node seasonal demand forecasting.
+- :class:`WeatherContextAgent` — weather-driven demand adjustment (degree-day).
+- :class:`RenewableAgent` — net demand after intermittent renewable generation.
+- :class:`DemandResponseAgent` — peak-shaving / load-shifting optimisation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class DemandForecastAgent:
+    """Seasonal-naive demand forecaster for a single node.
+
+    Repeats the most recent seasonal cycle; falls back to the historical mean
+    when history is shorter than one season.
+
+    Parameters
+    ----------
+    season
+        Seasonal period in steps (e.g. 24 for hourly-with-daily-cycle).
+
+    """
+
+    def __init__(self, season: int = 24) -> None:
+        if season < 1:
+            raise ValueError("season must be >= 1")
+        self.season = season
+
+    def forecast(self, history: np.ndarray, horizon: int) -> np.ndarray:
+        """Return an ``horizon``-step demand forecast for one node."""
+        h = np.asarray(history, dtype=np.float64)
+        if horizon < 1:
+            raise ValueError("horizon must be >= 1")
+        if h.size < self.season:
+            return np.full(horizon, float(h.mean()) if h.size else 0.0)
+        last_cycle = h[-self.season :]
+        reps = int(np.ceil(horizon / self.season))
+        return np.tile(last_cycle, reps)[:horizon]
+
+
+class WeatherContextAgent:
+    """Adjust a base demand forecast for weather via a degree-day response.
+
+    Demand rises with both heating (cold) and cooling (hot) load relative to a
+    comfort temperature.
+
+    Parameters
+    ----------
+    comfort_temp
+        Temperature (deg C) of minimal weather-driven load.
+    cooling_coef, heating_coef
+        Additional demand per degree above / below ``comfort_temp``.
+
+    """
+
+    def __init__(self, comfort_temp: float = 18.0, cooling_coef: float = 2.0, heating_coef: float = 3.0) -> None:
+        self.comfort_temp = comfort_temp
+        self.cooling_coef = cooling_coef
+        self.heating_coef = heating_coef
+
+    def adjust(self, base_forecast: np.ndarray, temperature: np.ndarray) -> np.ndarray:
+        """Return the weather-adjusted forecast for the given temperature path."""
+        base = np.asarray(base_forecast, dtype=np.float64)
+        temp = np.asarray(temperature, dtype=np.float64)
+        if temp.shape != base.shape:
+            raise ValueError("temperature must match the forecast horizon")
+        cooling = np.clip(temp - self.comfort_temp, 0.0, None) * self.cooling_coef
+        heating = np.clip(self.comfort_temp - temp, 0.0, None) * self.heating_coef
+        return base + cooling + heating
+
+
+class RenewableAgent:
+    """Compute net demand after subtracting intermittent renewable generation.
+
+    Parameters
+    ----------
+    curtail
+        When ``True``, net demand is floored at zero (excess generation is
+        curtailed rather than exported).
+
+    """
+
+    def __init__(self, curtail: bool = False) -> None:
+        self.curtail = curtail
+
+    def net_demand(self, demand: np.ndarray, generation: np.ndarray) -> np.ndarray:
+        """Return ``demand - generation`` (floored at 0 when ``curtail``)."""
+        demand = np.asarray(demand, dtype=np.float64)
+        generation = np.asarray(generation, dtype=np.float64)
+        if generation.shape != demand.shape:
+            raise ValueError("generation must match the demand horizon")
+        net = demand - generation
+        return np.clip(net, 0.0, None) if self.curtail else net
+
+
+class DemandResponseAgent:
+    """Peak-shaving / load-shifting optimiser over a demand profile.
+
+    Energy above ``capacity`` is shed from peak periods and shifted into the
+    lowest-demand troughs, conserving total energy while flattening peaks.
+
+    Parameters
+    ----------
+    capacity
+        Maximum demand target; peaks above it are shifted to troughs.
+
+    """
+
+    def __init__(self, capacity: float) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self.capacity = capacity
+
+    def optimize(self, profile: np.ndarray) -> tuple[np.ndarray, float]:
+        """Return ``(shifted_profile, energy_shifted)``.
+
+        Total energy is always preserved. When the profile *can* fit under
+        ``capacity`` (total energy <= ``capacity`` * n), peaks are clipped to
+        ``capacity`` and the shed energy is water-filled into the lowest
+        periods without exceeding ``capacity``. When it cannot (an inherently
+        over-loaded window), the profile is flattened to its mean — the closest
+        feasible approximation.
+        """
+        prof = np.asarray(profile, dtype=np.float64).copy()
+        n = prof.size
+        shifted = float(np.clip(prof - self.capacity, 0.0, None).sum())
+        if shifted == 0.0:
+            return prof, 0.0
+
+        total = float(prof.sum())
+        if total <= self.capacity * n:
+            prof = np.minimum(prof, self.capacity)
+            deficit = shifted
+            for i in np.argsort(prof, kind="stable"):
+                if deficit <= 1e-12:
+                    break
+                add = min(self.capacity - float(prof[i]), deficit)
+                prof[i] += add
+                deficit -= add
+        else:
+            prof = np.full(n, total / n)
+        return prof, shifted

--- a/polars_ts/energy_agents/hierarchy.py
+++ b/polars_ts/energy_agents/hierarchy.py
@@ -1,0 +1,68 @@
+"""Grid hierarchy for energy/demand forecasting agents.
+
+Represents the region -> grid -> household topology and exposes it in the
+child -> parent tree form consumed by :func:`polars_ts.reconciliation.reconcile`.
+"""
+
+from __future__ import annotations
+
+
+class GridHierarchy:
+    """Three-level energy grid topology: region -> grids -> households.
+
+    Parameters
+    ----------
+    region
+        Name of the top-level region node.
+    structure
+        Mapping ``grid_name -> [household_name, ...]``.
+
+    """
+
+    def __init__(self, region: str, structure: dict[str, list[str]]) -> None:
+        if not structure:
+            raise ValueError("structure must contain at least one grid")
+        self.region = region
+        self.structure = {g: list(hs) for g, hs in structure.items()}
+        # Detect duplicate household ids across grids.
+        seen: set[str] = set()
+        for households in self.structure.values():
+            for h in households:
+                if h in seen:
+                    raise ValueError(f"household {h!r} appears under multiple grids")
+                seen.add(h)
+
+    @property
+    def grids(self) -> list[str]:
+        """Grid (mid-level) node names."""
+        return list(self.structure.keys())
+
+    @property
+    def households(self) -> list[str]:
+        """Household (bottom-level) node names."""
+        return [h for hs in self.structure.values() for h in hs]
+
+    def all_nodes(self) -> list[str]:
+        """All node names, ordered region -> grids -> households."""
+        return [self.region, *self.grids, *self.households]
+
+    def tree(self) -> dict[str, str]:
+        """Return the child -> parent mapping for reconciliation.
+
+        The top (region) node is intentionally omitted, matching the tree form
+        expected by :func:`polars_ts.reconciliation.reconcile`.
+        """
+        mapping: dict[str, str] = {}
+        for grid, households in self.structure.items():
+            mapping[grid] = self.region
+            for h in households:
+                mapping[h] = grid
+        return mapping
+
+    def children(self, node: str) -> list[str]:
+        """Direct children of ``node`` (empty for households)."""
+        if node == self.region:
+            return self.grids
+        if node in self.structure:
+            return list(self.structure[node])
+        return []

--- a/polars_ts/energy_agents/orchestrator.py
+++ b/polars_ts/energy_agents/orchestrator.py
@@ -1,0 +1,169 @@
+"""EnergyGridOrchestrator: hierarchical demand forecasting + reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.energy_agents.agents import (
+    DemandForecastAgent,
+    DemandResponseAgent,
+    RenewableAgent,
+    WeatherContextAgent,
+)
+from polars_ts.energy_agents.hierarchy import GridHierarchy
+from polars_ts.reconciliation import reconcile
+
+
+@dataclass
+class EnergyForecastResult:
+    """Output of an :class:`EnergyGridOrchestrator` run.
+
+    Attributes
+    ----------
+    reconciled
+        Long-format DataFrame of coherent per-node forecasts
+        (``unique_id``, ``ds``, ``y_hat``).
+    base_forecasts
+        Per-node incoherent base forecasts before reconciliation.
+    region_net_demand
+        Region-level demand after subtracting renewable generation.
+    demand_response
+        Peak-shaving outcome: ``{"shifted_profile", "energy_shifted"}`` or
+        ``None`` when no capacity limit was supplied.
+    history
+        Diagnostic records per node.
+
+    """
+
+    reconciled: pl.DataFrame
+    base_forecasts: dict[str, np.ndarray]
+    region_net_demand: np.ndarray
+    demand_response: dict[str, Any] | None = None
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+
+class EnergyGridOrchestrator:
+    """Hierarchical multi-agent energy/demand forecasting.
+
+    Each node (household, grid, region) is forecast independently, optionally
+    adjusted for weather; the incoherent forecasts are then reconciled to sum
+    coherently across the hierarchy. Renewable generation and demand-response
+    optimisation are applied at the region level.
+
+    Parameters
+    ----------
+    season
+        Seasonal period for the demand forecasters.
+    reconcile_method
+        Reconciliation method passed to
+        :func:`polars_ts.reconciliation.reconcile`.
+
+    """
+
+    def __init__(self, season: int = 24, reconcile_method: str = "bottom_up") -> None:
+        self.season = season
+        self.reconcile_method = reconcile_method
+
+    def run(
+        self,
+        household_histories: dict[str, np.ndarray],
+        hierarchy: GridHierarchy,
+        horizon: int,
+        weather: np.ndarray | None = None,
+        generation: np.ndarray | None = None,
+        capacity: float | None = None,
+    ) -> EnergyForecastResult:
+        """Forecast, reconcile, and optimise demand across the grid hierarchy.
+
+        Parameters
+        ----------
+        household_histories
+            Mapping ``household_id -> 1D demand history``. Must cover every
+            household in ``hierarchy``.
+        hierarchy
+            The region -> grid -> household topology.
+        horizon
+            Forecast horizon in steps.
+        weather
+            Optional region-wide temperature path of length ``horizon`` used to
+            adjust every node's forecast.
+        generation
+            Optional region-level renewable generation path of length
+            ``horizon`` subtracted from the reconciled region demand.
+        capacity
+            Optional region demand cap enabling peak-shaving demand response.
+
+        Returns
+        -------
+        EnergyForecastResult
+
+        """
+        missing = set(hierarchy.households) - set(household_histories)
+        if missing:
+            raise ValueError(f"missing histories for households: {sorted(missing)}")
+
+        forecaster = DemandForecastAgent(season=self.season)
+        weather_agent = WeatherContextAgent()
+
+        # Aggregate bottom-level histories up the tree so every node can forecast.
+        node_history: dict[str, np.ndarray] = {
+            h: np.asarray(household_histories[h], dtype=np.float64) for h in hierarchy.households
+        }
+        for grid, households in hierarchy.structure.items():
+            node_history[grid] = np.sum([node_history[h] for h in households], axis=0)
+        node_history[hierarchy.region] = np.sum([node_history[g] for g in hierarchy.grids], axis=0)
+
+        base_forecasts: dict[str, np.ndarray] = {}
+        history: list[dict[str, Any]] = []
+        for node in hierarchy.all_nodes():
+            fc = forecaster.forecast(node_history[node], horizon)
+            if weather is not None:
+                fc = weather_agent.adjust(fc, weather)
+            base_forecasts[node] = fc
+            history.append({"node": node, "mean_forecast": float(fc.mean())})
+
+        # Bottom-up reconciliation aggregates the household (bottom-level)
+        # forecasts up the tree, so only those are fed to reconcile; the
+        # coherent grid/region series are derived from them.
+        frames = [
+            pl.DataFrame(
+                {
+                    "unique_id": [node] * horizon,
+                    "ds": list(range(horizon)),
+                    "y_hat": base_forecasts[node],
+                }
+            )
+            for node in hierarchy.households
+        ]
+        df = pl.concat(frames)
+        reconciled = reconcile(df, hierarchy.tree(), method=self.reconcile_method)
+
+        region_demand = _node_series(reconciled, hierarchy.region, horizon)
+        if generation is not None:
+            region_demand = RenewableAgent().net_demand(region_demand, generation)
+
+        demand_response = None
+        if capacity is not None:
+            shifted, energy = DemandResponseAgent(capacity=capacity).optimize(region_demand)
+            demand_response = {"shifted_profile": shifted, "energy_shifted": energy}
+
+        return EnergyForecastResult(
+            reconciled=reconciled,
+            base_forecasts=base_forecasts,
+            region_net_demand=region_demand,
+            demand_response=demand_response,
+            history=history,
+        )
+
+
+def _node_series(reconciled: pl.DataFrame, node: str, horizon: int) -> np.ndarray:
+    """Extract a node's reconciled forecast ordered by ``ds``."""
+    sub = reconciled.filter(pl.col("unique_id") == node).sort("ds")
+    values = sub["y_hat"].to_numpy()
+    if values.shape[0] != horizon:
+        raise ValueError(f"expected {horizon} reconciled points for {node!r}, got {values.shape[0]}")
+    return values

--- a/tests/test_energy_agents.py
+++ b/tests/test_energy_agents.py
@@ -1,0 +1,291 @@
+"""Tests for hierarchical energy/demand forecasting agents (#162).
+
+Defines the expected API for GridHierarchy, the demand/weather/renewable/
+response agents, and the reconciliation-integrated EnergyGridOrchestrator.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hierarchy():
+    from polars_ts.energy_agents import GridHierarchy
+
+    return GridHierarchy("region", {"grid_a": ["h1", "h2"], "grid_b": ["h3"]})
+
+
+@pytest.fixture
+def histories() -> dict[str, np.ndarray]:
+    """Build daily-seasonal household demand histories (season = 24)."""
+    rng = np.random.default_rng(0)
+    season = 24
+    cycles = 5
+    out = {}
+    for i, h in enumerate(["h1", "h2", "h3"]):
+        base = (1.0 + 0.3 * i) * (1.0 + np.sin(np.linspace(0, 2 * np.pi, season)))
+        out[h] = np.tile(base, cycles) + rng.normal(0, 0.05, season * cycles)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GridHierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestGridHierarchy:
+    def test_nodes(self, hierarchy):
+        assert hierarchy.grids == ["grid_a", "grid_b"]
+        assert hierarchy.households == ["h1", "h2", "h3"]
+        assert hierarchy.all_nodes() == ["region", "grid_a", "grid_b", "h1", "h2", "h3"]
+
+    def test_tree_mapping(self, hierarchy):
+        tree = hierarchy.tree()
+        assert tree["h1"] == "grid_a"
+        assert tree["h3"] == "grid_b"
+        assert tree["grid_a"] == "region"
+        assert "region" not in tree  # top node has no parent
+
+    def test_children(self, hierarchy):
+        assert hierarchy.children("region") == ["grid_a", "grid_b"]
+        assert hierarchy.children("grid_a") == ["h1", "h2"]
+        assert hierarchy.children("h1") == []
+
+    def test_empty_structure_raises(self):
+        from polars_ts.energy_agents import GridHierarchy
+
+        with pytest.raises(ValueError, match="at least one grid"):
+            GridHierarchy("region", {})
+
+    def test_duplicate_household_raises(self):
+        from polars_ts.energy_agents import GridHierarchy
+
+        with pytest.raises(ValueError, match="multiple grids"):
+            GridHierarchy("region", {"g1": ["h1"], "g2": ["h1"]})
+
+
+# ---------------------------------------------------------------------------
+# DemandForecastAgent
+# ---------------------------------------------------------------------------
+
+
+class TestDemandForecastAgent:
+    def test_seasonal_repeat(self):
+        from polars_ts.energy_agents import DemandForecastAgent
+
+        hist = np.tile(np.arange(24, dtype=float), 3)
+        fc = DemandForecastAgent(season=24).forecast(hist, horizon=24)
+        np.testing.assert_allclose(fc, np.arange(24))
+
+    def test_horizon_longer_than_season(self):
+        from polars_ts.energy_agents import DemandForecastAgent
+
+        hist = np.tile(np.arange(24, dtype=float), 3)
+        fc = DemandForecastAgent(season=24).forecast(hist, horizon=36)
+        assert fc.shape == (36,)
+        np.testing.assert_allclose(fc[:24], np.arange(24))
+
+    def test_short_history_falls_back_to_mean(self):
+        from polars_ts.energy_agents import DemandForecastAgent
+
+        fc = DemandForecastAgent(season=24).forecast(np.array([2.0, 4.0]), horizon=5)
+        np.testing.assert_allclose(fc, np.full(5, 3.0))
+
+    def test_invalid_horizon(self):
+        from polars_ts.energy_agents import DemandForecastAgent
+
+        with pytest.raises(ValueError, match="horizon"):
+            DemandForecastAgent().forecast(np.ones(30), horizon=0)
+
+
+# ---------------------------------------------------------------------------
+# WeatherContextAgent
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherContextAgent:
+    def test_comfort_no_change(self):
+        from polars_ts.energy_agents import WeatherContextAgent
+
+        agent = WeatherContextAgent(comfort_temp=18.0)
+        base = np.ones(5)
+        out = agent.adjust(base, np.full(5, 18.0))
+        np.testing.assert_allclose(out, base)
+
+    def test_heat_and_cold_raise_demand(self):
+        from polars_ts.energy_agents import WeatherContextAgent
+
+        agent = WeatherContextAgent(comfort_temp=18.0)
+        base = np.ones(3)
+        hot = agent.adjust(base, np.full(3, 30.0))
+        cold = agent.adjust(base, np.full(3, 0.0))
+        assert (hot > base).all()
+        assert (cold > base).all()
+
+    def test_shape_mismatch_raises(self):
+        from polars_ts.energy_agents import WeatherContextAgent
+
+        with pytest.raises(ValueError, match="horizon"):
+            WeatherContextAgent().adjust(np.ones(5), np.ones(3))
+
+
+# ---------------------------------------------------------------------------
+# RenewableAgent
+# ---------------------------------------------------------------------------
+
+
+class TestRenewableAgent:
+    def test_net_demand(self):
+        from polars_ts.energy_agents import RenewableAgent
+
+        net = RenewableAgent().net_demand(np.array([5.0, 3.0]), np.array([2.0, 4.0]))
+        np.testing.assert_allclose(net, [3.0, -1.0])
+
+    def test_curtail_floors_at_zero(self):
+        from polars_ts.energy_agents import RenewableAgent
+
+        net = RenewableAgent(curtail=True).net_demand(np.array([5.0, 3.0]), np.array([2.0, 4.0]))
+        np.testing.assert_allclose(net, [3.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# DemandResponseAgent
+# ---------------------------------------------------------------------------
+
+
+class TestDemandResponseAgent:
+    def test_conserves_energy(self):
+        from polars_ts.energy_agents import DemandResponseAgent
+
+        profile = np.array([10.0, 2.0, 8.0, 1.0])
+        shifted, energy = DemandResponseAgent(capacity=5.0).optimize(profile)
+        assert shifted.sum() == pytest.approx(profile.sum())
+        assert energy > 0
+
+    def test_peaks_shaved(self):
+        from polars_ts.energy_agents import DemandResponseAgent
+
+        # Feasible window (total 21 <= capacity 6 * 4 slots): peaks fit under cap.
+        profile = np.array([10.0, 2.0, 8.0, 1.0])
+        shifted, energy = DemandResponseAgent(capacity=6.0).optimize(profile)
+        assert shifted.max() <= 6.0 + 1e-9
+        assert shifted.sum() == pytest.approx(profile.sum())
+        assert energy > 0
+
+    def test_infeasible_window_flattens(self):
+        from polars_ts.energy_agents import DemandResponseAgent
+
+        # total 21 > capacity 5 * 4 slots -> cannot fit under cap; flatten to mean.
+        profile = np.array([10.0, 2.0, 8.0, 1.0])
+        shifted, _ = DemandResponseAgent(capacity=5.0).optimize(profile)
+        assert shifted.sum() == pytest.approx(profile.sum())
+        np.testing.assert_allclose(shifted, np.full(4, profile.sum() / 4))
+
+    def test_no_shift_when_under_capacity(self):
+        from polars_ts.energy_agents import DemandResponseAgent
+
+        profile = np.array([1.0, 2.0, 3.0])
+        shifted, energy = DemandResponseAgent(capacity=5.0).optimize(profile)
+        assert energy == 0.0
+        np.testing.assert_allclose(shifted, profile)
+
+    def test_invalid_capacity(self):
+        from polars_ts.energy_agents import DemandResponseAgent
+
+        with pytest.raises(ValueError, match="capacity"):
+            DemandResponseAgent(capacity=0.0)
+
+
+# ---------------------------------------------------------------------------
+# EnergyGridOrchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestEnergyGridOrchestrator:
+    def test_run_returns_result(self, hierarchy, histories):
+        from polars_ts.energy_agents import EnergyForecastResult, EnergyGridOrchestrator
+
+        result = EnergyGridOrchestrator(season=24).run(histories, hierarchy, horizon=24)
+        assert isinstance(result, EnergyForecastResult)
+        assert isinstance(result.reconciled, pl.DataFrame)
+
+    def test_forecasts_are_coherent(self, hierarchy, histories):
+        from polars_ts.energy_agents import EnergyGridOrchestrator
+
+        result = EnergyGridOrchestrator(season=24).run(histories, hierarchy, horizon=24)
+        rec = result.reconciled
+
+        def series(node):
+            return rec.filter(pl.col("unique_id") == node).sort("ds")["y_hat"].to_numpy()
+
+        # Household forecasts must sum to their grid; grids to the region.
+        np.testing.assert_allclose(series("grid_a"), series("h1") + series("h2"), rtol=1e-6)
+        np.testing.assert_allclose(series("region"), series("grid_a") + series("grid_b"), rtol=1e-6)
+
+    def test_missing_history_raises(self, hierarchy):
+        from polars_ts.energy_agents import EnergyGridOrchestrator
+
+        with pytest.raises(ValueError, match="missing histories"):
+            EnergyGridOrchestrator().run({"h1": np.ones(48)}, hierarchy, horizon=12)
+
+    def test_weather_raises_demand(self, hierarchy, histories):
+        from polars_ts.energy_agents import EnergyGridOrchestrator
+
+        orch = EnergyGridOrchestrator(season=24)
+        baseline = orch.run(histories, hierarchy, horizon=24)
+        hot = orch.run(histories, hierarchy, horizon=24, weather=np.full(24, 35.0))
+        assert hot.region_net_demand.sum() > baseline.region_net_demand.sum()
+
+    def test_renewable_reduces_net_demand(self, hierarchy, histories):
+        from polars_ts.energy_agents import EnergyGridOrchestrator
+
+        orch = EnergyGridOrchestrator(season=24)
+        base = orch.run(histories, hierarchy, horizon=24)
+        gen = np.full(24, 1.0)
+        with_gen = orch.run(histories, hierarchy, horizon=24, generation=gen)
+        assert with_gen.region_net_demand.sum() < base.region_net_demand.sum()
+
+    def test_demand_response_applied(self, hierarchy, histories):
+        from polars_ts.energy_agents import EnergyGridOrchestrator
+
+        orch = EnergyGridOrchestrator(season=24)
+        result = orch.run(histories, hierarchy, horizon=24, capacity=0.1)
+        assert result.demand_response is not None
+        assert result.demand_response["energy_shifted"] >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports
+# ---------------------------------------------------------------------------
+
+
+class TestLazyImports:
+    NAMES = [
+        "GridHierarchy",
+        "DemandForecastAgent",
+        "WeatherContextAgent",
+        "RenewableAgent",
+        "DemandResponseAgent",
+        "EnergyGridOrchestrator",
+        "EnergyForecastResult",
+    ]
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_module(self, name):
+        import polars_ts.energy_agents as mod
+
+        assert getattr(mod, name) is not None
+        assert name in mod.__all__
+
+    @pytest.mark.parametrize("name", NAMES)
+    def test_importable_from_top_level(self, name):
+        import polars_ts
+
+        assert getattr(polars_ts, name) is not None


### PR DESCRIPTION
## Summary

Implements **Phase 4 / T3-4** of the roadmap (#148): a hierarchical multi-agent system for energy and demand forecasting that integrates with the hierarchical reconciliation module.

Closes #162.

## Scope (per #162)

| Requirement | Delivered |
|-------------|-----------|
| Region → grid → household hierarchy | `GridHierarchy` + `EnergyGridOrchestrator` |
| Weather context via covariates | `WeatherContextAgent` (degree-day heating/cooling load) |
| Demand response optimization | `DemandResponseAgent` (energy-conserving peak-shaving) |
| Renewable intermittency handling | `RenewableAgent` (net demand, optional curtailment) |
| Integration with hierarchical reconciliation | orchestrator calls `polars_ts.reconciliation.reconcile` |

## Module `polars_ts.energy_agents`

- **`GridHierarchy`** — region → grid → household topology; exposes the child→parent tree consumed by `reconcile`.
- **`DemandForecastAgent`** — per-node seasonal-naive demand forecasting.
- **`WeatherContextAgent`**, **`RenewableAgent`**, **`DemandResponseAgent`**.
- **`EnergyGridOrchestrator` / `EnergyForecastResult`** — forecast every node (optionally weather-adjusted), reconcile **bottom-up** into coherent per-node forecasts, then apply renewable netting and demand response at the region level.

All names wired into the root `_LAZY_IMPORTS` registry.

## Tests & verification

- **39 new tests** (`tests/test_energy_agents.py`): hierarchy structure, each agent, **reconciliation coherence** (households sum to grids, grids to region), weather/renewable/demand-response effects, and lazy imports.
- Existing `tests/test_reconciliation.py` still passes (no regression).
- `ruff check` + `ruff format` clean (CI-pinned **ruff 0.8.4**).
- Single commit, based on current `main`.

## Notes

- The orchestrator feeds **bottom-level (household) forecasts** to `reconcile` — the correct input for bottom-up aggregation, which also sidesteps a latent double-counting path in `_bottom_up` when intermediate nodes carry their own base rows. Happy to file that as a separate reconciliation hardening issue if useful.
- Remaining Phase 4 domain agent after this: T3-5 supply chain (#163).