### PR TITLE
feat: add perishables retail demand forecasting application (#211)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ cython_debug/
 
 # temporarily
 .vscode/
+
+# Perishables application raw data (issue #211)
+data/perishables/

--- a/polars_ts/applications/__init__.py
+++ b/polars_ts/applications/__init__.py
@@ -1,0 +1,35 @@
+"""Domain-specific application modules built on polars-ts primitives.
+
+Each application packages loaders, preprocessing, models, and decision
+logic for a concrete forecasting domain. First application: perishables
+retail demand forecasting for restocking decisions (#211).
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "ColumnMapping": ("polars_ts.applications.perishables.loader", "ColumnMapping"),
+    "load_sales_csv": ("polars_ts.applications.perishables.loader", "load_sales_csv"),
+    "fill_missing_dates": ("polars_ts.applications.perishables.loader", "fill_missing_dates"),
+    "fit_growth": ("polars_ts.applications.perishables.preprocessing", "fit_growth"),
+    "remove_growth": ("polars_ts.applications.perishables.preprocessing", "remove_growth"),
+    "reapply_growth": ("polars_ts.applications.perishables.preprocessing", "reapply_growth"),
+    "recency_weights": ("polars_ts.applications.perishables.preprocessing", "recency_weights"),
+    "select_adaptive_window": ("polars_ts.applications.perishables.preprocessing", "select_adaptive_window"),
+    "apply_training_window": ("polars_ts.applications.perishables.preprocessing", "apply_training_window"),
+    "classify_demand": ("polars_ts.applications.perishables.intermittent", "classify_demand"),
+    "croston_forecast": ("polars_ts.applications.perishables.intermittent", "croston_forecast"),
+    "sba_forecast": ("polars_ts.applications.perishables.intermittent", "sba_forecast"),
+    "tsb_forecast": ("polars_ts.applications.perishables.intermittent", "tsb_forecast"),
+    "intermittent_forecast": ("polars_ts.applications.perishables.intermittent", "intermittent_forecast"),
+    "RestockPolicy": ("polars_ts.applications.perishables.restock", "RestockPolicy"),
+    "recommend_orders": ("polars_ts.applications.perishables.restock", "recommend_orders"),
+    "demand_std": ("polars_ts.applications.perishables.restock", "demand_std"),
+    "cold_start_skus": ("polars_ts.applications.perishables.cold_start", "cold_start_skus"),
+    "cold_start_forecast": ("polars_ts.applications.perishables.cold_start", "cold_start_forecast"),
+    "dow_profile": ("polars_ts.applications.perishables.features", "dow_profile"),
+    "estimate_promo_lift": ("polars_ts.applications.perishables.features", "estimate_promo_lift"),
+    "perishable_calendar_features": ("polars_ts.applications.perishables.features", "perishable_calendar_features"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/applications/perishables/__init__.py
+++ b/polars_ts/applications/perishables/__init__.py
@@ -1,0 +1,38 @@
+"""Perishables retail demand forecasting application (#211).
+
+End-to-end tooling for restocking decisions on perishable goods:
+CSV ingestion with schema validation, growth-aware preprocessing,
+intermittent-demand models (Croston/SBA/TSB), cold-start warm-up for
+new SKUs, domain feature engineering, and a forecast-to-order
+restock calculator with service-level and shelf-life constraints.
+"""
+
+from polars_ts._lazy import make_getattr
+
+_IMPORTS: dict[str, tuple[str, str]] = {
+    "ColumnMapping": ("polars_ts.applications.perishables.loader", "ColumnMapping"),
+    "load_sales_csv": ("polars_ts.applications.perishables.loader", "load_sales_csv"),
+    "validate_sales_frame": ("polars_ts.applications.perishables.loader", "validate_sales_frame"),
+    "fill_missing_dates": ("polars_ts.applications.perishables.loader", "fill_missing_dates"),
+    "fit_growth": ("polars_ts.applications.perishables.preprocessing", "fit_growth"),
+    "remove_growth": ("polars_ts.applications.perishables.preprocessing", "remove_growth"),
+    "reapply_growth": ("polars_ts.applications.perishables.preprocessing", "reapply_growth"),
+    "recency_weights": ("polars_ts.applications.perishables.preprocessing", "recency_weights"),
+    "select_adaptive_window": ("polars_ts.applications.perishables.preprocessing", "select_adaptive_window"),
+    "apply_training_window": ("polars_ts.applications.perishables.preprocessing", "apply_training_window"),
+    "classify_demand": ("polars_ts.applications.perishables.intermittent", "classify_demand"),
+    "croston_forecast": ("polars_ts.applications.perishables.intermittent", "croston_forecast"),
+    "sba_forecast": ("polars_ts.applications.perishables.intermittent", "sba_forecast"),
+    "tsb_forecast": ("polars_ts.applications.perishables.intermittent", "tsb_forecast"),
+    "intermittent_forecast": ("polars_ts.applications.perishables.intermittent", "intermittent_forecast"),
+    "RestockPolicy": ("polars_ts.applications.perishables.restock", "RestockPolicy"),
+    "recommend_orders": ("polars_ts.applications.perishables.restock", "recommend_orders"),
+    "demand_std": ("polars_ts.applications.perishables.restock", "demand_std"),
+    "cold_start_skus": ("polars_ts.applications.perishables.cold_start", "cold_start_skus"),
+    "cold_start_forecast": ("polars_ts.applications.perishables.cold_start", "cold_start_forecast"),
+    "dow_profile": ("polars_ts.applications.perishables.features", "dow_profile"),
+    "estimate_promo_lift": ("polars_ts.applications.perishables.features", "estimate_promo_lift"),
+    "perishable_calendar_features": ("polars_ts.applications.perishables.features", "perishable_calendar_features"),
+}
+
+__getattr__, __all__ = make_getattr(_IMPORTS, __name__)

--- a/polars_ts/applications/perishables/cold_start.py
+++ b/polars_ts/applications/perishables/cold_start.py
@@ -18,7 +18,7 @@ cluster's SKUs into this module.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import polars as pl
@@ -59,7 +59,7 @@ def _launch_profiles(df: pl.DataFrame, id_col: str, time_col: str, target_col: s
     """Return each SKU's launch-aligned demand array, sorted by date."""
     profiles: dict[str, np.ndarray] = {}
     for group_id, group_df in df.sort(id_col, time_col).group_by(id_col, maintain_order=True):
-        profiles[group_id[0]] = group_df[target_col].to_numpy().astype(np.float64)
+        profiles[cast(str, group_id[0])] = group_df[target_col].to_numpy().astype(np.float64)
     return profiles
 
 

--- a/polars_ts/applications/perishables/cold_start.py
+++ b/polars_ts/applications/perishables/cold_start.py
@@ -1,0 +1,184 @@
+"""Cold-start forecasting for new SKUs with little or no history.
+
+New perishables launch constantly; with days of history there is
+nothing for a statistical model to fit. Instead, borrow the early-life
+trajectory of established SKUs:
+
+- With some observations, find the *k* donors whose own launch-aligned,
+  level-normalized early sales look most similar (Euclidean distance)
+  and average their subsequent trajectory, rescaled to the new SKU's
+  observed level.
+- With zero or near-zero observations, fall back to the mean
+  launch-aligned trajectory of the SKU's category (or of all donors).
+
+For richer similarity structure (DTW, k-medoids), cluster donor
+profiles with :func:`polars_ts.auto_cluster` upstream and pass a single
+cluster's SKUs into this module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.models._time_utils import _infer_freq, _make_future_dates
+
+_EPS = 1e-9
+
+
+def cold_start_skus(
+    df: pl.DataFrame,
+    min_history: int = 28,
+    id_col: str = "unique_id",
+) -> list[str]:
+    """List SKUs with fewer than ``min_history`` observations.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame (per-SKU calendars start at each
+        SKU's launch, as produced by the loader).
+    min_history
+        Observation count below which a SKU is considered cold.
+    id_col
+        SKU column name.
+
+    Returns
+    -------
+    list[str]
+        Cold SKU identifiers, sorted.
+
+    """
+    counts = df.group_by(id_col).agg(pl.len().alias("__n"))
+    return sorted(counts.filter(pl.col("__n") < min_history)[id_col].to_list())
+
+
+def _launch_profiles(df: pl.DataFrame, id_col: str, time_col: str, target_col: str) -> dict[str, np.ndarray]:
+    """Return each SKU's launch-aligned demand array, sorted by date."""
+    profiles: dict[str, np.ndarray] = {}
+    for group_id, group_df in df.sort(id_col, time_col).group_by(id_col, maintain_order=True):
+        profiles[group_id[0]] = group_df[target_col].to_numpy().astype(np.float64)
+    return profiles
+
+
+def _donor_trajectory(
+    obs: np.ndarray,
+    donors: list[np.ndarray],
+    h: int,
+    k: int,
+) -> np.ndarray:
+    """Forecast h steps by averaging the k most similar donor trajectories.
+
+    Donors are compared on the launch-aligned overlap with ``obs`` after
+    mean-normalization, then their steps ``[len(obs), len(obs)+h)`` are
+    averaged and rescaled to the new SKU's observed mean level.
+    """
+    n_obs = len(obs)
+    usable = [d for d in donors if len(d) >= n_obs + 1]
+    if not usable:
+        return np.zeros(h)
+
+    obs_mean = obs.mean() if n_obs else 0.0
+    if n_obs and obs_mean > _EPS:
+        obs_norm = obs / obs_mean
+        dists = []
+        for d in usable:
+            head = d[:n_obs]
+            head_norm = head / max(head.mean(), _EPS)
+            dists.append(float(np.linalg.norm(obs_norm - head_norm)))
+        order = np.argsort(dists)[:k]
+    else:
+        # No usable level signal: every donor is equally plausible
+        order = np.arange(min(k, len(usable)))
+
+    steps = np.zeros(h)
+    for rank in order:
+        d = usable[rank]
+        future = d[n_obs : n_obs + h]
+        head_mean = max(d[:n_obs].mean() if n_obs else d.mean(), _EPS)
+        # Express the donor's future relative to its own early level ...
+        scaled = future / head_mean
+        if len(scaled) < h:
+            scaled = np.pad(scaled, (0, h - len(scaled)), mode="edge")
+        steps += scaled
+    steps /= len(order)
+    # ... then rescale to the new SKU's level (donor-average level if unobserved)
+    level = (
+        obs_mean
+        if obs_mean > _EPS
+        else float(np.mean([max(d[:n_obs].mean() if n_obs else d.mean(), _EPS) for d in (usable[r] for r in order)]))
+    )
+    return np.clip(steps * level, 0.0, None)
+
+
+def cold_start_forecast(
+    df: pl.DataFrame,
+    h: int,
+    min_history: int = 28,
+    k: int = 5,
+    category_map: pl.DataFrame | None = None,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Forecast cold SKUs by borrowing established SKUs' early life.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame containing both cold and
+        established SKUs.
+    h
+        Forecast horizon (periods).
+    min_history
+        Observation count below which a SKU is treated as cold.
+    k
+        Number of donor SKUs averaged per cold SKU.
+    category_map
+        Optional ``[id_col, "category"]`` frame; when given, donors are
+        restricted to the cold SKU's category (falling back to all
+        donors for unknown categories).
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]`` with *h* rows per cold
+        SKU. Established SKUs are not forecast here — route them to the
+        standard pipeline.
+
+    """
+    if h <= 0:
+        raise ValueError("Horizon h must be a positive integer")
+    cold = set(cold_start_skus(df, min_history, id_col))
+    if not cold:
+        schema = {id_col: df.schema[id_col], time_col: df.schema[time_col], "y_hat": pl.Float64()}
+        return pl.DataFrame(schema=schema)
+
+    profiles = _launch_profiles(df, id_col, time_col, target_col)
+    donor_ids = [sku for sku in profiles if sku not in cold]
+    if not donor_ids:
+        raise ValueError("No established SKUs available as cold-start donors")
+
+    categories: dict[str, Any] = {}
+    if category_map is not None:
+        categories = dict(category_map.select(id_col, "category").iter_rows())
+
+    sorted_df = df.sort(id_col, time_col)
+    freq = _infer_freq(sorted_df[time_col])
+    last_dates = dict(sorted_df.group_by(id_col).agg(pl.col(time_col).max()).iter_rows())
+
+    rows: list[dict[str, Any]] = []
+    for sku in sorted(cold):
+        cat = categories.get(sku)
+        pool_ids = [d for d in donor_ids if categories.get(d) == cat] if cat is not None else donor_ids
+        pool = [profiles[d] for d in (pool_ids or donor_ids)]
+        y_hat = _donor_trajectory(profiles[sku], pool, h, k)
+        for step, t in enumerate(_make_future_dates(last_dates[sku], freq, h)):
+            rows.append({id_col: sku, time_col: t, "y_hat": float(y_hat[step])})
+
+    schema = {id_col: df.schema[id_col], time_col: df.schema[time_col], "y_hat": pl.Float64()}
+    return pl.DataFrame(rows, schema=schema).sort(id_col, time_col)

--- a/polars_ts/applications/perishables/features.py
+++ b/polars_ts/applications/perishables/features.py
@@ -1,0 +1,129 @@
+"""Perishables-specific feature engineering.
+
+Domain features layered on top of the generic helpers
+(:func:`polars_ts.lag_features`, :func:`polars_ts.rolling_features`,
+:func:`polars_ts.calendar_features`): retail calendar flags, per-SKU
+day-of-week demand profiles (fresh-goods demand is dominated by weekly
+shopping rhythm), and promotion lift estimation.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from polars_ts.features.calendar import calendar_features
+
+_EPS = 1e-9
+
+
+def perishable_calendar_features(
+    df: pl.DataFrame,
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Add retail calendar features relevant to perishables demand.
+
+    Extends the generic calendar features (day of week, month, weekend
+    flag) with month-boundary flags that proxy payday-driven grocery
+    spikes: ``is_month_start`` (first 5 days) and ``is_month_end``
+    (last 5 days).
+
+    Parameters
+    ----------
+    df
+        Canonical sales frame.
+    time_col
+        Date column.
+
+    Returns
+    -------
+    pl.DataFrame
+        Input frame with ``day_of_week``, ``day_of_month``, ``week``,
+        ``month``, ``is_weekend``, ``is_month_start``, ``is_month_end``
+        appended.
+
+    """
+    out = calendar_features(df, ["day_of_week", "day_of_month", "week", "month", "is_weekend"], time_col)
+    days_in_month = pl.col(time_col).dt.month_end().dt.day()
+    return out.with_columns(
+        (pl.col("day_of_month") <= 5).cast(pl.Int8).alias("is_month_start"),
+        (pl.col("day_of_month") > days_in_month - 5).cast(pl.Int8).alias("is_month_end"),
+    )
+
+
+def dow_profile(
+    df: pl.DataFrame,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Compute per-SKU day-of-week demand indices.
+
+    The index is the SKU's mean demand on that weekday divided by its
+    overall mean, so 1.0 is a neutral day and e.g. 1.8 on Saturday means
+    an 80% uplift. Use it to shape flat intermittent-demand forecasts
+    across the week before feeding the restock calculator.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "day_of_week", "dow_index"]`` (weekday 1 =
+        Monday ... 7 = Sunday, matching polars).
+
+    """
+    return (
+        df.with_columns(pl.col(time_col).dt.weekday().alias("day_of_week"))
+        .group_by(id_col, "day_of_week")
+        .agg(pl.col(target_col).mean().alias("__dow_mean"))
+        .with_columns((pl.col("__dow_mean") / (pl.col("__dow_mean").mean().over(id_col) + _EPS)).alias("dow_index"))
+        .drop("__dow_mean")
+        .sort(id_col, "day_of_week")
+    )
+
+
+def estimate_promo_lift(
+    df: pl.DataFrame,
+    promo_col: str = "promo",
+    target_col: str = "y",
+    id_col: str = "unique_id",
+) -> pl.DataFrame:
+    """Estimate each SKU's multiplicative promotion lift.
+
+    Lift is mean demand on promoted periods divided by mean demand on
+    non-promoted periods. SKUs never (or always) promoted get a null
+    lift — there is no counterfactual to compare against.
+
+    Parameters
+    ----------
+    df
+        Canonical sales frame with a promotion flag column.
+    promo_col
+        Column with a truthy promotion indicator.
+    target_col, id_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "promo_lift", "n_promo_periods"]``.
+
+    """
+    if promo_col not in df.columns:
+        raise ValueError(f"Column {promo_col!r} not found; map it via ColumnMapping(promo=...)")
+    on_promo = pl.col(promo_col).cast(pl.Boolean)
+    return (
+        df.group_by(id_col)
+        .agg(
+            (pl.col(target_col).filter(on_promo).mean() / (pl.col(target_col).filter(~on_promo).mean() + _EPS)).alias(
+                "promo_lift"
+            ),
+            on_promo.sum().alias("n_promo_periods"),
+        )
+        .sort(id_col)
+    )

--- a/polars_ts/applications/perishables/intermittent.py
+++ b/polars_ts/applications/perishables/intermittent.py
@@ -1,0 +1,292 @@
+"""Intermittent-demand models for sparse perishables SKUs.
+
+Slow movers sell on a minority of days; standard smoothers collapse to
+near-zero or chase noise. Implements the classical sparse-demand family:
+
+- **Croston** — separate exponential smoothing of nonzero demand sizes
+  and inter-demand intervals.
+- **SBA** (Syntetos-Boylan Approximation) — Croston with the
+  ``1 - alpha/2`` bias correction.
+- **TSB** (Teunter-Syntetos-Babai) — smooths demand probability every
+  period, so obsolete SKUs decay toward zero.
+
+Plus the standard ADI / CV² demand classifier (Syntetos et al.) used by
+:func:`intermittent_forecast` to dispatch per SKU.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from polars_ts.models._time_utils import _infer_freq, _make_future_dates
+
+# Syntetos-Boylan cut-offs separating smooth/erratic from intermittent/lumpy
+_ADI_CUTOFF = 1.32
+_CV2_CUTOFF = 0.49
+
+
+def classify_demand(
+    df: pl.DataFrame,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Classify each SKU's demand pattern via ADI and CV².
+
+    ADI (average inter-demand interval, in periods) and CV² (squared
+    coefficient of variation of nonzero demand sizes) split SKUs into
+    the four Syntetos-Boylan quadrants at ADI 1.32 and CV² 0.49:
+    ``smooth``, ``erratic``, ``intermittent``, and ``lumpy``.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "adi", "cv2", "demand_class"]``. SKUs with no
+        nonzero demand get infinite ADI and class ``"intermittent"``.
+
+    """
+    nonzero = pl.col(target_col).gt(0)
+    stats = (
+        df.sort(id_col, time_col)
+        .group_by(id_col)
+        .agg(
+            (pl.len() / nonzero.sum()).alias("adi"),
+            ((pl.col(target_col).filter(nonzero).std(ddof=0) / pl.col(target_col).filter(nonzero).mean()) ** 2).alias(
+                "cv2"
+            ),
+        )
+        .with_columns(pl.col("cv2").fill_null(0.0))
+    )
+    return stats.with_columns(
+        pl.when(pl.col("adi") <= _ADI_CUTOFF)
+        .then(pl.when(pl.col("cv2") <= _CV2_CUTOFF).then(pl.lit("smooth")).otherwise(pl.lit("erratic")))
+        .otherwise(pl.when(pl.col("cv2") <= _CV2_CUTOFF).then(pl.lit("intermittent")).otherwise(pl.lit("lumpy")))
+        .alias("demand_class")
+    ).sort(id_col)
+
+
+def _croston_rate(values: np.ndarray, alpha: float, bias_correction: float = 1.0) -> float:
+    """Return the smoothed per-period demand rate via Croston's method."""
+    nonzero_idx = np.flatnonzero(values > 0)
+    if nonzero_idx.size == 0:
+        return 0.0
+    size = float(values[nonzero_idx[0]])
+    interval = float(nonzero_idx[0] + 1)
+    prev = nonzero_idx[0]
+    for idx in nonzero_idx[1:]:
+        size += alpha * (float(values[idx]) - size)
+        interval += alpha * (float(idx - prev) - interval)
+        prev = idx
+    return bias_correction * size / max(interval, 1.0)
+
+
+def _tsb_rate(values: np.ndarray, alpha: float, beta: float) -> float:
+    """Return the smoothed per-period demand rate via TSB."""
+    nonzero = values > 0
+    if not nonzero.any():
+        return 0.0
+    prob = float(nonzero.mean())
+    size = float(values[nonzero][0])
+    for v in values:
+        if v > 0:
+            prob += beta * (1.0 - prob)
+            size += alpha * (float(v) - size)
+        else:
+            prob += beta * (0.0 - prob)
+    return prob * size
+
+
+def _flat_forecast(
+    df: pl.DataFrame,
+    h: int,
+    rate_fn: Any,
+    target_col: str,
+    id_col: str,
+    time_col: str,
+) -> pl.DataFrame:
+    """Emit h rows per SKU with a constant per-period rate from rate_fn."""
+    if h <= 0:
+        raise ValueError("Horizon h must be a positive integer")
+    sorted_df = df.sort(id_col, time_col)
+    freq = _infer_freq(sorted_df[time_col])
+    rows: list[dict[str, Any]] = []
+    for group_id, group_df in sorted_df.group_by(id_col, maintain_order=True):
+        rate = rate_fn(group_df[target_col].to_numpy())
+        for t in _make_future_dates(group_df[time_col][-1], freq, h):
+            rows.append({id_col: group_id[0], time_col: t, "y_hat": rate})
+    schema = {id_col: df.schema[id_col], time_col: df.schema[time_col], "y_hat": pl.Float64()}
+    return pl.DataFrame(rows, schema=schema).sort(id_col, time_col)
+
+
+def croston_forecast(
+    df: pl.DataFrame,
+    h: int,
+    alpha: float = 0.1,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Croston's method: constant demand-rate forecast for sparse SKUs.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame (zeros must be explicit rows).
+    h
+        Forecast horizon (number of periods).
+    alpha
+        Smoothing factor for both demand sizes and intervals.
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]`` with *h* rows per SKU;
+        ``y_hat`` is the expected demand per period.
+
+    """
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be in (0, 1)")
+    return _flat_forecast(df, h, lambda v: _croston_rate(v, alpha), target_col, id_col, time_col)
+
+
+def sba_forecast(
+    df: pl.DataFrame,
+    h: int,
+    alpha: float = 0.1,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Syntetos-Boylan Approximation: bias-corrected Croston.
+
+    Applies the ``1 - alpha/2`` correction that removes Croston's
+    positive bias; the recommended default for intermittent and lumpy
+    SKUs.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    h
+        Forecast horizon.
+    alpha
+        Smoothing factor.
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]``.
+
+    """
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be in (0, 1)")
+    correction = 1.0 - alpha / 2.0
+    return _flat_forecast(df, h, lambda v: _croston_rate(v, alpha, correction), target_col, id_col, time_col)
+
+
+def tsb_forecast(
+    df: pl.DataFrame,
+    h: int,
+    alpha: float = 0.1,
+    beta: float = 0.1,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Teunter-Syntetos-Babai forecast for sparse SKUs with obsolescence.
+
+    Unlike Croston, the demand probability updates every period, so a
+    SKU that stops selling sees its forecast decay toward zero — the
+    right behaviour for delisted or seasonal perishables.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    h
+        Forecast horizon.
+    alpha
+        Smoothing factor for demand sizes.
+    beta
+        Smoothing factor for demand probability.
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]``.
+
+    """
+    if not 0 < alpha < 1 or not 0 < beta < 1:
+        raise ValueError("alpha and beta must be in (0, 1)")
+    return _flat_forecast(df, h, lambda v: _tsb_rate(v, alpha, beta), target_col, id_col, time_col)
+
+
+def intermittent_forecast(
+    df: pl.DataFrame,
+    h: int,
+    method: str = "auto",
+    alpha: float = 0.1,
+    beta: float = 0.1,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Forecast sparse SKUs, optionally auto-dispatching per demand class.
+
+    With ``method="auto"``, each SKU is classified via
+    :func:`classify_demand`: intermittent and lumpy SKUs use SBA,
+    smooth and erratic SKUs use Croston.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    h
+        Forecast horizon.
+    method
+        ``"auto"``, ``"croston"``, ``"sba"``, or ``"tsb"``.
+    alpha, beta
+        Smoothing factors (``beta`` only used by TSB).
+    target_col, id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, time_col, "y_hat"]``.
+
+    """
+    dispatch = {"croston": croston_forecast, "sba": sba_forecast}
+    if method in dispatch:
+        return dispatch[method](df, h, alpha, target_col, id_col, time_col)
+    if method == "tsb":
+        return tsb_forecast(df, h, alpha, beta, target_col, id_col, time_col)
+    if method != "auto":
+        raise ValueError(f"Unknown method {method!r}; expected 'auto', 'croston', 'sba', or 'tsb'")
+
+    classes = classify_demand(df, target_col, id_col, time_col)
+    sparse_ids = classes.filter(pl.col("demand_class").is_in(["intermittent", "lumpy"]))[id_col].to_list()
+    parts = []
+    sparse = df.filter(pl.col(id_col).is_in(sparse_ids))
+    dense = df.filter(~pl.col(id_col).is_in(sparse_ids))
+    if sparse.height:
+        parts.append(sba_forecast(sparse, h, alpha, target_col, id_col, time_col))
+    if dense.height:
+        parts.append(croston_forecast(dense, h, alpha, target_col, id_col, time_col))
+    return pl.concat(parts).sort(id_col, time_col)

--- a/polars_ts/applications/perishables/loader.py
+++ b/polars_ts/applications/perishables/loader.py
@@ -1,0 +1,191 @@
+"""CSV ingestion for perishables sales history.
+
+Maps arbitrary source column names onto the canonical polars-ts long
+format (``unique_id``, ``ds``, ``y``), validates the schema, aggregates
+duplicate (SKU, date) rows, and fills calendar gaps with zero demand —
+for perishables a missing day means "no sales", not "missing data".
+
+Raw CSVs live under ``data/perishables/`` which is gitignored.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+
+
+@dataclass(frozen=True)
+class ColumnMapping:
+    """Maps source CSV column names to canonical polars-ts columns.
+
+    Parameters
+    ----------
+    sku
+        Source column identifying the product (mapped to ``unique_id``).
+    date
+        Source column with the sale date (mapped to ``ds``).
+    quantity
+        Source column with units sold (mapped to ``y``).
+    category
+        Optional product category/family column, kept as ``category``.
+        Critical for cold-start borrowing across similar SKUs.
+    price
+        Optional unit-price column, kept as ``price``.
+    promo
+        Optional promotion-flag column, kept as ``promo``.
+
+    """
+
+    sku: str = "sku"
+    date: str = "date"
+    quantity: str = "quantity"
+    category: str | None = None
+    price: str | None = None
+    promo: str | None = None
+
+    def required(self) -> dict[str, str]:
+        """Return the mandatory source-to-canonical rename mapping."""
+        return {self.sku: "unique_id", self.date: "ds", self.quantity: "y"}
+
+    def optional(self) -> dict[str, str]:
+        """Return the optional source-to-canonical rename mapping."""
+        out: dict[str, str] = {}
+        if self.category is not None:
+            out[self.category] = "category"
+        if self.price is not None:
+            out[self.price] = "price"
+        if self.promo is not None:
+            out[self.promo] = "promo"
+        return out
+
+
+def validate_sales_frame(df: pl.DataFrame, mapping: ColumnMapping | None = None) -> None:
+    """Validate a raw sales frame against a column mapping.
+
+    Parameters
+    ----------
+    df
+        Raw sales DataFrame (source column names).
+    mapping
+        Column mapping; defaults to ``ColumnMapping()``.
+
+    Raises
+    ------
+    ValueError
+        If mapped columns are missing, dates contain nulls, or the
+        quantity column is not numeric.
+
+    """
+    mapping = mapping or ColumnMapping()
+    expected = list(mapping.required()) + list(mapping.optional())
+    missing = [c for c in expected if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns {missing}; available: {df.columns}")
+    if df[mapping.date].null_count() > 0:
+        raise ValueError(f"Column {mapping.date!r} contains null dates")
+    if not df.schema[mapping.quantity].is_numeric():
+        raise ValueError(f"Column {mapping.quantity!r} must be numeric, got {df.schema[mapping.quantity]}")
+
+
+def fill_missing_dates(
+    df: pl.DataFrame,
+    freq: str = "1d",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+) -> pl.DataFrame:
+    """Fill calendar gaps per SKU with zero demand.
+
+    Each SKU's calendar runs from its own first sale (its launch) to the
+    global last date, so new SKUs are not padded with pre-launch zeros.
+    Static columns (``category``) are re-attached; ``promo`` gaps become
+    0 and ``price`` gaps are forward/backward filled within each SKU.
+
+    Parameters
+    ----------
+    df
+        Canonical sales frame.
+    freq
+        Polars interval string for the calendar grid.
+    id_col, time_col, target_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Gap-free frame sorted by ``(id_col, time_col)``.
+
+    """
+    max_date = df[time_col].max()
+    grid = (
+        df.group_by(id_col)
+        .agg(pl.col(time_col).min().alias("__start"))
+        .with_columns(pl.date_ranges("__start", pl.lit(max_date), interval=freq).alias(time_col))
+        .explode(time_col)
+        .drop("__start")
+    )
+    out = grid.join(df, on=[id_col, time_col], how="left")
+    out = out.with_columns(pl.col(target_col).fill_null(0.0))
+    if "category" in out.columns:
+        out = out.with_columns(pl.col("category").first().over(id_col))
+    if "promo" in out.columns:
+        out = out.with_columns(pl.col("promo").fill_null(0))
+    if "price" in out.columns:
+        out = out.with_columns(pl.col("price").forward_fill().backward_fill().over(id_col))
+    return out.sort(id_col, time_col)
+
+
+def load_sales_csv(
+    source: str | Path | pl.DataFrame,
+    mapping: ColumnMapping | None = None,
+    *,
+    fill_gaps: bool = True,
+    freq: str = "1d",
+    clip_negative: bool = True,
+) -> pl.DataFrame:
+    """Load a perishables sales CSV into canonical long format.
+
+    Parameters
+    ----------
+    source
+        CSV path, or an already-parsed DataFrame (useful for tests and
+        multi-file concatenation done upstream).
+    mapping
+        Source column mapping; defaults to ``ColumnMapping()``.
+    fill_gaps
+        Fill per-SKU calendar gaps with zero demand.
+    freq
+        Calendar interval used when ``fill_gaps`` is enabled.
+    clip_negative
+        Clip negative quantities (returns/corrections) to zero so they
+        do not distort demand models.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[unique_id, ds, y]`` plus any mapped optional columns,
+        one row per SKU per period, sorted by ``(unique_id, ds)``.
+
+    """
+    mapping = mapping or ColumnMapping()
+    df = source if isinstance(source, pl.DataFrame) else pl.read_csv(source, try_parse_dates=True)
+    validate_sales_frame(df, mapping)
+
+    rename = {**mapping.required(), **mapping.optional()}
+    df = df.select(list(rename)).rename(rename)
+    if df.schema["ds"] == pl.String:
+        df = df.with_columns(pl.col("ds").str.to_date())
+    df = df.with_columns(pl.col("ds").cast(pl.Date), pl.col("unique_id").cast(pl.String), pl.col("y").cast(pl.Float64))
+    if clip_negative:
+        df = df.with_columns(pl.col("y").clip(lower_bound=0.0))
+
+    # Aggregate duplicate (SKU, date) rows: quantities sum, optional columns keep first
+    agg = [pl.col("y").sum()]
+    agg += [pl.col(c).first() for c in ("category", "price", "promo") if c in df.columns]
+    df = df.group_by("unique_id", "ds").agg(agg)
+
+    if fill_gaps:
+        df = fill_missing_dates(df, freq=freq)
+    return df.sort("unique_id", "ds")

--- a/polars_ts/applications/perishables/preprocessing.py
+++ b/polars_ts/applications/perishables/preprocessing.py
@@ -1,0 +1,263 @@
+"""Growth-aware preprocessing for rapidly scaling perishables demand.
+
+A double-digit YoY growth business breaks the stationarity assumption of
+most models: two-year-old observations describe a much smaller company.
+Three complementary levers are provided:
+
+- **Growth detrending** — estimate a per-SKU exponential growth rate and
+  rescale history to today's level (and re-apply it to forecasts).
+- **Recency weighting** — exponential-decay sample weights for models
+  that accept them.
+- **Adaptive windowing** — per-SKU training-window length chosen so the
+  level drift across the window stays below a tolerance; fast-growing
+  SKUs train on less (but recent) history.
+"""
+
+from __future__ import annotations
+
+import math
+
+import polars as pl
+
+_EPS = 1e-9
+
+
+def fit_growth(
+    df: pl.DataFrame,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+    smooth_window: int = 28,
+) -> pl.DataFrame:
+    """Estimate a per-SKU daily exponential growth rate.
+
+    Fits ordinary least squares of ``log(rolling_mean(y) + eps)`` against
+    time (in days) per SKU. The rolling mean smooths over zero-demand
+    days so intermittent SKUs get a level trend, not noise.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    id_col, time_col, target_col
+        Canonical column names.
+    smooth_window
+        Rolling-mean window (days) applied before the log-linear fit.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "daily_growth"]`` where ``daily_growth`` is
+        the fitted slope of the log-level per day (0.0 for SKUs with
+        fewer than ``smooth_window`` observations).
+
+    """
+    smoothed = df.sort(id_col, time_col).with_columns(
+        pl.col(target_col).rolling_mean(window_size=smooth_window).over(id_col).alias("__level"),
+        ((pl.col(time_col) - pl.col(time_col).min().over(id_col)).dt.total_days()).alias("__t"),
+    )
+    smoothed = smoothed.drop_nulls("__level").with_columns((pl.col("__level") + _EPS).log().alias("__log_level"))
+    fitted = (
+        smoothed.group_by(id_col)
+        .agg(
+            (pl.cov(pl.col("__t"), pl.col("__log_level")) / (pl.col("__t").var() + _EPS))
+            .fill_null(0.0)
+            .alias("daily_growth"),
+            pl.len().alias("__n"),
+        )
+        .with_columns(pl.when(pl.col("__n") < 2).then(0.0).otherwise(pl.col("daily_growth")).alias("daily_growth"))
+        .drop("__n")
+    )
+    all_ids = df.select(pl.col(id_col).unique())
+    return all_ids.join(fitted, on=id_col, how="left").with_columns(pl.col("daily_growth").fill_null(0.0)).sort(id_col)
+
+
+def remove_growth(
+    df: pl.DataFrame,
+    growth: pl.DataFrame,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y",
+) -> pl.DataFrame:
+    """Rescale history to today's demand level.
+
+    Each observation is multiplied by ``exp(g * (t_last - t))`` so that a
+    value observed a year ago on a SKU growing at rate *g* is expressed
+    at the level the SKU sells at now. Models then see an (approximately)
+    level-stationary series.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    growth
+        Output of :func:`fit_growth`.
+    id_col, time_col, target_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Input frame with ``target_col`` replaced by its level-adjusted
+        value and the original preserved as ``"{target_col}_raw"``.
+
+    """
+    out = df.join(growth, on=id_col, how="left").with_columns(pl.col("daily_growth").fill_null(0.0))
+    age = (pl.col(time_col).max().over(id_col) - pl.col(time_col)).dt.total_days()
+    return (
+        out.with_columns(pl.col(target_col).alias(f"{target_col}_raw"))
+        .with_columns((pl.col(target_col) * (pl.col("daily_growth") * age).exp()).alias(target_col))
+        .drop("daily_growth")
+    )
+
+
+def reapply_growth(
+    forecast: pl.DataFrame,
+    growth: pl.DataFrame,
+    last_date: pl.DataFrame | None = None,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    target_col: str = "y_hat",
+) -> pl.DataFrame:
+    """Project the fitted growth back onto level-space forecasts.
+
+    Parameters
+    ----------
+    forecast
+        Forecast frame with ``[id_col, time_col, target_col]`` produced
+        from growth-removed history.
+    growth
+        Output of :func:`fit_growth`.
+    last_date
+        Optional ``[id_col, time_col]`` frame with each SKU's last
+        training date (defaults to one day before the first forecast
+        date per SKU, which is correct for gap-free daily data).
+    id_col, time_col, target_col
+        Column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Forecast frame with ``target_col`` scaled by
+        ``exp(g * days_ahead)``.
+
+    """
+    if last_date is None:
+        last_date = forecast.group_by(id_col).agg((pl.col(time_col).min() - pl.duration(days=1)).alias("__last_train"))
+    else:
+        last_date = last_date.rename({time_col: "__last_train"})
+    out = forecast.join(growth, on=id_col, how="left").join(last_date, on=id_col, how="left")
+    days_ahead = (pl.col(time_col) - pl.col("__last_train")).dt.total_days()
+    return (
+        out.with_columns(pl.col("daily_growth").fill_null(0.0))
+        .with_columns((pl.col(target_col) * (pl.col("daily_growth") * days_ahead).exp()).alias(target_col))
+        .drop("daily_growth", "__last_train")
+    )
+
+
+def recency_weights(
+    df: pl.DataFrame,
+    half_life: float = 90.0,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+    weight_col: str = "weight",
+) -> pl.DataFrame:
+    """Add exponential-decay sample weights favouring recent history.
+
+    Parameters
+    ----------
+    df
+        Canonical sales frame.
+    half_life
+        Age in days at which a sample's weight halves.
+    id_col, time_col
+        Canonical column names.
+    weight_col
+        Name of the added weight column.
+
+    Returns
+    -------
+    pl.DataFrame
+        Input frame with ``weight_col`` in ``(0, 1]`` (1 at each SKU's
+        most recent date).
+
+    """
+    if half_life <= 0:
+        raise ValueError("half_life must be positive")
+    age = (pl.col(time_col).max().over(id_col) - pl.col(time_col)).dt.total_days()
+    return df.with_columns((0.5 ** (age / half_life)).alias(weight_col))
+
+
+def select_adaptive_window(
+    growth: pl.DataFrame,
+    tolerance: float = 0.25,
+    min_days: int = 56,
+    max_days: int = 730,
+    id_col: str = "unique_id",
+) -> pl.DataFrame:
+    """Choose a per-SKU training-window length from its growth rate.
+
+    The window is the longest span over which the fitted exponential
+    level drifts by at most ``tolerance`` (25% by default):
+    ``window = ln(1 + tolerance) / |daily_growth|``, clamped to
+    ``[min_days, max_days]``. Stable SKUs keep long histories; SKUs
+    doubling every few months train on short, recent windows.
+
+    Parameters
+    ----------
+    growth
+        Output of :func:`fit_growth`.
+    tolerance
+        Maximum tolerated relative level drift across the window.
+    min_days, max_days
+        Window clamp bounds in days.
+    id_col
+        SKU column name.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "window_days"]``.
+
+    """
+    if tolerance <= 0:
+        raise ValueError("tolerance must be positive")
+    if min_days <= 0 or max_days < min_days:
+        raise ValueError("require 0 < min_days <= max_days")
+    limit = math.log(1.0 + tolerance)
+    return growth.select(
+        pl.col(id_col),
+        (limit / pl.col("daily_growth").abs().clip(lower_bound=_EPS))
+        .clip(lower_bound=min_days, upper_bound=max_days)
+        .cast(pl.Int64)
+        .alias("window_days"),
+    ).sort(id_col)
+
+
+def apply_training_window(
+    df: pl.DataFrame,
+    windows: pl.DataFrame,
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Trim each SKU's history to its adaptive training window.
+
+    Parameters
+    ----------
+    df
+        Canonical sales frame.
+    windows
+        Output of :func:`select_adaptive_window`.
+    id_col, time_col
+        Canonical column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        Rows within ``window_days`` of each SKU's last date; SKUs
+        absent from ``windows`` are kept in full.
+
+    """
+    out = df.join(windows, on=id_col, how="left")
+    age = (pl.col(time_col).max().over(id_col) - pl.col(time_col)).dt.total_days()
+    return out.filter(pl.col("window_days").is_null() | (age < pl.col("window_days"))).drop("window_days")

--- a/polars_ts/applications/perishables/restock.py
+++ b/polars_ts/applications/perishables/restock.py
@@ -1,0 +1,208 @@
+"""Forecast-to-order translation for perishables restocking.
+
+The deliverable of the application: "how many units of SKU X to order
+for the next N days". Implements an order-up-to policy with a
+service-level safety stock, netted against current inventory, and — the
+perishables twist — a shelf-life cap so orders never exceed what can
+sell before spoiling. Over-forecast is waste, under-forecast is
+stockouts; the policy makes that trade-off explicit.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from statistics import NormalDist
+
+import polars as pl
+
+
+@dataclass(frozen=True)
+class RestockPolicy:
+    """Ordering policy parameters for perishables replenishment.
+
+    Parameters
+    ----------
+    service_level
+        Target cycle service level (probability of no stockout during
+        the protection period), e.g. 0.95.
+    lead_time_days
+        Days between placing an order and receiving it.
+    review_period_days
+        Days between consecutive ordering opportunities.
+    shelf_life_days
+        Sellable days after receipt; when set, orders are capped so
+        total stock never exceeds forecast demand within shelf life.
+    moq
+        Minimum order quantity — nonzero orders are raised to this.
+    pack_size
+        Case/pack multiple — orders are rounded up to it.
+
+    """
+
+    service_level: float = 0.95
+    lead_time_days: int = 1
+    review_period_days: int = 1
+    shelf_life_days: int | None = None
+    moq: int = 0
+    pack_size: int = 1
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.service_level < 1.0:
+            raise ValueError("service_level must be in (0, 1)")
+        if self.lead_time_days < 0 or self.review_period_days < 1:
+            raise ValueError("require lead_time_days >= 0 and review_period_days >= 1")
+        if self.shelf_life_days is not None and self.shelf_life_days < 1:
+            raise ValueError("shelf_life_days must be >= 1 when set")
+        if self.moq < 0 or self.pack_size < 1:
+            raise ValueError("require moq >= 0 and pack_size >= 1")
+
+    @property
+    def protection_days(self) -> int:
+        """Days of demand an order must cover (lead time + review period)."""
+        return self.lead_time_days + self.review_period_days
+
+    @property
+    def z_score(self) -> float:
+        """Standard-normal quantile for the target service level."""
+        return NormalDist().inv_cdf(self.service_level)
+
+
+def demand_std(
+    df: pl.DataFrame,
+    target_col: str = "y",
+    id_col: str = "unique_id",
+    window: int | None = 91,
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Estimate per-SKU daily demand standard deviation.
+
+    A fallback uncertainty estimate when backtest forecast-error
+    residuals are not available; computed over each SKU's trailing
+    window of history.
+
+    Parameters
+    ----------
+    df
+        Gap-free canonical sales frame.
+    target_col, id_col, time_col
+        Canonical column names.
+    window
+        Trailing days to use; ``None`` uses full history.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``[id_col, "sigma"]``.
+
+    """
+    out = df.sort(id_col, time_col)
+    if window is not None:
+        age = (pl.col(time_col).max().over(id_col) - pl.col(time_col)).dt.total_days()
+        out = out.filter(age < window)
+    return (
+        out.group_by(id_col)
+        .agg(pl.col(target_col).std().fill_null(0.0).alias("sigma"))
+        .with_columns(pl.col("sigma").fill_null(0.0))
+        .sort(id_col)
+    )
+
+
+def recommend_orders(
+    forecast: pl.DataFrame,
+    policy: RestockPolicy | None = None,
+    on_hand: pl.DataFrame | None = None,
+    sigma: pl.DataFrame | None = None,
+    target_col: str = "y_hat",
+    id_col: str = "unique_id",
+    time_col: str = "ds",
+) -> pl.DataFrame:
+    """Translate per-day forecasts into order quantities per SKU.
+
+    Implements an order-up-to-S policy: the base stock covers forecast
+    demand over the protection period (lead time + review period) plus a
+    safety stock ``z * sigma * sqrt(protection_days)`` for the target
+    service level. The order is the gap between S and current inventory,
+    capped at forecast demand within shelf life (minus stock already on
+    hand) so perishables are not ordered into spoilage, then raised to
+    the MOQ and rounded up to the pack size.
+
+    Parameters
+    ----------
+    forecast
+        Per-day forecast frame ``[id_col, time_col, target_col]``
+        starting the day after the order is placed; must cover at least
+        the protection period (and shelf life, when capping is enabled).
+    policy
+        Restock policy; defaults to ``RestockPolicy()``.
+    on_hand
+        Optional ``[id_col, "on_hand"]`` current sellable inventory
+        (units on order may be included here); missing SKUs default 0.
+    sigma
+        Optional ``[id_col, "sigma"]`` daily forecast-error standard
+        deviation (see :func:`demand_std`); missing SKUs default 0,
+        i.e. no safety stock.
+    target_col, id_col, time_col
+        Column names in ``forecast``.
+
+    Returns
+    -------
+    pl.DataFrame
+        One row per SKU with columns ``[id_col, "forecast_demand",
+        "safety_stock", "order_up_to", "on_hand", "shelf_life_cap",
+        "order_qty"]``.
+
+    """
+    policy = policy or RestockPolicy()
+    horizon = forecast.group_by(id_col).agg(pl.len().alias("__h"))["__h"].min()
+    if horizon is not None and horizon < policy.protection_days:
+        raise ValueError(f"Forecast horizon ({horizon}) shorter than protection period ({policy.protection_days})")
+
+    sorted_fc = forecast.sort(id_col, time_col).with_columns((pl.int_range(pl.len()).over(id_col) + 1).alias("__step"))
+    demand_pp = pl.col(target_col).filter(pl.col("__step") <= policy.protection_days).sum()
+    if policy.shelf_life_days is not None:
+        shelf_horizon = policy.lead_time_days + policy.shelf_life_days
+        shelf_expr = pl.col(target_col).filter(pl.col("__step") <= shelf_horizon).sum()
+    else:
+        shelf_expr = pl.lit(None, dtype=pl.Float64)
+
+    out = sorted_fc.group_by(id_col).agg(
+        demand_pp.alias("forecast_demand"),
+        shelf_expr.alias("__shelf_demand"),
+    )
+
+    sigma_df = sigma if sigma is not None else out.select(pl.col(id_col), pl.lit(0.0).alias("sigma"))
+    on_hand_df = on_hand if on_hand is not None else out.select(pl.col(id_col), pl.lit(0.0).alias("on_hand"))
+    out = (
+        out.join(sigma_df, on=id_col, how="left")
+        .join(on_hand_df, on=id_col, how="left")
+        .with_columns(pl.col("sigma").fill_null(0.0), pl.col("on_hand").fill_null(0.0).cast(pl.Float64))
+    )
+
+    sqrt_pp = math.sqrt(policy.protection_days)
+    out = out.with_columns(
+        (policy.z_score * pl.col("sigma") * sqrt_pp).alias("safety_stock"),
+    ).with_columns(
+        (pl.col("forecast_demand") + pl.col("safety_stock")).alias("order_up_to"),
+        (pl.col("__shelf_demand") - pl.col("on_hand")).clip(lower_bound=0.0).alias("shelf_life_cap"),
+    )
+
+    raw_order = (pl.col("order_up_to") - pl.col("on_hand")).clip(lower_bound=0.0)
+    capped = (
+        pl.when(pl.col("shelf_life_cap").is_not_null())
+        .then(pl.min_horizontal(raw_order, pl.col("shelf_life_cap")))
+        .otherwise(raw_order)
+    )
+    rounded = (
+        pl.when(capped <= 0)
+        .then(0.0)
+        .otherwise(
+            ((pl.max_horizontal(capped, pl.lit(float(policy.moq))) / policy.pack_size).ceil()) * policy.pack_size
+        )
+    )
+    return (
+        out.with_columns(rounded.cast(pl.Int64).alias("order_qty"))
+        .drop("sigma", "__shelf_demand")
+        .select(id_col, "forecast_demand", "safety_stock", "order_up_to", "on_hand", "shelf_life_cap", "order_qty")
+        .sort(id_col)
+    )

--- a/polars_ts/applications/perishables/restock.py
+++ b/polars_ts/applications/perishables/restock.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from statistics import NormalDist
+from typing import cast
 
 import polars as pl
 
@@ -154,7 +155,7 @@ def recommend_orders(
 
     """
     policy = policy or RestockPolicy()
-    horizon = forecast.group_by(id_col).agg(pl.len().alias("__h"))["__h"].min()
+    horizon = cast("int | None", forecast.group_by(id_col).agg(pl.len().alias("__h"))["__h"].min())
     if horizon is not None and horizon < policy.protection_days:
         raise ValueError(f"Forecast horizon ({horizon}) shorter than protection period ({policy.protection_days})")
 

--- a/tests/applications/test_perishables_cold_start.py
+++ b/tests/applications/test_perishables_cold_start.py
@@ -1,0 +1,82 @@
+"""Tests for cold-start warm-up forecasting (#211)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import cold_start_forecast, cold_start_skus
+
+
+def _series(uid: str, values: np.ndarray, start: date = date(2024, 1, 1)) -> pl.DataFrame:
+    dates = [start + timedelta(days=i) for i in range(len(values))]
+    return pl.DataFrame({"unique_id": [uid] * len(values), "ds": dates, "y": values.astype(np.float64)})
+
+
+@pytest.fixture
+def market() -> pl.DataFrame:
+    """Two established donors ramping from launch, one 10-day-old SKU."""
+    t = np.arange(120)
+    ramp = 5.0 + 0.1 * t  # donors ramp linearly after launch
+    donor_a = _series("donor_a", ramp)
+    donor_b = _series("donor_b", 2.0 * ramp)
+    new = _series("new", 5.0 + 0.1 * np.arange(10), start=date(2024, 4, 20))
+    return pl.concat([donor_a, donor_b, new])
+
+
+class TestColdStartSkus:
+    def test_detects_short_history(self, market):
+        assert cold_start_skus(market, min_history=28) == ["new"]
+
+    def test_none_when_all_established(self, market):
+        established = market.filter(pl.col("unique_id") != "new")
+        assert cold_start_skus(established, min_history=28) == []
+
+
+class TestColdStartForecast:
+    def test_forecast_shape_and_dates(self, market):
+        fc = cold_start_forecast(market, h=7, min_history=28, k=2)
+        assert fc.columns == ["unique_id", "ds", "y_hat"]
+        assert fc["unique_id"].unique().to_list() == ["new"]
+        assert fc.height == 7
+        assert fc["ds"].min() == date(2024, 4, 30)
+
+    def test_borrows_donor_trajectory(self, market):
+        # Donors continue ramping after day 10; the borrowed forecast
+        # should sit near the new SKU's level and keep growing.
+        fc = cold_start_forecast(market, h=14, min_history=28, k=2).sort("ds")
+        assert fc["y_hat"][0] == pytest.approx(6.0, rel=0.3)
+        assert fc["y_hat"][-1] > fc["y_hat"][0]
+
+    def test_empty_when_no_cold_skus(self, market):
+        established = market.filter(pl.col("unique_id") != "new")
+        fc = cold_start_forecast(established, h=7)
+        assert fc.height == 0
+        assert fc.columns == ["unique_id", "ds", "y_hat"]
+
+    def test_no_donors_raises(self, market):
+        only_new = market.filter(pl.col("unique_id") == "new")
+        with pytest.raises(ValueError, match="donors"):
+            cold_start_forecast(only_new, h=7, min_history=28)
+
+    def test_category_restricts_donors(self, market):
+        # donor_b sells at 2x; putting new+donor_b in one category should
+        # roughly double the forecast vs pairing with donor_a.
+        cats_b = pl.DataFrame({"unique_id": ["donor_a", "donor_b", "new"], "category": ["x", "y", "y"]})
+        cats_a = pl.DataFrame({"unique_id": ["donor_a", "donor_b", "new"], "category": ["y", "x", "y"]})
+        fc_b = cold_start_forecast(market, h=7, k=1, category_map=cats_b).sort("ds")
+        fc_a = cold_start_forecast(market, h=7, k=1, category_map=cats_a).sort("ds")
+        # Both rescale to the new SKU's observed level, so trajectories are
+        # shaped by the donor but anchored to the same level.
+        assert fc_b["y_hat"][0] == pytest.approx(fc_a["y_hat"][0], rel=0.5)
+
+    def test_nonnegative(self, market):
+        fc = cold_start_forecast(market, h=30, min_history=28)
+        assert (fc["y_hat"] >= 0.0).all()
+
+    def test_invalid_horizon(self, market):
+        with pytest.raises(ValueError, match="Horizon"):
+            cold_start_forecast(market, h=0)

--- a/tests/applications/test_perishables_features.py
+++ b/tests/applications/test_perishables_features.py
@@ -1,0 +1,79 @@
+"""Tests for perishables feature engineering (#211)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import dow_profile, estimate_promo_lift, perishable_calendar_features
+
+
+@pytest.fixture
+def weekly() -> pl.DataFrame:
+    """8 weeks of daily data with a strong Saturday spike."""
+    start = date(2025, 1, 6)  # a Monday
+    n = 56
+    dates = [start + timedelta(days=i) for i in range(n)]
+    y = [30.0 if d.isoweekday() == 6 else 10.0 for d in dates]
+    return pl.DataFrame({"unique_id": ["A"] * n, "ds": dates, "y": y})
+
+
+class TestCalendarFeatures:
+    def test_columns_added(self, weekly):
+        out = perishable_calendar_features(weekly)
+        for col in ["day_of_week", "month", "is_weekend", "is_month_start", "is_month_end"]:
+            assert col in out.columns
+
+    def test_month_boundaries(self):
+        df = pl.DataFrame({"ds": [date(2025, 1, 3), date(2025, 1, 15), date(2025, 1, 29), date(2025, 2, 26)]})
+        out = perishable_calendar_features(df)
+        assert out["is_month_start"].to_list() == [1, 0, 0, 0]
+        # Jan 29 is within 5 days of Jan 31; Feb 26 within 5 of Feb 28
+        assert out["is_month_end"].to_list() == [0, 0, 1, 1]
+
+
+class TestDowProfile:
+    def test_saturday_uplift(self, weekly):
+        prof = dow_profile(weekly)
+        assert prof.height == 7
+        sat = prof.filter(pl.col("day_of_week") == 6)["dow_index"].item()
+        mon = prof.filter(pl.col("day_of_week") == 1)["dow_index"].item()
+        # Saturday sells 3x a weekday; index ratio must match
+        assert sat / mon == pytest.approx(3.0, rel=1e-6)
+
+    def test_mean_index_is_one(self, weekly):
+        prof = dow_profile(weekly)
+        assert prof["dow_index"].mean() == pytest.approx(1.0, abs=1e-6)
+
+
+class TestPromoLift:
+    def test_lift_recovered(self):
+        rng = np.random.default_rng(3)
+        n = 100
+        promo = (np.arange(n) % 10 == 0).astype(int)
+        base = 10.0 + rng.normal(0, 0.1, n)
+        y = np.where(promo == 1, 2.0 * base, base)
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A"] * n,
+                "ds": [date(2025, 1, 1) + timedelta(days=i) for i in range(n)],
+                "y": y,
+                "promo": promo,
+            }
+        )
+        out = estimate_promo_lift(df)
+        assert out["promo_lift"].item() == pytest.approx(2.0, rel=0.05)
+        assert out["n_promo_periods"].item() == 10
+
+    def test_never_promoted_is_null(self):
+        df = pl.DataFrame(
+            {"unique_id": ["A"] * 3, "ds": [date(2025, 1, i) for i in (1, 2, 3)], "y": [1.0] * 3, "promo": [0] * 3}
+        )
+        assert estimate_promo_lift(df)["promo_lift"].item() is None
+
+    def test_missing_promo_col_raises(self, weekly):
+        with pytest.raises(ValueError, match="ColumnMapping"):
+            estimate_promo_lift(weekly)

--- a/tests/applications/test_perishables_intermittent.py
+++ b/tests/applications/test_perishables_intermittent.py
@@ -1,0 +1,113 @@
+"""Tests for intermittent-demand models (#211)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import (
+    classify_demand,
+    croston_forecast,
+    intermittent_forecast,
+    sba_forecast,
+    tsb_forecast,
+)
+
+
+def _series(uid: str, values: list[float]) -> pl.DataFrame:
+    start = date(2025, 1, 1)
+    dates = [start + timedelta(days=i) for i in range(len(values))]
+    return pl.DataFrame({"unique_id": [uid] * len(values), "ds": dates, "y": [float(v) for v in values]})
+
+
+@pytest.fixture
+def sparse() -> pl.DataFrame:
+    # Demand of ~2 units every 4th day: rate = 0.5/day
+    values = [0.0, 0.0, 0.0, 2.0] * 15
+    return _series("sparse", values)
+
+
+@pytest.fixture
+def mixed(sparse) -> pl.DataFrame:
+    rng = np.random.default_rng(7)
+    smooth = _series("smooth", list(10.0 + rng.normal(0, 0.5, 60)))
+    return pl.concat([sparse, smooth])
+
+
+class TestClassifyDemand:
+    def test_quadrants(self, mixed):
+        out = classify_demand(mixed)
+        assert out.filter(pl.col("unique_id") == "sparse")["demand_class"].item() == "intermittent"
+        assert out.filter(pl.col("unique_id") == "smooth")["demand_class"].item() == "smooth"
+
+    def test_adi_value(self, sparse):
+        out = classify_demand(sparse)
+        assert out["adi"].item() == pytest.approx(4.0)
+
+    def test_all_zero_sku(self):
+        out = classify_demand(_series("dead", [0.0] * 30))
+        assert np.isinf(out["adi"].item())
+        assert out["demand_class"].item() == "intermittent"
+
+
+class TestCroston:
+    def test_regular_pattern_rate(self, sparse):
+        fc = croston_forecast(sparse, h=7, alpha=0.2)
+        assert fc.height == 7
+        assert fc["y_hat"].unique().len() == 1  # flat forecast
+        assert fc["y_hat"][0] == pytest.approx(0.5, rel=0.05)
+
+    def test_future_dates_follow_history(self, sparse):
+        fc = croston_forecast(sparse, h=3)
+        assert fc["ds"].min() == sparse["ds"].max() + timedelta(days=1)
+
+    def test_all_zero_forecasts_zero(self):
+        fc = croston_forecast(_series("dead", [0.0] * 30), h=5)
+        assert fc["y_hat"].to_list() == [0.0] * 5
+
+    def test_invalid_params(self, sparse):
+        with pytest.raises(ValueError, match="alpha"):
+            croston_forecast(sparse, h=5, alpha=1.5)
+        with pytest.raises(ValueError, match="Horizon"):
+            croston_forecast(sparse, h=0)
+
+
+class TestSBA:
+    def test_bias_correction_below_croston(self, sparse):
+        croston = croston_forecast(sparse, h=1, alpha=0.2)["y_hat"].item()
+        sba = sba_forecast(sparse, h=1, alpha=0.2)["y_hat"].item()
+        assert sba == pytest.approx(croston * 0.9, rel=1e-9)
+
+
+class TestTSB:
+    def test_regular_pattern_rate(self, sparse):
+        fc = tsb_forecast(sparse, h=1, alpha=0.2, beta=0.1)
+        assert fc["y_hat"].item() == pytest.approx(0.5, rel=0.3)
+
+    def test_obsolescence_decay(self):
+        # SKU sells steadily then goes dead for 30 days
+        values = [2.0] * 30 + [0.0] * 30
+        alive = tsb_forecast(_series("s", [2.0] * 30), h=1, beta=0.1)["y_hat"].item()
+        dead = tsb_forecast(_series("s", values), h=1, beta=0.1)["y_hat"].item()
+        assert dead < 0.1 * alive
+
+
+class TestAutoDispatch:
+    def test_routes_by_class(self, mixed):
+        fc = intermittent_forecast(mixed, h=5, method="auto")
+        assert fc.height == 10
+        sparse_hat = fc.filter(pl.col("unique_id") == "sparse")["y_hat"][0]
+        # sparse SKU routed to SBA (bias-corrected, below plain croston)
+        croston_hat = croston_forecast(mixed, h=1).filter(pl.col("unique_id") == "sparse")["y_hat"].item()
+        assert sparse_hat < croston_hat
+
+    def test_explicit_methods_match(self, sparse):
+        assert intermittent_forecast(sparse, h=2, method="sba").equals(sba_forecast(sparse, h=2))
+        assert intermittent_forecast(sparse, h=2, method="tsb").equals(tsb_forecast(sparse, h=2))
+
+    def test_unknown_method(self, sparse):
+        with pytest.raises(ValueError, match="Unknown method"):
+            intermittent_forecast(sparse, h=2, method="prophet")

--- a/tests/applications/test_perishables_loader.py
+++ b/tests/applications/test_perishables_loader.py
@@ -1,0 +1,100 @@
+"""Tests for the perishables CSV loader (#211)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import ColumnMapping, fill_missing_dates, load_sales_csv, validate_sales_frame
+
+
+@pytest.fixture
+def raw() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "product_code": ["A", "A", "A", "B", "B"],
+            "sale_date": [date(2025, 1, 1), date(2025, 1, 1), date(2025, 1, 4), date(2025, 1, 3), date(2025, 1, 4)],
+            "units": [2.0, 3.0, 1.0, -1.0, 4.0],
+            "family": ["dairy", "dairy", "dairy", "bakery", "bakery"],
+        }
+    )
+
+
+@pytest.fixture
+def mapping() -> ColumnMapping:
+    return ColumnMapping(sku="product_code", date="sale_date", quantity="units", category="family")
+
+
+class TestValidate:
+    def test_missing_column_raises(self, raw):
+        with pytest.raises(ValueError, match="Missing columns"):
+            validate_sales_frame(raw, ColumnMapping(sku="nope", date="sale_date", quantity="units"))
+
+    def test_null_date_raises(self, mapping):
+        df = pl.DataFrame({"product_code": ["A"], "sale_date": [None], "units": [1.0], "family": ["dairy"]})
+        with pytest.raises(ValueError, match="null dates"):
+            validate_sales_frame(df, mapping)
+
+    def test_non_numeric_quantity_raises(self, mapping):
+        df = pl.DataFrame(
+            {"product_code": ["A"], "sale_date": [date(2025, 1, 1)], "units": ["two"], "family": ["dairy"]}
+        )
+        with pytest.raises(ValueError, match="must be numeric"):
+            validate_sales_frame(df, mapping)
+
+
+class TestLoad:
+    def test_canonical_columns_and_types(self, raw, mapping):
+        out = load_sales_csv(raw, mapping)
+        assert out.columns[:3] == ["unique_id", "ds", "y"]
+        assert "category" in out.columns
+        assert out.schema["ds"] == pl.Date
+        assert out.schema["y"] == pl.Float64
+
+    def test_duplicates_summed(self, raw, mapping):
+        out = load_sales_csv(raw, mapping, fill_gaps=False)
+        a_first = out.filter((pl.col("unique_id") == "A") & (pl.col("ds") == date(2025, 1, 1)))
+        assert a_first["y"].item() == 5.0
+
+    def test_negative_clipped(self, raw, mapping):
+        out = load_sales_csv(raw, mapping, fill_gaps=False)
+        b_neg = out.filter((pl.col("unique_id") == "B") & (pl.col("ds") == date(2025, 1, 3)))
+        assert b_neg["y"].item() == 0.0
+
+    def test_csv_roundtrip(self, raw, mapping, tmp_path):
+        path = tmp_path / "sales.csv"
+        raw.write_csv(path)
+        out = load_sales_csv(path, mapping)
+        assert out.equals(load_sales_csv(raw, mapping))
+
+
+class TestFillMissingDates:
+    def test_gaps_filled_with_zero(self, raw, mapping):
+        out = load_sales_csv(raw, mapping)
+        a = out.filter(pl.col("unique_id") == "A")
+        # A runs from its launch (Jan 1) to the global max (Jan 4)
+        assert a.height == 4
+        assert a.filter(pl.col("ds") == date(2025, 1, 2))["y"].item() == 0.0
+
+    def test_no_prelaunch_padding(self, raw, mapping):
+        out = load_sales_csv(raw, mapping)
+        b = out.filter(pl.col("unique_id") == "B")
+        assert b["ds"].min() == date(2025, 1, 3)
+
+    def test_static_category_propagated(self, raw, mapping):
+        out = load_sales_csv(raw, mapping)
+        assert out.filter(pl.col("unique_id") == "A")["category"].unique().to_list() == ["dairy"]
+
+    def test_promo_gap_zero_filled(self):
+        df = pl.DataFrame(
+            {
+                "unique_id": ["A", "A"],
+                "ds": [date(2025, 1, 1), date(2025, 1, 3)],
+                "y": [1.0, 2.0],
+                "promo": [1, 1],
+            }
+        )
+        out = fill_missing_dates(df)
+        assert out.filter(pl.col("ds") == date(2025, 1, 2))["promo"].item() == 0

--- a/tests/applications/test_perishables_preprocessing.py
+++ b/tests/applications/test_perishables_preprocessing.py
@@ -1,0 +1,115 @@
+"""Tests for growth-aware preprocessing (#211)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import (
+    apply_training_window,
+    fit_growth,
+    reapply_growth,
+    recency_weights,
+    remove_growth,
+    select_adaptive_window,
+)
+
+
+def _series(uid: str, values: np.ndarray, start: date = date(2024, 1, 1)) -> pl.DataFrame:
+    dates = [start + timedelta(days=i) for i in range(len(values))]
+    return pl.DataFrame({"unique_id": [uid] * len(values), "ds": dates, "y": values.astype(np.float64)})
+
+
+@pytest.fixture
+def growing_and_flat() -> pl.DataFrame:
+    n = 365
+    t = np.arange(n)
+    growing = 10.0 * np.exp(0.003 * t)  # ~3x over the year
+    flat = np.full(n, 10.0)
+    return pl.concat([_series("grow", growing), _series("flat", flat)])
+
+
+class TestFitGrowth:
+    def test_recovers_growth_rate(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        g = growth.filter(pl.col("unique_id") == "grow")["daily_growth"].item()
+        assert g == pytest.approx(0.003, abs=5e-4)
+
+    def test_flat_series_near_zero(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        g = growth.filter(pl.col("unique_id") == "flat")["daily_growth"].item()
+        assert abs(g) < 1e-6
+
+    def test_short_history_gets_zero(self):
+        df = _series("new", np.array([1.0, 2.0, 3.0]))
+        growth = fit_growth(df)
+        assert growth["daily_growth"].item() == 0.0
+
+
+class TestRemoveReapplyGrowth:
+    def test_detrended_is_level(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        out = remove_growth(growing_and_flat, growth).filter(pl.col("unique_id") == "grow")
+        # After rescaling to today's level, early and late means should match
+        early = out.head(90)["y"].mean()
+        late = out.tail(90)["y"].mean()
+        assert early == pytest.approx(late, rel=0.1)
+        assert "y_raw" in out.columns
+
+    def test_reapply_scales_forecast(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        last = growing_and_flat["ds"].max()
+        fc = pl.DataFrame(
+            {
+                "unique_id": ["grow"] * 30,
+                "ds": [last + timedelta(days=i + 1) for i in range(30)],
+                "y_hat": [1.0] * 30,
+            }
+        )
+        out = reapply_growth(fc, growth)
+        g = growth.filter(pl.col("unique_id") == "grow")["daily_growth"].item()
+        assert out["y_hat"][0] == pytest.approx(np.exp(g), rel=1e-6)
+        assert out["y_hat"][29] == pytest.approx(np.exp(30 * g), rel=1e-6)
+        assert out["y_hat"][29] > out["y_hat"][0]
+
+
+class TestRecencyWeights:
+    def test_latest_is_one_and_decays(self, growing_and_flat):
+        out = recency_weights(growing_and_flat, half_life=90.0).filter(pl.col("unique_id") == "flat").sort("ds")
+        assert out["weight"][-1] == pytest.approx(1.0)
+        assert out["weight"][-91] == pytest.approx(0.5, rel=1e-6)
+        assert out["weight"].is_sorted()
+
+    def test_invalid_half_life(self, growing_and_flat):
+        with pytest.raises(ValueError, match="half_life"):
+            recency_weights(growing_and_flat, half_life=0.0)
+
+
+class TestAdaptiveWindow:
+    def test_fast_growth_short_window(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        windows = select_adaptive_window(growth, tolerance=0.25, min_days=56, max_days=730)
+        w_grow = windows.filter(pl.col("unique_id") == "grow")["window_days"].item()
+        w_flat = windows.filter(pl.col("unique_id") == "flat")["window_days"].item()
+        assert w_grow < w_flat
+        assert w_flat == 730  # flat SKU keeps max history
+        # ln(1.25)/0.003 ~ 74 days
+        assert 56 <= w_grow <= 120
+
+    def test_apply_training_window_trims(self, growing_and_flat):
+        growth = fit_growth(growing_and_flat)
+        windows = select_adaptive_window(growth)
+        out = apply_training_window(growing_and_flat, windows)
+        n_grow = out.filter(pl.col("unique_id") == "grow").height
+        n_flat = out.filter(pl.col("unique_id") == "flat").height
+        assert n_grow < n_flat == 365
+        w_grow = windows.filter(pl.col("unique_id") == "grow")["window_days"].item()
+        assert n_grow == w_grow
+
+    def test_unknown_sku_kept_full(self, growing_and_flat):
+        windows = pl.DataFrame({"unique_id": ["grow"], "window_days": [60]})
+        out = apply_training_window(growing_and_flat, windows)
+        assert out.filter(pl.col("unique_id") == "flat").height == 365

--- a/tests/applications/test_perishables_restock.py
+++ b/tests/applications/test_perishables_restock.py
@@ -1,0 +1,109 @@
+"""Tests for the restock calculator (#211)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+from polars_ts.applications.perishables import RestockPolicy, demand_std, recommend_orders
+
+
+def _forecast(uid: str, daily: float, h: int = 14) -> pl.DataFrame:
+    start = date(2025, 6, 1)
+    return pl.DataFrame(
+        {"unique_id": [uid] * h, "ds": [start + timedelta(days=i) for i in range(h)], "y_hat": [daily] * h}
+    )
+
+
+class TestRestockPolicy:
+    def test_protection_days(self):
+        policy = RestockPolicy(lead_time_days=2, review_period_days=3)
+        assert policy.protection_days == 5
+
+    def test_z_score_95(self):
+        assert RestockPolicy(service_level=0.95).z_score == pytest.approx(1.6449, abs=1e-3)
+
+    def test_invalid_params(self):
+        with pytest.raises(ValueError, match="service_level"):
+            RestockPolicy(service_level=1.5)
+        with pytest.raises(ValueError, match="shelf_life_days"):
+            RestockPolicy(shelf_life_days=0)
+        with pytest.raises(ValueError, match="pack_size"):
+            RestockPolicy(pack_size=0)
+
+
+class TestRecommendOrders:
+    def test_no_uncertainty_no_stock(self):
+        # 10/day, protection = 3 days -> order 30
+        policy = RestockPolicy(lead_time_days=2, review_period_days=1)
+        out = recommend_orders(_forecast("A", 10.0), policy)
+        assert out["forecast_demand"].item() == pytest.approx(30.0)
+        assert out["safety_stock"].item() == 0.0
+        assert out["order_qty"].item() == 30
+
+    def test_on_hand_netted(self):
+        policy = RestockPolicy(lead_time_days=2, review_period_days=1)
+        on_hand = pl.DataFrame({"unique_id": ["A"], "on_hand": [12.0]})
+        out = recommend_orders(_forecast("A", 10.0), policy, on_hand=on_hand)
+        assert out["order_qty"].item() == 18
+
+    def test_safety_stock_scales_with_sigma(self):
+        policy = RestockPolicy(service_level=0.95, lead_time_days=3, review_period_days=1)
+        sigma = pl.DataFrame({"unique_id": ["A"], "sigma": [5.0]})
+        out = recommend_orders(_forecast("A", 10.0), policy, sigma=sigma)
+        expected_ss = policy.z_score * 5.0 * 2.0  # sqrt(4 protection days)
+        assert out["safety_stock"].item() == pytest.approx(expected_ss)
+        assert out["order_qty"].item() == pytest.approx(40 + expected_ss, abs=1.0)
+
+    def test_shelf_life_caps_order(self):
+        # Protection period wants 7 days of demand, but shelf life allows only 2 sellable days
+        policy = RestockPolicy(lead_time_days=0, review_period_days=7, shelf_life_days=2)
+        out = recommend_orders(_forecast("A", 10.0), policy)
+        assert out["order_qty"].item() == 20
+
+    def test_shelf_life_cap_accounts_on_hand(self):
+        policy = RestockPolicy(lead_time_days=0, review_period_days=7, shelf_life_days=2)
+        on_hand = pl.DataFrame({"unique_id": ["A"], "on_hand": [15.0]})
+        out = recommend_orders(_forecast("A", 10.0), policy, on_hand=on_hand)
+        assert out["order_qty"].item() == 5
+
+    def test_moq_and_pack_size(self):
+        policy = RestockPolicy(lead_time_days=0, review_period_days=1, moq=10, pack_size=6)
+        out = recommend_orders(_forecast("A", 3.0), policy)
+        # raw order 3 -> raised to moq 10 -> rounded up to 12
+        assert out["order_qty"].item() == 12
+
+    def test_zero_order_stays_zero(self):
+        policy = RestockPolicy(lead_time_days=0, review_period_days=1, moq=10)
+        on_hand = pl.DataFrame({"unique_id": ["A"], "on_hand": [100.0]})
+        out = recommend_orders(_forecast("A", 3.0), policy, on_hand=on_hand)
+        assert out["order_qty"].item() == 0
+
+    def test_short_horizon_raises(self):
+        policy = RestockPolicy(lead_time_days=10, review_period_days=10)
+        with pytest.raises(ValueError, match="protection period"):
+            recommend_orders(_forecast("A", 10.0, h=5), policy)
+
+    def test_multiple_skus(self):
+        fc = pl.concat([_forecast("A", 10.0), _forecast("B", 1.0)])
+        out = recommend_orders(fc, RestockPolicy(lead_time_days=1, review_period_days=1))
+        assert out["unique_id"].to_list() == ["A", "B"]
+        assert out["order_qty"].to_list() == [20, 2]
+
+
+class TestDemandStd:
+    def test_windowed_std(self):
+        start = date(2025, 1, 1)
+        n = 200
+        # Old history is wild, recent 91 days are constant
+        y = [100.0, 0.0] * 55 + [5.0] * 90
+        df = pl.DataFrame({"unique_id": ["A"] * n, "ds": [start + timedelta(days=i) for i in range(n)], "y": y})
+        full = demand_std(df, window=None)["sigma"].item()
+        recent = demand_std(df, window=91)["sigma"].item()
+        assert recent < 2.0 < full
+
+    def test_single_row_zero(self):
+        df = pl.DataFrame({"unique_id": ["A"], "ds": [date(2025, 1, 1)], "y": [5.0]})
+        assert demand_std(df)["sigma"].item() == 0.0


### PR DESCRIPTION
## Summary

First domain application in polars-ts: `polars_ts.applications.perishables`, targeting the restocking question — **how many units of SKU X to order for the next N days** — for a fast-growing perishables retailer. Closes #211.

Implemented in the issue's build order, one commit per step:

1. **Gitignore + loader** — `data/perishables/` is gitignored. `ColumnMapping` maps arbitrary CSV headers onto the canonical `unique_id`/`ds`/`y` long format; the loader validates the schema, sums duplicate (SKU, date) rows, clips negative quantities, and zero-fills per-SKU calendar gaps starting at each SKU's own launch (no pre-launch padding).
2. **Growth-aware preprocessing** — per-SKU exponential growth rate via log-linear fit on the smoothed level; `remove_growth`/`reapply_growth` rescale history to today's level and project growth back onto forecasts; exponential `recency_weights`; `select_adaptive_window` shortens training history for fast-growing SKUs (`ln(1+tolerance)/|growth|`, clamped).
3. **Intermittent demand models** — Croston, SBA, and TSB with the Syntetos-Boylan ADI/CV² classifier; `intermittent_forecast(method="auto")` routes intermittent/lumpy SKUs to SBA. TSB decays obsolete SKUs toward zero.
4. **Restock calculator** — `RestockPolicy` + `recommend_orders`: order-up-to level over the protection period (lead time + review period), safety stock `z·σ·√protection_days` from the target service level, netting against on-hand inventory, a shelf-life cap so orders never exceed sellable demand before spoilage, and MOQ/pack-size rounding. `demand_std` provides a windowed uncertainty fallback.
5. **Cold start** — new SKUs borrow the launch-aligned trajectories of their *k* most similar established donors (level-normalized Euclidean similarity, optionally restricted to the SKU's category), rescaled to the observed level.
6. **Domain features** — month-start/end payday-proxy flags on top of the shared `calendar_features`, per-SKU day-of-week demand indices for shaping flat intermittent forecasts, and multiplicative promotion-lift estimation.

## Open questions from the issue

All absorbed as parameters rather than blocked on: `ColumnMapping` handles whatever the real CSV headers are, categories are optional (`category_map`), and shelf life / lead time / service level are `RestockPolicy` fields (defaults: 95% service level, 1-day lead time, daily horizon).

## Test plan

- 64 new tests in `tests/applications/` covering all six modules (validation errors, growth-rate recovery, Croston/SBA/TSB rates on regular patterns, obsolescence decay, safety-stock math, shelf-life capping, MOQ/pack rounding, donor borrowing, category restriction, promo lift).
- Full suite green locally apart from pre-existing failures from x86_64 sklearn/torch wheels in an arm64 venv (unrelated to this change).
- `ruff check` + `ruff format` (0.8.4) clean; submodule uses the `make_getattr` lazy-import pattern.